### PR TITLE
fix root validator example usage

### DIFF
--- a/src/fern_python/generators/pydantic_model/validators/validator_generators/root_validator_generator.py
+++ b/src/fern_python/generators/pydantic_model/validators/validator_generators/root_validator_generator.py
@@ -144,7 +144,7 @@ class RootValidatorGenerator(ValidatorGenerator):
 
         with writer.indent():
             writer.write("@")
-            writer.write_line(reference_to_decorator)
+            writer.write_line(f"{reference_to_decorator}()")
 
             writer.write("def validate(values: ")
             writer.write_reference(reference_to_partial)

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_admin_types_store_traced_test_case_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_admin_types_store_traced_test_case_request.py
@@ -23,7 +23,7 @@ class StoreTracedTestCaseRequest(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @StoreTracedTestCaseRequest.Validators.root
+            @StoreTracedTestCaseRequest.Validators.root()
             def validate(values: StoreTracedTestCaseRequest.Partial) -> StoreTracedTestCaseRequest.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_admin_types_store_traced_workspace_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_admin_types_store_traced_workspace_request.py
@@ -25,7 +25,7 @@ class StoreTracedWorkspaceRequest(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @StoreTracedWorkspaceRequest.Validators.root
+            @StoreTracedWorkspaceRequest.Validators.root()
             def validate(values: StoreTracedWorkspaceRequest.Partial) -> StoreTracedWorkspaceRequest.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_binary_tree_node_and_tree_value.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_binary_tree_node_and_tree_value.py
@@ -23,7 +23,7 @@ class BinaryTreeNodeAndTreeValue(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @BinaryTreeNodeAndTreeValue.Validators.root
+            @BinaryTreeNodeAndTreeValue.Validators.root()
             def validate(values: BinaryTreeNodeAndTreeValue.Partial) -> BinaryTreeNodeAndTreeValue.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_binary_tree_node_value.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_binary_tree_node_value.py
@@ -26,7 +26,7 @@ class BinaryTreeNodeValue(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @BinaryTreeNodeValue.Validators.root
+            @BinaryTreeNodeValue.Validators.root()
             def validate(values: BinaryTreeNodeValue.Partial) -> BinaryTreeNodeValue.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_binary_tree_value.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_binary_tree_value.py
@@ -23,7 +23,7 @@ class BinaryTreeValue(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @BinaryTreeValue.Validators.root
+            @BinaryTreeValue.Validators.root()
             def validate(values: BinaryTreeValue.Partial) -> BinaryTreeValue.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_debug_key_value_pairs.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_debug_key_value_pairs.py
@@ -20,7 +20,7 @@ class DebugKeyValuePairs(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @DebugKeyValuePairs.Validators.root
+            @DebugKeyValuePairs.Validators.root()
             def validate(values: DebugKeyValuePairs.Partial) -> DebugKeyValuePairs.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_debug_map_value.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_debug_map_value.py
@@ -18,7 +18,7 @@ class DebugMapValue(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @DebugMapValue.Validators.root
+            @DebugMapValue.Validators.root()
             def validate(values: DebugMapValue.Partial) -> DebugMapValue.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_doubly_linked_list_node_and_list_value.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_doubly_linked_list_node_and_list_value.py
@@ -23,7 +23,7 @@ class DoublyLinkedListNodeAndListValue(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @DoublyLinkedListNodeAndListValue.Validators.root
+            @DoublyLinkedListNodeAndListValue.Validators.root()
             def validate(values: DoublyLinkedListNodeAndListValue.Partial) -> DoublyLinkedListNodeAndListValue.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_doubly_linked_list_node_value.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_doubly_linked_list_node_value.py
@@ -26,7 +26,7 @@ class DoublyLinkedListNodeValue(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @DoublyLinkedListNodeValue.Validators.root
+            @DoublyLinkedListNodeValue.Validators.root()
             def validate(values: DoublyLinkedListNodeValue.Partial) -> DoublyLinkedListNodeValue.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_doubly_linked_list_value.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_doubly_linked_list_value.py
@@ -23,7 +23,7 @@ class DoublyLinkedListValue(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @DoublyLinkedListValue.Validators.root
+            @DoublyLinkedListValue.Validators.root()
             def validate(values: DoublyLinkedListValue.Partial) -> DoublyLinkedListValue.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_file_info.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_file_info.py
@@ -20,7 +20,7 @@ class FileInfo(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @FileInfo.Validators.root
+            @FileInfo.Validators.root()
             def validate(values: FileInfo.Partial) -> FileInfo.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_generic_value.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_generic_value.py
@@ -20,7 +20,7 @@ class GenericValue(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @GenericValue.Validators.root
+            @GenericValue.Validators.root()
             def validate(values: GenericValue.Partial) -> GenericValue.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_key_value_pair.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_key_value_pair.py
@@ -20,7 +20,7 @@ class KeyValuePair(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @KeyValuePair.Validators.root
+            @KeyValuePair.Validators.root()
             def validate(values: KeyValuePair.Partial) -> KeyValuePair.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_list_type.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_list_type.py
@@ -25,7 +25,7 @@ class ListType(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @ListType.Validators.root
+            @ListType.Validators.root()
             def validate(values: ListType.Partial) -> ListType.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_map_type.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_map_type.py
@@ -20,7 +20,7 @@ class MapType(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @MapType.Validators.root
+            @MapType.Validators.root()
             def validate(values: MapType.Partial) -> MapType.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_map_value.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_map_value.py
@@ -18,7 +18,7 @@ class MapValue(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @MapValue.Validators.root
+            @MapValue.Validators.root()
             def validate(values: MapValue.Partial) -> MapValue.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_singly_linked_list_node_and_list_value.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_singly_linked_list_node_and_list_value.py
@@ -23,7 +23,7 @@ class SinglyLinkedListNodeAndListValue(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @SinglyLinkedListNodeAndListValue.Validators.root
+            @SinglyLinkedListNodeAndListValue.Validators.root()
             def validate(values: SinglyLinkedListNodeAndListValue.Partial) -> SinglyLinkedListNodeAndListValue.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_singly_linked_list_node_value.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_singly_linked_list_node_value.py
@@ -24,7 +24,7 @@ class SinglyLinkedListNodeValue(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @SinglyLinkedListNodeValue.Validators.root
+            @SinglyLinkedListNodeValue.Validators.root()
             def validate(values: SinglyLinkedListNodeValue.Partial) -> SinglyLinkedListNodeValue.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_singly_linked_list_value.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_singly_linked_list_value.py
@@ -23,7 +23,7 @@ class SinglyLinkedListValue(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @SinglyLinkedListValue.Validators.root
+            @SinglyLinkedListValue.Validators.root()
             def validate(values: SinglyLinkedListValue.Partial) -> SinglyLinkedListValue.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_test_case.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_test_case.py
@@ -22,7 +22,7 @@ class TestCase(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TestCase.Validators.root
+            @TestCase.Validators.root()
             def validate(values: TestCase.Partial) -> TestCase.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_test_case_with_expected_result.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_test_case_with_expected_result.py
@@ -23,7 +23,7 @@ class TestCaseWithExpectedResult(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TestCaseWithExpectedResult.Validators.root
+            @TestCaseWithExpectedResult.Validators.root()
             def validate(values: TestCaseWithExpectedResult.Partial) -> TestCaseWithExpectedResult.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_lang_server_types_lang_server_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_lang_server_types_lang_server_request.py
@@ -18,7 +18,7 @@ class LangServerRequest(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @LangServerRequest.Validators.root
+            @LangServerRequest.Validators.root()
             def validate(values: LangServerRequest.Partial) -> LangServerRequest.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_lang_server_types_lang_server_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_lang_server_types_lang_server_response.py
@@ -18,7 +18,7 @@ class LangServerResponse(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @LangServerResponse.Validators.root
+            @LangServerResponse.Validators.root()
             def validate(values: LangServerResponse.Partial) -> LangServerResponse.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_migration_types_migration.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_migration_types_migration.py
@@ -22,7 +22,7 @@ class Migration(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @Migration.Validators.root
+            @Migration.Validators.root()
             def validate(values: Migration.Partial) -> Migration.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_playlist_types_playlist.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_playlist_types_playlist.py
@@ -24,7 +24,7 @@ class Playlist(PlaylistCreateRequest):
         """
         Use this class to add validators to the Pydantic model.
 
-            @Playlist.Validators.root
+            @Playlist.Validators.root()
             def validate(values: Playlist.Partial) -> Playlist.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_playlist_types_playlist_create_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_playlist_types_playlist_create_request.py
@@ -22,7 +22,7 @@ class PlaylistCreateRequest(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @PlaylistCreateRequest.Validators.root
+            @PlaylistCreateRequest.Validators.root()
             def validate(values: PlaylistCreateRequest.Partial) -> PlaylistCreateRequest.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_playlist_types_update_playlist_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_playlist_types_update_playlist_request.py
@@ -22,7 +22,7 @@ class UpdatePlaylistRequest(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @UpdatePlaylistRequest.Validators.root
+            @UpdatePlaylistRequest.Validators.root()
             def validate(values: UpdatePlaylistRequest.Partial) -> UpdatePlaylistRequest.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_create_problem_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_create_problem_request.py
@@ -47,7 +47,7 @@ class CreateProblemRequest(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @CreateProblemRequest.Validators.root
+            @CreateProblemRequest.Validators.root()
             def validate(values: CreateProblemRequest.Partial) -> CreateProblemRequest.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_generic_create_problem_error.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_generic_create_problem_error.py
@@ -22,7 +22,7 @@ class GenericCreateProblemError(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @GenericCreateProblemError.Validators.root
+            @GenericCreateProblemError.Validators.root()
             def validate(values: GenericCreateProblemError.Partial) -> GenericCreateProblemError.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_get_default_starter_files_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_get_default_starter_files_request.py
@@ -25,7 +25,7 @@ class GetDefaultStarterFilesRequest(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @GetDefaultStarterFilesRequest.Validators.root
+            @GetDefaultStarterFilesRequest.Validators.root()
             def validate(values: GetDefaultStarterFilesRequest.Partial) -> GetDefaultStarterFilesRequest.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_get_default_starter_files_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_get_default_starter_files_response.py
@@ -21,7 +21,7 @@ class GetDefaultStarterFilesResponse(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @GetDefaultStarterFilesResponse.Validators.root
+            @GetDefaultStarterFilesResponse.Validators.root()
             def validate(values: GetDefaultStarterFilesResponse.Partial) -> GetDefaultStarterFilesResponse.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_problem_description.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_problem_description.py
@@ -20,7 +20,7 @@ class ProblemDescription(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @ProblemDescription.Validators.root
+            @ProblemDescription.Validators.root()
             def validate(values: ProblemDescription.Partial) -> ProblemDescription.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_problem_files.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_problem_files.py
@@ -22,7 +22,7 @@ class ProblemFiles(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @ProblemFiles.Validators.root
+            @ProblemFiles.Validators.root()
             def validate(values: ProblemFiles.Partial) -> ProblemFiles.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_problem_info.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_problem_info.py
@@ -44,7 +44,7 @@ class ProblemInfo(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @ProblemInfo.Validators.root
+            @ProblemInfo.Validators.root()
             def validate(values: ProblemInfo.Partial) -> ProblemInfo.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_update_problem_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_update_problem_response.py
@@ -18,7 +18,7 @@ class UpdateProblemResponse(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @UpdateProblemResponse.Validators.root
+            @UpdateProblemResponse.Validators.root()
             def validate(values: UpdateProblemResponse.Partial) -> UpdateProblemResponse.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_variable_type_and_name.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_variable_type_and_name.py
@@ -22,7 +22,7 @@ class VariableTypeAndName(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @VariableTypeAndName.Validators.root
+            @VariableTypeAndName.Validators.root()
             def validate(values: VariableTypeAndName.Partial) -> VariableTypeAndName.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_building_executor_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_building_executor_response.py
@@ -23,7 +23,7 @@ class BuildingExecutorResponse(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @BuildingExecutorResponse.Validators.root
+            @BuildingExecutorResponse.Validators.root()
             def validate(values: BuildingExecutorResponse.Partial) -> BuildingExecutorResponse.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_compile_error.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_compile_error.py
@@ -18,7 +18,7 @@ class CompileError(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @CompileError.Validators.root
+            @CompileError.Validators.root()
             def validate(values: CompileError.Partial) -> CompileError.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_custom_test_cases_unsupported.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_custom_test_cases_unsupported.py
@@ -23,7 +23,7 @@ class CustomTestCasesUnsupported(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @CustomTestCasesUnsupported.Validators.root
+            @CustomTestCasesUnsupported.Validators.root()
             def validate(values: CustomTestCasesUnsupported.Partial) -> CustomTestCasesUnsupported.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_errored_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_errored_response.py
@@ -23,7 +23,7 @@ class ErroredResponse(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @ErroredResponse.Validators.root
+            @ErroredResponse.Validators.root()
             def validate(values: ErroredResponse.Partial) -> ErroredResponse.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_exception_info.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_exception_info.py
@@ -22,7 +22,7 @@ class ExceptionInfo(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @ExceptionInfo.Validators.root
+            @ExceptionInfo.Validators.root()
             def validate(values: ExceptionInfo.Partial) -> ExceptionInfo.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_execution_session_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_execution_session_response.py
@@ -27,7 +27,7 @@ class ExecutionSessionResponse(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @ExecutionSessionResponse.Validators.root
+            @ExecutionSessionResponse.Validators.root()
             def validate(values: ExecutionSessionResponse.Partial) -> ExecutionSessionResponse.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_execution_session_state.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_execution_session_state.py
@@ -33,7 +33,7 @@ class ExecutionSessionState(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @ExecutionSessionState.Validators.root
+            @ExecutionSessionState.Validators.root()
             def validate(values: ExecutionSessionState.Partial) -> ExecutionSessionState.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_existing_submission_executing.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_existing_submission_executing.py
@@ -20,7 +20,7 @@ class ExistingSubmissionExecuting(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @ExistingSubmissionExecuting.Validators.root
+            @ExistingSubmissionExecuting.Validators.root()
             def validate(values: ExistingSubmissionExecuting.Partial) -> ExistingSubmissionExecuting.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_expression_location.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_expression_location.py
@@ -20,7 +20,7 @@ class ExpressionLocation(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @ExpressionLocation.Validators.root
+            @ExpressionLocation.Validators.root()
             def validate(values: ExpressionLocation.Partial) -> ExpressionLocation.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_finished_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_finished_response.py
@@ -20,7 +20,7 @@ class FinishedResponse(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @FinishedResponse.Validators.root
+            @FinishedResponse.Validators.root()
             def validate(values: FinishedResponse.Partial) -> FinishedResponse.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_get_execution_session_state_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_get_execution_session_state_response.py
@@ -24,7 +24,7 @@ class GetExecutionSessionStateResponse(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @GetExecutionSessionStateResponse.Validators.root
+            @GetExecutionSessionStateResponse.Validators.root()
             def validate(values: GetExecutionSessionStateResponse.Partial) -> GetExecutionSessionStateResponse.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_get_submission_state_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_get_submission_state_response.py
@@ -28,7 +28,7 @@ class GetSubmissionStateResponse(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @GetSubmissionStateResponse.Validators.root
+            @GetSubmissionStateResponse.Validators.root()
             def validate(values: GetSubmissionStateResponse.Partial) -> GetSubmissionStateResponse.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_get_trace_responses_page_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_get_trace_responses_page_request.py
@@ -18,7 +18,7 @@ class GetTraceResponsesPageRequest(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @GetTraceResponsesPageRequest.Validators.root
+            @GetTraceResponsesPageRequest.Validators.root()
             def validate(values: GetTraceResponsesPageRequest.Partial) -> GetTraceResponsesPageRequest.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_graded_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_graded_response.py
@@ -23,7 +23,7 @@ class GradedResponse(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @GradedResponse.Validators.root
+            @GradedResponse.Validators.root()
             def validate(values: GradedResponse.Partial) -> GradedResponse.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_graded_response_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_graded_response_v_2.py
@@ -24,7 +24,7 @@ class GradedResponseV2(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @GradedResponseV2.Validators.root
+            @GradedResponseV2.Validators.root()
             def validate(values: GradedResponseV2.Partial) -> GradedResponseV2.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_graded_test_case_update.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_graded_test_case_update.py
@@ -23,7 +23,7 @@ class GradedTestCaseUpdate(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @GradedTestCaseUpdate.Validators.root
+            @GradedTestCaseUpdate.Validators.root()
             def validate(values: GradedTestCaseUpdate.Partial) -> GradedTestCaseUpdate.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_initialize_problem_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_initialize_problem_request.py
@@ -22,7 +22,7 @@ class InitializeProblemRequest(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @InitializeProblemRequest.Validators.root
+            @InitializeProblemRequest.Validators.root()
             def validate(values: InitializeProblemRequest.Partial) -> InitializeProblemRequest.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_internal_error.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_internal_error.py
@@ -20,7 +20,7 @@ class InternalError(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @InternalError.Validators.root
+            @InternalError.Validators.root()
             def validate(values: InternalError.Partial) -> InternalError.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_invalid_request_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_invalid_request_response.py
@@ -23,7 +23,7 @@ class InvalidRequestResponse(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @InvalidRequestResponse.Validators.root
+            @InvalidRequestResponse.Validators.root()
             def validate(values: InvalidRequestResponse.Partial) -> InvalidRequestResponse.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_lightweight_stackframe_information.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_lightweight_stackframe_information.py
@@ -20,7 +20,7 @@ class LightweightStackframeInformation(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @LightweightStackframeInformation.Validators.root
+            @LightweightStackframeInformation.Validators.root()
             def validate(values: LightweightStackframeInformation.Partial) -> LightweightStackframeInformation.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_recorded_response_notification.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_recorded_response_notification.py
@@ -24,7 +24,7 @@ class RecordedResponseNotification(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @RecordedResponseNotification.Validators.root
+            @RecordedResponseNotification.Validators.root()
             def validate(values: RecordedResponseNotification.Partial) -> RecordedResponseNotification.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_recorded_test_case_update.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_recorded_test_case_update.py
@@ -22,7 +22,7 @@ class RecordedTestCaseUpdate(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @RecordedTestCaseUpdate.Validators.root
+            @RecordedTestCaseUpdate.Validators.root()
             def validate(values: RecordedTestCaseUpdate.Partial) -> RecordedTestCaseUpdate.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_recording_response_notification.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_recording_response_notification.py
@@ -30,7 +30,7 @@ class RecordingResponseNotification(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @RecordingResponseNotification.Validators.root
+            @RecordingResponseNotification.Validators.root()
             def validate(values: RecordingResponseNotification.Partial) -> RecordingResponseNotification.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_running_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_running_response.py
@@ -23,7 +23,7 @@ class RunningResponse(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @RunningResponse.Validators.root
+            @RunningResponse.Validators.root()
             def validate(values: RunningResponse.Partial) -> RunningResponse.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_runtime_error.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_runtime_error.py
@@ -18,7 +18,7 @@ class RuntimeError(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @RuntimeError.Validators.root
+            @RuntimeError.Validators.root()
             def validate(values: RuntimeError.Partial) -> RuntimeError.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_scope.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_scope.py
@@ -20,7 +20,7 @@ class Scope(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @Scope.Validators.root
+            @Scope.Validators.root()
             def validate(values: Scope.Partial) -> Scope.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_stack_frame.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_stack_frame.py
@@ -24,7 +24,7 @@ class StackFrame(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @StackFrame.Validators.root
+            @StackFrame.Validators.root()
             def validate(values: StackFrame.Partial) -> StackFrame.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_stack_information.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_stack_information.py
@@ -22,7 +22,7 @@ class StackInformation(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @StackInformation.Validators.root
+            @StackInformation.Validators.root()
             def validate(values: StackInformation.Partial) -> StackInformation.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_stderr_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_stderr_response.py
@@ -22,7 +22,7 @@ class StderrResponse(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @StderrResponse.Validators.root
+            @StderrResponse.Validators.root()
             def validate(values: StderrResponse.Partial) -> StderrResponse.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_stdout_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_stdout_response.py
@@ -22,7 +22,7 @@ class StdoutResponse(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @StdoutResponse.Validators.root
+            @StdoutResponse.Validators.root()
             def validate(values: StdoutResponse.Partial) -> StdoutResponse.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_stop_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_stop_request.py
@@ -20,7 +20,7 @@ class StopRequest(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @StopRequest.Validators.root
+            @StopRequest.Validators.root()
             def validate(values: StopRequest.Partial) -> StopRequest.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_stopped_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_stopped_response.py
@@ -20,7 +20,7 @@ class StoppedResponse(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @StoppedResponse.Validators.root
+            @StoppedResponse.Validators.root()
             def validate(values: StoppedResponse.Partial) -> StoppedResponse.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_submission_file_info.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_submission_file_info.py
@@ -22,7 +22,7 @@ class SubmissionFileInfo(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @SubmissionFileInfo.Validators.root
+            @SubmissionFileInfo.Validators.root()
             def validate(values: SubmissionFileInfo.Partial) -> SubmissionFileInfo.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_submission_id_not_found.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_submission_id_not_found.py
@@ -20,7 +20,7 @@ class SubmissionIdNotFound(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @SubmissionIdNotFound.Validators.root
+            @SubmissionIdNotFound.Validators.root()
             def validate(values: SubmissionIdNotFound.Partial) -> SubmissionIdNotFound.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_submit_request_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_submit_request_v_2.py
@@ -33,7 +33,7 @@ class SubmitRequestV2(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @SubmitRequestV2.Validators.root
+            @SubmitRequestV2.Validators.root()
             def validate(values: SubmitRequestV2.Partial) -> SubmitRequestV2.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_terminated_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_terminated_response.py
@@ -16,7 +16,7 @@ class TerminatedResponse(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TerminatedResponse.Validators.root
+            @TerminatedResponse.Validators.root()
             def validate(values: TerminatedResponse.Partial) -> TerminatedResponse.Partial:
                 ...
         """

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_case_hidden_grade.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_case_hidden_grade.py
@@ -18,7 +18,7 @@ class TestCaseHiddenGrade(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TestCaseHiddenGrade.Validators.root
+            @TestCaseHiddenGrade.Validators.root()
             def validate(values: TestCaseHiddenGrade.Partial) -> TestCaseHiddenGrade.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_case_non_hidden_grade.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_case_non_hidden_grade.py
@@ -27,7 +27,7 @@ class TestCaseNonHiddenGrade(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TestCaseNonHiddenGrade.Validators.root
+            @TestCaseNonHiddenGrade.Validators.root()
             def validate(values: TestCaseNonHiddenGrade.Partial) -> TestCaseNonHiddenGrade.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_case_result.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_case_result.py
@@ -25,7 +25,7 @@ class TestCaseResult(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TestCaseResult.Validators.root
+            @TestCaseResult.Validators.root()
             def validate(values: TestCaseResult.Partial) -> TestCaseResult.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_case_result_with_stdout.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_case_result_with_stdout.py
@@ -22,7 +22,7 @@ class TestCaseResultWithStdout(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TestCaseResultWithStdout.Validators.root
+            @TestCaseResultWithStdout.Validators.root()
             def validate(values: TestCaseResultWithStdout.Partial) -> TestCaseResultWithStdout.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_submission_state.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_submission_state.py
@@ -28,7 +28,7 @@ class TestSubmissionState(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TestSubmissionState.Validators.root
+            @TestSubmissionState.Validators.root()
             def validate(values: TestSubmissionState.Partial) -> TestSubmissionState.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_submission_status_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_submission_status_v_2.py
@@ -28,7 +28,7 @@ class TestSubmissionStatusV2(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TestSubmissionStatusV2.Validators.root
+            @TestSubmissionStatusV2.Validators.root()
             def validate(values: TestSubmissionStatusV2.Partial) -> TestSubmissionStatusV2.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_submission_update.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_submission_update.py
@@ -23,7 +23,7 @@ class TestSubmissionUpdate(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TestSubmissionUpdate.Validators.root
+            @TestSubmissionUpdate.Validators.root()
             def validate(values: TestSubmissionUpdate.Partial) -> TestSubmissionUpdate.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_trace_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_trace_response.py
@@ -33,7 +33,7 @@ class TraceResponse(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TraceResponse.Validators.root
+            @TraceResponse.Validators.root()
             def validate(values: TraceResponse.Partial) -> TraceResponse.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_trace_response_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_trace_response_v_2.py
@@ -36,7 +36,7 @@ class TraceResponseV2(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TraceResponseV2.Validators.root
+            @TraceResponseV2.Validators.root()
             def validate(values: TraceResponseV2.Partial) -> TraceResponseV2.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_trace_responses_page.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_trace_responses_page.py
@@ -27,7 +27,7 @@ class TraceResponsesPage(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TraceResponsesPage.Validators.root
+            @TraceResponsesPage.Validators.root()
             def validate(values: TraceResponsesPage.Partial) -> TraceResponsesPage.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_trace_responses_page_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_trace_responses_page_v_2.py
@@ -27,7 +27,7 @@ class TraceResponsesPageV2(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TraceResponsesPageV2.Validators.root
+            @TraceResponsesPageV2.Validators.root()
             def validate(values: TraceResponsesPageV2.Partial) -> TraceResponsesPageV2.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_traced_file.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_traced_file.py
@@ -20,7 +20,7 @@ class TracedFile(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TracedFile.Validators.root
+            @TracedFile.Validators.root()
             def validate(values: TracedFile.Partial) -> TracedFile.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_traced_test_case.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_traced_test_case.py
@@ -22,7 +22,7 @@ class TracedTestCase(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TracedTestCase.Validators.root
+            @TracedTestCase.Validators.root()
             def validate(values: TracedTestCase.Partial) -> TracedTestCase.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_unexpected_language_error.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_unexpected_language_error.py
@@ -22,7 +22,7 @@ class UnexpectedLanguageError(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @UnexpectedLanguageError.Validators.root
+            @UnexpectedLanguageError.Validators.root()
             def validate(values: UnexpectedLanguageError.Partial) -> UnexpectedLanguageError.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_files.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_files.py
@@ -22,7 +22,7 @@ class WorkspaceFiles(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @WorkspaceFiles.Validators.root
+            @WorkspaceFiles.Validators.root()
             def validate(values: WorkspaceFiles.Partial) -> WorkspaceFiles.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_ran_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_ran_response.py
@@ -23,7 +23,7 @@ class WorkspaceRanResponse(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @WorkspaceRanResponse.Validators.root
+            @WorkspaceRanResponse.Validators.root()
             def validate(values: WorkspaceRanResponse.Partial) -> WorkspaceRanResponse.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_run_details.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_run_details.py
@@ -25,7 +25,7 @@ class WorkspaceRunDetails(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @WorkspaceRunDetails.Validators.root
+            @WorkspaceRunDetails.Validators.root()
             def validate(values: WorkspaceRunDetails.Partial) -> WorkspaceRunDetails.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_starter_files_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_starter_files_response.py
@@ -21,7 +21,7 @@ class WorkspaceStarterFilesResponse(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @WorkspaceStarterFilesResponse.Validators.root
+            @WorkspaceStarterFilesResponse.Validators.root()
             def validate(values: WorkspaceStarterFilesResponse.Partial) -> WorkspaceStarterFilesResponse.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_starter_files_response_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_starter_files_response_v_2.py
@@ -21,7 +21,7 @@ class WorkspaceStarterFilesResponseV2(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @WorkspaceStarterFilesResponseV2.Validators.root
+            @WorkspaceStarterFilesResponseV2.Validators.root()
             def validate(values: WorkspaceStarterFilesResponseV2.Partial) -> WorkspaceStarterFilesResponseV2.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_submission_state.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_submission_state.py
@@ -20,7 +20,7 @@ class WorkspaceSubmissionState(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @WorkspaceSubmissionState.Validators.root
+            @WorkspaceSubmissionState.Validators.root()
             def validate(values: WorkspaceSubmissionState.Partial) -> WorkspaceSubmissionState.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_submission_status_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_submission_status_v_2.py
@@ -20,7 +20,7 @@ class WorkspaceSubmissionStatusV2(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @WorkspaceSubmissionStatusV2.Validators.root
+            @WorkspaceSubmissionStatusV2.Validators.root()
             def validate(values: WorkspaceSubmissionStatusV2.Partial) -> WorkspaceSubmissionStatusV2.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_submission_update.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_submission_update.py
@@ -23,7 +23,7 @@ class WorkspaceSubmissionUpdate(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @WorkspaceSubmissionUpdate.Validators.root
+            @WorkspaceSubmissionUpdate.Validators.root()
             def validate(values: WorkspaceSubmissionUpdate.Partial) -> WorkspaceSubmissionUpdate.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_submit_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_submit_request.py
@@ -28,7 +28,7 @@ class WorkspaceSubmitRequest(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @WorkspaceSubmitRequest.Validators.root
+            @WorkspaceSubmitRequest.Validators.root()
             def validate(values: WorkspaceSubmitRequest.Partial) -> WorkspaceSubmitRequest.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_traced_update.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_traced_update.py
@@ -18,7 +18,7 @@ class WorkspaceTracedUpdate(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @WorkspaceTracedUpdate.Validators.root
+            @WorkspaceTracedUpdate.Validators.root()
             def validate(values: WorkspaceTracedUpdate.Partial) -> WorkspaceTracedUpdate.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_basic_custom_files.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_basic_custom_files.py
@@ -29,7 +29,7 @@ class BasicCustomFiles(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @BasicCustomFiles.Validators.root
+            @BasicCustomFiles.Validators.root()
             def validate(values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_basic_test_case_template.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_basic_test_case_template.py
@@ -28,7 +28,7 @@ class BasicTestCaseTemplate(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @BasicTestCaseTemplate.Validators.root
+            @BasicTestCaseTemplate.Validators.root()
             def validate(values: BasicTestCaseTemplate.Partial) -> BasicTestCaseTemplate.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_create_problem_request_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_create_problem_request_v_2.py
@@ -36,7 +36,7 @@ class CreateProblemRequestV2(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @CreateProblemRequestV2.Validators.root
+            @CreateProblemRequestV2.Validators.root()
             def validate(values: CreateProblemRequestV2.Partial) -> CreateProblemRequestV2.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_deep_equality_correctness_check.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_deep_equality_correctness_check.py
@@ -20,7 +20,7 @@ class DeepEqualityCorrectnessCheck(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @DeepEqualityCorrectnessCheck.Validators.root
+            @DeepEqualityCorrectnessCheck.Validators.root()
             def validate(values: DeepEqualityCorrectnessCheck.Partial) -> DeepEqualityCorrectnessCheck.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_default_provided_file.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_default_provided_file.py
@@ -23,7 +23,7 @@ class DefaultProvidedFile(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @DefaultProvidedFile.Validators.root
+            @DefaultProvidedFile.Validators.root()
             def validate(values: DefaultProvidedFile.Partial) -> DefaultProvidedFile.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_file_info_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_file_info_v_2.py
@@ -24,7 +24,7 @@ class FileInfoV2(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @FileInfoV2.Validators.root
+            @FileInfoV2.Validators.root()
             def validate(values: FileInfoV2.Partial) -> FileInfoV2.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_files.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_files.py
@@ -20,7 +20,7 @@ class Files(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @Files.Validators.root
+            @Files.Validators.root()
             def validate(values: Files.Partial) -> Files.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_function_implementation.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_function_implementation.py
@@ -20,7 +20,7 @@ class FunctionImplementation(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @FunctionImplementation.Validators.root
+            @FunctionImplementation.Validators.root()
             def validate(values: FunctionImplementation.Partial) -> FunctionImplementation.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_function_implementation_for_multiple_languages.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_function_implementation_for_multiple_languages.py
@@ -21,7 +21,7 @@ class FunctionImplementationForMultipleLanguages(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @FunctionImplementationForMultipleLanguages.Validators.root
+            @FunctionImplementationForMultipleLanguages.Validators.root()
             def validate(values: FunctionImplementationForMultipleLanguages.Partial) -> FunctionImplementationForMultipleLanguages.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_generated_files.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_generated_files.py
@@ -25,7 +25,7 @@ class GeneratedFiles(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @GeneratedFiles.Validators.root
+            @GeneratedFiles.Validators.root()
             def validate(values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_get_basic_solution_file_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_get_basic_solution_file_request.py
@@ -22,7 +22,7 @@ class GetBasicSolutionFileRequest(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @GetBasicSolutionFileRequest.Validators.root
+            @GetBasicSolutionFileRequest.Validators.root()
             def validate(values: GetBasicSolutionFileRequest.Partial) -> GetBasicSolutionFileRequest.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_get_basic_solution_file_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_get_basic_solution_file_response.py
@@ -21,7 +21,7 @@ class GetBasicSolutionFileResponse(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @GetBasicSolutionFileResponse.Validators.root
+            @GetBasicSolutionFileResponse.Validators.root()
             def validate(values: GetBasicSolutionFileResponse.Partial) -> GetBasicSolutionFileResponse.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_get_function_signature_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_get_function_signature_request.py
@@ -20,7 +20,7 @@ class GetFunctionSignatureRequest(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @GetFunctionSignatureRequest.Validators.root
+            @GetFunctionSignatureRequest.Validators.root()
             def validate(values: GetFunctionSignatureRequest.Partial) -> GetFunctionSignatureRequest.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_get_function_signature_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_get_function_signature_response.py
@@ -20,7 +20,7 @@ class GetFunctionSignatureResponse(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @GetFunctionSignatureResponse.Validators.root
+            @GetFunctionSignatureResponse.Validators.root()
             def validate(values: GetFunctionSignatureResponse.Partial) -> GetFunctionSignatureResponse.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_get_generated_test_case_file_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_get_generated_test_case_file_request.py
@@ -23,7 +23,7 @@ class GetGeneratedTestCaseFileRequest(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @GetGeneratedTestCaseFileRequest.Validators.root
+            @GetGeneratedTestCaseFileRequest.Validators.root()
             def validate(values: GetGeneratedTestCaseFileRequest.Partial) -> GetGeneratedTestCaseFileRequest.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_get_generated_test_case_template_file_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_get_generated_test_case_template_file_request.py
@@ -20,7 +20,7 @@ class GetGeneratedTestCaseTemplateFileRequest(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @GetGeneratedTestCaseTemplateFileRequest.Validators.root
+            @GetGeneratedTestCaseTemplateFileRequest.Validators.root()
             def validate(values: GetGeneratedTestCaseTemplateFileRequest.Partial) -> GetGeneratedTestCaseTemplateFileRequest.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_lightweight_problem_info_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_lightweight_problem_info_v_2.py
@@ -27,7 +27,7 @@ class LightweightProblemInfoV2(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @LightweightProblemInfoV2.Validators.root
+            @LightweightProblemInfoV2.Validators.root()
             def validate(values: LightweightProblemInfoV2.Partial) -> LightweightProblemInfoV2.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_non_void_function_definition.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_non_void_function_definition.py
@@ -23,7 +23,7 @@ class NonVoidFunctionDefinition(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @NonVoidFunctionDefinition.Validators.root
+            @NonVoidFunctionDefinition.Validators.root()
             def validate(values: NonVoidFunctionDefinition.Partial) -> NonVoidFunctionDefinition.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_non_void_function_signature.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_non_void_function_signature.py
@@ -23,7 +23,7 @@ class NonVoidFunctionSignature(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @NonVoidFunctionSignature.Validators.root
+            @NonVoidFunctionSignature.Validators.root()
             def validate(values: NonVoidFunctionSignature.Partial) -> NonVoidFunctionSignature.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_parameter.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_parameter.py
@@ -25,7 +25,7 @@ class Parameter(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @Parameter.Validators.root
+            @Parameter.Validators.root()
             def validate(values: Parameter.Partial) -> Parameter.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_problem_info_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_problem_info_v_2.py
@@ -44,7 +44,7 @@ class ProblemInfoV2(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @ProblemInfoV2.Validators.root
+            @ProblemInfoV2.Validators.root()
             def validate(values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_test_case_expects.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_test_case_expects.py
@@ -18,7 +18,7 @@ class TestCaseExpects(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TestCaseExpects.Validators.root
+            @TestCaseExpects.Validators.root()
             def validate(values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_test_case_implementation.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_test_case_implementation.py
@@ -23,7 +23,7 @@ class TestCaseImplementation(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TestCaseImplementation.Validators.root
+            @TestCaseImplementation.Validators.root()
             def validate(values: TestCaseImplementation.Partial) -> TestCaseImplementation.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_test_case_implementation_description.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_test_case_implementation_description.py
@@ -20,7 +20,7 @@ class TestCaseImplementationDescription(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TestCaseImplementationDescription.Validators.root
+            @TestCaseImplementationDescription.Validators.root()
             def validate(values: TestCaseImplementationDescription.Partial) -> TestCaseImplementationDescription.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_test_case_metadata.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_test_case_metadata.py
@@ -24,7 +24,7 @@ class TestCaseMetadata(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TestCaseMetadata.Validators.root
+            @TestCaseMetadata.Validators.root()
             def validate(values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_test_case_template.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_test_case_template.py
@@ -25,7 +25,7 @@ class TestCaseTemplate(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TestCaseTemplate.Validators.root
+            @TestCaseTemplate.Validators.root()
             def validate(values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_test_case_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_test_case_v_2.py
@@ -30,7 +30,7 @@ class TestCaseV2(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TestCaseV2.Validators.root
+            @TestCaseV2.Validators.root()
             def validate(values: TestCaseV2.Partial) -> TestCaseV2.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_test_case_with_actual_result_implementation.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_test_case_with_actual_result_implementation.py
@@ -23,7 +23,7 @@ class TestCaseWithActualResultImplementation(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TestCaseWithActualResultImplementation.Validators.root
+            @TestCaseWithActualResultImplementation.Validators.root()
             def validate(values: TestCaseWithActualResultImplementation.Partial) -> TestCaseWithActualResultImplementation.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_void_function_definition.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_void_function_definition.py
@@ -23,7 +23,7 @@ class VoidFunctionDefinition(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @VoidFunctionDefinition.Validators.root
+            @VoidFunctionDefinition.Validators.root()
             def validate(values: VoidFunctionDefinition.Partial) -> VoidFunctionDefinition.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_void_function_definition_that_takes_actual_result.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_void_function_definition_that_takes_actual_result.py
@@ -27,7 +27,7 @@ class VoidFunctionDefinitionThatTakesActualResult(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @VoidFunctionDefinitionThatTakesActualResult.Validators.root
+            @VoidFunctionDefinitionThatTakesActualResult.Validators.root()
             def validate(values: VoidFunctionDefinitionThatTakesActualResult.Partial) -> VoidFunctionDefinitionThatTakesActualResult.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_void_function_signature.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_void_function_signature.py
@@ -20,7 +20,7 @@ class VoidFunctionSignature(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @VoidFunctionSignature.Validators.root
+            @VoidFunctionSignature.Validators.root()
             def validate(values: VoidFunctionSignature.Partial) -> VoidFunctionSignature.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_void_function_signature_that_takes_actual_result.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_problem_types_void_function_signature_that_takes_actual_result.py
@@ -23,7 +23,7 @@ class VoidFunctionSignatureThatTakesActualResult(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @VoidFunctionSignatureThatTakesActualResult.Validators.root
+            @VoidFunctionSignatureThatTakesActualResult.Validators.root()
             def validate(values: VoidFunctionSignatureThatTakesActualResult.Partial) -> VoidFunctionSignatureThatTakesActualResult.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_basic_custom_files.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_basic_custom_files.py
@@ -29,7 +29,7 @@ class BasicCustomFiles(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @BasicCustomFiles.Validators.root
+            @BasicCustomFiles.Validators.root()
             def validate(values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_basic_test_case_template.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_basic_test_case_template.py
@@ -28,7 +28,7 @@ class BasicTestCaseTemplate(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @BasicTestCaseTemplate.Validators.root
+            @BasicTestCaseTemplate.Validators.root()
             def validate(values: BasicTestCaseTemplate.Partial) -> BasicTestCaseTemplate.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_create_problem_request_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_create_problem_request_v_2.py
@@ -36,7 +36,7 @@ class CreateProblemRequestV2(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @CreateProblemRequestV2.Validators.root
+            @CreateProblemRequestV2.Validators.root()
             def validate(values: CreateProblemRequestV2.Partial) -> CreateProblemRequestV2.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_deep_equality_correctness_check.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_deep_equality_correctness_check.py
@@ -20,7 +20,7 @@ class DeepEqualityCorrectnessCheck(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @DeepEqualityCorrectnessCheck.Validators.root
+            @DeepEqualityCorrectnessCheck.Validators.root()
             def validate(values: DeepEqualityCorrectnessCheck.Partial) -> DeepEqualityCorrectnessCheck.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_default_provided_file.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_default_provided_file.py
@@ -23,7 +23,7 @@ class DefaultProvidedFile(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @DefaultProvidedFile.Validators.root
+            @DefaultProvidedFile.Validators.root()
             def validate(values: DefaultProvidedFile.Partial) -> DefaultProvidedFile.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_file_info_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_file_info_v_2.py
@@ -24,7 +24,7 @@ class FileInfoV2(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @FileInfoV2.Validators.root
+            @FileInfoV2.Validators.root()
             def validate(values: FileInfoV2.Partial) -> FileInfoV2.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_files.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_files.py
@@ -20,7 +20,7 @@ class Files(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @Files.Validators.root
+            @Files.Validators.root()
             def validate(values: Files.Partial) -> Files.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_function_implementation.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_function_implementation.py
@@ -20,7 +20,7 @@ class FunctionImplementation(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @FunctionImplementation.Validators.root
+            @FunctionImplementation.Validators.root()
             def validate(values: FunctionImplementation.Partial) -> FunctionImplementation.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_function_implementation_for_multiple_languages.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_function_implementation_for_multiple_languages.py
@@ -21,7 +21,7 @@ class FunctionImplementationForMultipleLanguages(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @FunctionImplementationForMultipleLanguages.Validators.root
+            @FunctionImplementationForMultipleLanguages.Validators.root()
             def validate(values: FunctionImplementationForMultipleLanguages.Partial) -> FunctionImplementationForMultipleLanguages.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_generated_files.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_generated_files.py
@@ -25,7 +25,7 @@ class GeneratedFiles(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @GeneratedFiles.Validators.root
+            @GeneratedFiles.Validators.root()
             def validate(values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_get_basic_solution_file_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_get_basic_solution_file_request.py
@@ -22,7 +22,7 @@ class GetBasicSolutionFileRequest(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @GetBasicSolutionFileRequest.Validators.root
+            @GetBasicSolutionFileRequest.Validators.root()
             def validate(values: GetBasicSolutionFileRequest.Partial) -> GetBasicSolutionFileRequest.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_get_basic_solution_file_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_get_basic_solution_file_response.py
@@ -21,7 +21,7 @@ class GetBasicSolutionFileResponse(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @GetBasicSolutionFileResponse.Validators.root
+            @GetBasicSolutionFileResponse.Validators.root()
             def validate(values: GetBasicSolutionFileResponse.Partial) -> GetBasicSolutionFileResponse.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_get_function_signature_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_get_function_signature_request.py
@@ -20,7 +20,7 @@ class GetFunctionSignatureRequest(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @GetFunctionSignatureRequest.Validators.root
+            @GetFunctionSignatureRequest.Validators.root()
             def validate(values: GetFunctionSignatureRequest.Partial) -> GetFunctionSignatureRequest.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_get_function_signature_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_get_function_signature_response.py
@@ -20,7 +20,7 @@ class GetFunctionSignatureResponse(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @GetFunctionSignatureResponse.Validators.root
+            @GetFunctionSignatureResponse.Validators.root()
             def validate(values: GetFunctionSignatureResponse.Partial) -> GetFunctionSignatureResponse.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_get_generated_test_case_file_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_get_generated_test_case_file_request.py
@@ -23,7 +23,7 @@ class GetGeneratedTestCaseFileRequest(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @GetGeneratedTestCaseFileRequest.Validators.root
+            @GetGeneratedTestCaseFileRequest.Validators.root()
             def validate(values: GetGeneratedTestCaseFileRequest.Partial) -> GetGeneratedTestCaseFileRequest.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_get_generated_test_case_template_file_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_get_generated_test_case_template_file_request.py
@@ -20,7 +20,7 @@ class GetGeneratedTestCaseTemplateFileRequest(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @GetGeneratedTestCaseTemplateFileRequest.Validators.root
+            @GetGeneratedTestCaseTemplateFileRequest.Validators.root()
             def validate(values: GetGeneratedTestCaseTemplateFileRequest.Partial) -> GetGeneratedTestCaseTemplateFileRequest.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_lightweight_problem_info_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_lightweight_problem_info_v_2.py
@@ -27,7 +27,7 @@ class LightweightProblemInfoV2(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @LightweightProblemInfoV2.Validators.root
+            @LightweightProblemInfoV2.Validators.root()
             def validate(values: LightweightProblemInfoV2.Partial) -> LightweightProblemInfoV2.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_non_void_function_definition.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_non_void_function_definition.py
@@ -23,7 +23,7 @@ class NonVoidFunctionDefinition(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @NonVoidFunctionDefinition.Validators.root
+            @NonVoidFunctionDefinition.Validators.root()
             def validate(values: NonVoidFunctionDefinition.Partial) -> NonVoidFunctionDefinition.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_non_void_function_signature.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_non_void_function_signature.py
@@ -23,7 +23,7 @@ class NonVoidFunctionSignature(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @NonVoidFunctionSignature.Validators.root
+            @NonVoidFunctionSignature.Validators.root()
             def validate(values: NonVoidFunctionSignature.Partial) -> NonVoidFunctionSignature.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_parameter.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_parameter.py
@@ -25,7 +25,7 @@ class Parameter(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @Parameter.Validators.root
+            @Parameter.Validators.root()
             def validate(values: Parameter.Partial) -> Parameter.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_problem_info_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_problem_info_v_2.py
@@ -44,7 +44,7 @@ class ProblemInfoV2(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @ProblemInfoV2.Validators.root
+            @ProblemInfoV2.Validators.root()
             def validate(values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_test_case_expects.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_test_case_expects.py
@@ -18,7 +18,7 @@ class TestCaseExpects(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TestCaseExpects.Validators.root
+            @TestCaseExpects.Validators.root()
             def validate(values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_test_case_implementation.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_test_case_implementation.py
@@ -23,7 +23,7 @@ class TestCaseImplementation(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TestCaseImplementation.Validators.root
+            @TestCaseImplementation.Validators.root()
             def validate(values: TestCaseImplementation.Partial) -> TestCaseImplementation.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_test_case_implementation_description.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_test_case_implementation_description.py
@@ -20,7 +20,7 @@ class TestCaseImplementationDescription(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TestCaseImplementationDescription.Validators.root
+            @TestCaseImplementationDescription.Validators.root()
             def validate(values: TestCaseImplementationDescription.Partial) -> TestCaseImplementationDescription.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_test_case_metadata.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_test_case_metadata.py
@@ -24,7 +24,7 @@ class TestCaseMetadata(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TestCaseMetadata.Validators.root
+            @TestCaseMetadata.Validators.root()
             def validate(values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_test_case_template.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_test_case_template.py
@@ -25,7 +25,7 @@ class TestCaseTemplate(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TestCaseTemplate.Validators.root
+            @TestCaseTemplate.Validators.root()
             def validate(values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_test_case_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_test_case_v_2.py
@@ -30,7 +30,7 @@ class TestCaseV2(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TestCaseV2.Validators.root
+            @TestCaseV2.Validators.root()
             def validate(values: TestCaseV2.Partial) -> TestCaseV2.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_test_case_with_actual_result_implementation.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_test_case_with_actual_result_implementation.py
@@ -23,7 +23,7 @@ class TestCaseWithActualResultImplementation(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TestCaseWithActualResultImplementation.Validators.root
+            @TestCaseWithActualResultImplementation.Validators.root()
             def validate(values: TestCaseWithActualResultImplementation.Partial) -> TestCaseWithActualResultImplementation.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_void_function_definition.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_void_function_definition.py
@@ -23,7 +23,7 @@ class VoidFunctionDefinition(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @VoidFunctionDefinition.Validators.root
+            @VoidFunctionDefinition.Validators.root()
             def validate(values: VoidFunctionDefinition.Partial) -> VoidFunctionDefinition.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_void_function_definition_that_takes_actual_result.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_void_function_definition_that_takes_actual_result.py
@@ -27,7 +27,7 @@ class VoidFunctionDefinitionThatTakesActualResult(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @VoidFunctionDefinitionThatTakesActualResult.Validators.root
+            @VoidFunctionDefinitionThatTakesActualResult.Validators.root()
             def validate(values: VoidFunctionDefinitionThatTakesActualResult.Partial) -> VoidFunctionDefinitionThatTakesActualResult.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_void_function_signature.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_void_function_signature.py
@@ -20,7 +20,7 @@ class VoidFunctionSignature(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @VoidFunctionSignature.Validators.root
+            @VoidFunctionSignature.Validators.root()
             def validate(values: VoidFunctionSignature.Partial) -> VoidFunctionSignature.Partial:
                 ...
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_void_function_signature_that_takes_actual_result.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_v_3_problem_types_void_function_signature_that_takes_actual_result.py
@@ -23,7 +23,7 @@ class VoidFunctionSignatureThatTakesActualResult(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @VoidFunctionSignatureThatTakesActualResult.Validators.root
+            @VoidFunctionSignatureThatTakesActualResult.Validators.root()
             def validate(values: VoidFunctionSignatureThatTakesActualResult.Partial) -> VoidFunctionSignatureThatTakesActualResult.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model admin_store_traced_test_case_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model admin_store_traced_test_case_request.py
@@ -23,7 +23,7 @@ class StoreTracedTestCaseRequest(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @StoreTracedTestCaseRequest.Validators.root
+            @StoreTracedTestCaseRequest.Validators.root()
             def validate(values: StoreTracedTestCaseRequest.Partial) -> StoreTracedTestCaseRequest.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model admin_store_traced_workspace_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model admin_store_traced_workspace_request.py
@@ -23,7 +23,7 @@ class StoreTracedWorkspaceRequest(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @StoreTracedWorkspaceRequest.Validators.root
+            @StoreTracedWorkspaceRequest.Validators.root()
             def validate(values: StoreTracedWorkspaceRequest.Partial) -> StoreTracedWorkspaceRequest.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model commons_binary_tree_node_and_tree_value.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model commons_binary_tree_node_and_tree_value.py
@@ -23,7 +23,7 @@ class BinaryTreeNodeAndTreeValue(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @BinaryTreeNodeAndTreeValue.Validators.root
+            @BinaryTreeNodeAndTreeValue.Validators.root()
             def validate(values: BinaryTreeNodeAndTreeValue.Partial) -> BinaryTreeNodeAndTreeValue.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model commons_binary_tree_node_value.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model commons_binary_tree_node_value.py
@@ -26,7 +26,7 @@ class BinaryTreeNodeValue(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @BinaryTreeNodeValue.Validators.root
+            @BinaryTreeNodeValue.Validators.root()
             def validate(values: BinaryTreeNodeValue.Partial) -> BinaryTreeNodeValue.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model commons_binary_tree_value.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model commons_binary_tree_value.py
@@ -23,7 +23,7 @@ class BinaryTreeValue(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @BinaryTreeValue.Validators.root
+            @BinaryTreeValue.Validators.root()
             def validate(values: BinaryTreeValue.Partial) -> BinaryTreeValue.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model commons_debug_key_value_pairs.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model commons_debug_key_value_pairs.py
@@ -20,7 +20,7 @@ class DebugKeyValuePairs(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @DebugKeyValuePairs.Validators.root
+            @DebugKeyValuePairs.Validators.root()
             def validate(values: DebugKeyValuePairs.Partial) -> DebugKeyValuePairs.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model commons_debug_map_value.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model commons_debug_map_value.py
@@ -18,7 +18,7 @@ class DebugMapValue(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @DebugMapValue.Validators.root
+            @DebugMapValue.Validators.root()
             def validate(values: DebugMapValue.Partial) -> DebugMapValue.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model commons_doubly_linked_list_node_and_list_value.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model commons_doubly_linked_list_node_and_list_value.py
@@ -23,7 +23,7 @@ class DoublyLinkedListNodeAndListValue(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @DoublyLinkedListNodeAndListValue.Validators.root
+            @DoublyLinkedListNodeAndListValue.Validators.root()
             def validate(values: DoublyLinkedListNodeAndListValue.Partial) -> DoublyLinkedListNodeAndListValue.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model commons_doubly_linked_list_node_value.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model commons_doubly_linked_list_node_value.py
@@ -26,7 +26,7 @@ class DoublyLinkedListNodeValue(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @DoublyLinkedListNodeValue.Validators.root
+            @DoublyLinkedListNodeValue.Validators.root()
             def validate(values: DoublyLinkedListNodeValue.Partial) -> DoublyLinkedListNodeValue.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model commons_doubly_linked_list_value.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model commons_doubly_linked_list_value.py
@@ -23,7 +23,7 @@ class DoublyLinkedListValue(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @DoublyLinkedListValue.Validators.root
+            @DoublyLinkedListValue.Validators.root()
             def validate(values: DoublyLinkedListValue.Partial) -> DoublyLinkedListValue.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model commons_file_info.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model commons_file_info.py
@@ -20,7 +20,7 @@ class FileInfo(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @FileInfo.Validators.root
+            @FileInfo.Validators.root()
             def validate(values: FileInfo.Partial) -> FileInfo.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model commons_generic_value.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model commons_generic_value.py
@@ -20,7 +20,7 @@ class GenericValue(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @GenericValue.Validators.root
+            @GenericValue.Validators.root()
             def validate(values: GenericValue.Partial) -> GenericValue.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model commons_key_value_pair.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model commons_key_value_pair.py
@@ -20,7 +20,7 @@ class KeyValuePair(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @KeyValuePair.Validators.root
+            @KeyValuePair.Validators.root()
             def validate(values: KeyValuePair.Partial) -> KeyValuePair.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model commons_list_type.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model commons_list_type.py
@@ -25,7 +25,7 @@ class ListType(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @ListType.Validators.root
+            @ListType.Validators.root()
             def validate(values: ListType.Partial) -> ListType.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model commons_map_type.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model commons_map_type.py
@@ -20,7 +20,7 @@ class MapType(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @MapType.Validators.root
+            @MapType.Validators.root()
             def validate(values: MapType.Partial) -> MapType.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model commons_map_value.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model commons_map_value.py
@@ -18,7 +18,7 @@ class MapValue(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @MapValue.Validators.root
+            @MapValue.Validators.root()
             def validate(values: MapValue.Partial) -> MapValue.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model commons_singly_linked_list_node_and_list_value.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model commons_singly_linked_list_node_and_list_value.py
@@ -23,7 +23,7 @@ class SinglyLinkedListNodeAndListValue(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @SinglyLinkedListNodeAndListValue.Validators.root
+            @SinglyLinkedListNodeAndListValue.Validators.root()
             def validate(values: SinglyLinkedListNodeAndListValue.Partial) -> SinglyLinkedListNodeAndListValue.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model commons_singly_linked_list_node_value.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model commons_singly_linked_list_node_value.py
@@ -24,7 +24,7 @@ class SinglyLinkedListNodeValue(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @SinglyLinkedListNodeValue.Validators.root
+            @SinglyLinkedListNodeValue.Validators.root()
             def validate(values: SinglyLinkedListNodeValue.Partial) -> SinglyLinkedListNodeValue.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model commons_singly_linked_list_value.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model commons_singly_linked_list_value.py
@@ -23,7 +23,7 @@ class SinglyLinkedListValue(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @SinglyLinkedListValue.Validators.root
+            @SinglyLinkedListValue.Validators.root()
             def validate(values: SinglyLinkedListValue.Partial) -> SinglyLinkedListValue.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model commons_test_case.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model commons_test_case.py
@@ -22,7 +22,7 @@ class TestCase(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TestCase.Validators.root
+            @TestCase.Validators.root()
             def validate(values: TestCase.Partial) -> TestCase.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model commons_test_case_with_expected_result.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model commons_test_case_with_expected_result.py
@@ -23,7 +23,7 @@ class TestCaseWithExpectedResult(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TestCaseWithExpectedResult.Validators.root
+            @TestCaseWithExpectedResult.Validators.root()
             def validate(values: TestCaseWithExpectedResult.Partial) -> TestCaseWithExpectedResult.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model lang_server_lang_server_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model lang_server_lang_server_request.py
@@ -18,7 +18,7 @@ class LangServerRequest(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @LangServerRequest.Validators.root
+            @LangServerRequest.Validators.root()
             def validate(values: LangServerRequest.Partial) -> LangServerRequest.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model lang_server_lang_server_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model lang_server_lang_server_response.py
@@ -18,7 +18,7 @@ class LangServerResponse(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @LangServerResponse.Validators.root
+            @LangServerResponse.Validators.root()
             def validate(values: LangServerResponse.Partial) -> LangServerResponse.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model migration_migration.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model migration_migration.py
@@ -22,7 +22,7 @@ class Migration(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @Migration.Validators.root
+            @Migration.Validators.root()
             def validate(values: Migration.Partial) -> Migration.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model playlist_playlist.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model playlist_playlist.py
@@ -24,7 +24,7 @@ class Playlist(PlaylistCreateRequest):
         """
         Use this class to add validators to the Pydantic model.
 
-            @Playlist.Validators.root
+            @Playlist.Validators.root()
             def validate(values: Playlist.Partial) -> Playlist.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model playlist_playlist_create_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model playlist_playlist_create_request.py
@@ -22,7 +22,7 @@ class PlaylistCreateRequest(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @PlaylistCreateRequest.Validators.root
+            @PlaylistCreateRequest.Validators.root()
             def validate(values: PlaylistCreateRequest.Partial) -> PlaylistCreateRequest.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model playlist_update_playlist_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model playlist_update_playlist_request.py
@@ -22,7 +22,7 @@ class UpdatePlaylistRequest(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @UpdatePlaylistRequest.Validators.root
+            @UpdatePlaylistRequest.Validators.root()
             def validate(values: UpdatePlaylistRequest.Partial) -> UpdatePlaylistRequest.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model problem_create_problem_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model problem_create_problem_request.py
@@ -37,7 +37,7 @@ class CreateProblemRequest(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @CreateProblemRequest.Validators.root
+            @CreateProblemRequest.Validators.root()
             def validate(values: CreateProblemRequest.Partial) -> CreateProblemRequest.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model problem_generic_create_problem_error.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model problem_generic_create_problem_error.py
@@ -22,7 +22,7 @@ class GenericCreateProblemError(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @GenericCreateProblemError.Validators.root
+            @GenericCreateProblemError.Validators.root()
             def validate(values: GenericCreateProblemError.Partial) -> GenericCreateProblemError.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model problem_get_default_starter_files_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model problem_get_default_starter_files_request.py
@@ -25,7 +25,7 @@ class GetDefaultStarterFilesRequest(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @GetDefaultStarterFilesRequest.Validators.root
+            @GetDefaultStarterFilesRequest.Validators.root()
             def validate(values: GetDefaultStarterFilesRequest.Partial) -> GetDefaultStarterFilesRequest.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model problem_get_default_starter_files_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model problem_get_default_starter_files_response.py
@@ -21,7 +21,7 @@ class GetDefaultStarterFilesResponse(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @GetDefaultStarterFilesResponse.Validators.root
+            @GetDefaultStarterFilesResponse.Validators.root()
             def validate(values: GetDefaultStarterFilesResponse.Partial) -> GetDefaultStarterFilesResponse.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model problem_problem_description.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model problem_problem_description.py
@@ -20,7 +20,7 @@ class ProblemDescription(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @ProblemDescription.Validators.root
+            @ProblemDescription.Validators.root()
             def validate(values: ProblemDescription.Partial) -> ProblemDescription.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model problem_problem_files.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model problem_problem_files.py
@@ -22,7 +22,7 @@ class ProblemFiles(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @ProblemFiles.Validators.root
+            @ProblemFiles.Validators.root()
             def validate(values: ProblemFiles.Partial) -> ProblemFiles.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model problem_problem_info.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model problem_problem_info.py
@@ -44,7 +44,7 @@ class ProblemInfo(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @ProblemInfo.Validators.root
+            @ProblemInfo.Validators.root()
             def validate(values: ProblemInfo.Partial) -> ProblemInfo.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model problem_update_problem_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model problem_update_problem_response.py
@@ -18,7 +18,7 @@ class UpdateProblemResponse(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @UpdateProblemResponse.Validators.root
+            @UpdateProblemResponse.Validators.root()
             def validate(values: UpdateProblemResponse.Partial) -> UpdateProblemResponse.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model problem_variable_type_and_name.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model problem_variable_type_and_name.py
@@ -22,7 +22,7 @@ class VariableTypeAndName(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @VariableTypeAndName.Validators.root
+            @VariableTypeAndName.Validators.root()
             def validate(values: VariableTypeAndName.Partial) -> VariableTypeAndName.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_building_executor_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_building_executor_response.py
@@ -23,7 +23,7 @@ class BuildingExecutorResponse(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @BuildingExecutorResponse.Validators.root
+            @BuildingExecutorResponse.Validators.root()
             def validate(values: BuildingExecutorResponse.Partial) -> BuildingExecutorResponse.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_compile_error.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_compile_error.py
@@ -18,7 +18,7 @@ class CompileError(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @CompileError.Validators.root
+            @CompileError.Validators.root()
             def validate(values: CompileError.Partial) -> CompileError.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_custom_test_cases_unsupported.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_custom_test_cases_unsupported.py
@@ -23,7 +23,7 @@ class CustomTestCasesUnsupported(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @CustomTestCasesUnsupported.Validators.root
+            @CustomTestCasesUnsupported.Validators.root()
             def validate(values: CustomTestCasesUnsupported.Partial) -> CustomTestCasesUnsupported.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_errored_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_errored_response.py
@@ -23,7 +23,7 @@ class ErroredResponse(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @ErroredResponse.Validators.root
+            @ErroredResponse.Validators.root()
             def validate(values: ErroredResponse.Partial) -> ErroredResponse.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_exception_info.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_exception_info.py
@@ -22,7 +22,7 @@ class ExceptionInfo(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @ExceptionInfo.Validators.root
+            @ExceptionInfo.Validators.root()
             def validate(values: ExceptionInfo.Partial) -> ExceptionInfo.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_execution_session_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_execution_session_response.py
@@ -27,7 +27,7 @@ class ExecutionSessionResponse(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @ExecutionSessionResponse.Validators.root
+            @ExecutionSessionResponse.Validators.root()
             def validate(values: ExecutionSessionResponse.Partial) -> ExecutionSessionResponse.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_execution_session_state.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_execution_session_state.py
@@ -31,7 +31,7 @@ class ExecutionSessionState(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @ExecutionSessionState.Validators.root
+            @ExecutionSessionState.Validators.root()
             def validate(values: ExecutionSessionState.Partial) -> ExecutionSessionState.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_existing_submission_executing.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_existing_submission_executing.py
@@ -20,7 +20,7 @@ class ExistingSubmissionExecuting(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @ExistingSubmissionExecuting.Validators.root
+            @ExistingSubmissionExecuting.Validators.root()
             def validate(values: ExistingSubmissionExecuting.Partial) -> ExistingSubmissionExecuting.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_expression_location.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_expression_location.py
@@ -20,7 +20,7 @@ class ExpressionLocation(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @ExpressionLocation.Validators.root
+            @ExpressionLocation.Validators.root()
             def validate(values: ExpressionLocation.Partial) -> ExpressionLocation.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_finished_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_finished_response.py
@@ -20,7 +20,7 @@ class FinishedResponse(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @FinishedResponse.Validators.root
+            @FinishedResponse.Validators.root()
             def validate(values: FinishedResponse.Partial) -> FinishedResponse.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_get_execution_session_state_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_get_execution_session_state_response.py
@@ -24,7 +24,7 @@ class GetExecutionSessionStateResponse(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @GetExecutionSessionStateResponse.Validators.root
+            @GetExecutionSessionStateResponse.Validators.root()
             def validate(values: GetExecutionSessionStateResponse.Partial) -> GetExecutionSessionStateResponse.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_get_submission_state_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_get_submission_state_response.py
@@ -28,7 +28,7 @@ class GetSubmissionStateResponse(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @GetSubmissionStateResponse.Validators.root
+            @GetSubmissionStateResponse.Validators.root()
             def validate(values: GetSubmissionStateResponse.Partial) -> GetSubmissionStateResponse.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_get_trace_responses_page_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_get_trace_responses_page_request.py
@@ -18,7 +18,7 @@ class GetTraceResponsesPageRequest(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @GetTraceResponsesPageRequest.Validators.root
+            @GetTraceResponsesPageRequest.Validators.root()
             def validate(values: GetTraceResponsesPageRequest.Partial) -> GetTraceResponsesPageRequest.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_graded_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_graded_response.py
@@ -23,7 +23,7 @@ class GradedResponse(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @GradedResponse.Validators.root
+            @GradedResponse.Validators.root()
             def validate(values: GradedResponse.Partial) -> GradedResponse.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_graded_response_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_graded_response_v_2.py
@@ -24,7 +24,7 @@ class GradedResponseV2(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @GradedResponseV2.Validators.root
+            @GradedResponseV2.Validators.root()
             def validate(values: GradedResponseV2.Partial) -> GradedResponseV2.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_graded_test_case_update.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_graded_test_case_update.py
@@ -23,7 +23,7 @@ class GradedTestCaseUpdate(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @GradedTestCaseUpdate.Validators.root
+            @GradedTestCaseUpdate.Validators.root()
             def validate(values: GradedTestCaseUpdate.Partial) -> GradedTestCaseUpdate.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_initialize_problem_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_initialize_problem_request.py
@@ -22,7 +22,7 @@ class InitializeProblemRequest(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @InitializeProblemRequest.Validators.root
+            @InitializeProblemRequest.Validators.root()
             def validate(values: InitializeProblemRequest.Partial) -> InitializeProblemRequest.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_internal_error.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_internal_error.py
@@ -20,7 +20,7 @@ class InternalError(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @InternalError.Validators.root
+            @InternalError.Validators.root()
             def validate(values: InternalError.Partial) -> InternalError.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_invalid_request_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_invalid_request_response.py
@@ -23,7 +23,7 @@ class InvalidRequestResponse(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @InvalidRequestResponse.Validators.root
+            @InvalidRequestResponse.Validators.root()
             def validate(values: InvalidRequestResponse.Partial) -> InvalidRequestResponse.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_lightweight_stackframe_information.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_lightweight_stackframe_information.py
@@ -20,7 +20,7 @@ class LightweightStackframeInformation(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @LightweightStackframeInformation.Validators.root
+            @LightweightStackframeInformation.Validators.root()
             def validate(values: LightweightStackframeInformation.Partial) -> LightweightStackframeInformation.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_recorded_response_notification.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_recorded_response_notification.py
@@ -24,7 +24,7 @@ class RecordedResponseNotification(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @RecordedResponseNotification.Validators.root
+            @RecordedResponseNotification.Validators.root()
             def validate(values: RecordedResponseNotification.Partial) -> RecordedResponseNotification.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_recorded_test_case_update.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_recorded_test_case_update.py
@@ -22,7 +22,7 @@ class RecordedTestCaseUpdate(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @RecordedTestCaseUpdate.Validators.root
+            @RecordedTestCaseUpdate.Validators.root()
             def validate(values: RecordedTestCaseUpdate.Partial) -> RecordedTestCaseUpdate.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_recording_response_notification.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_recording_response_notification.py
@@ -30,7 +30,7 @@ class RecordingResponseNotification(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @RecordingResponseNotification.Validators.root
+            @RecordingResponseNotification.Validators.root()
             def validate(values: RecordingResponseNotification.Partial) -> RecordingResponseNotification.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_running_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_running_response.py
@@ -23,7 +23,7 @@ class RunningResponse(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @RunningResponse.Validators.root
+            @RunningResponse.Validators.root()
             def validate(values: RunningResponse.Partial) -> RunningResponse.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_runtime_error.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_runtime_error.py
@@ -18,7 +18,7 @@ class RuntimeError(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @RuntimeError.Validators.root
+            @RuntimeError.Validators.root()
             def validate(values: RuntimeError.Partial) -> RuntimeError.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_scope.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_scope.py
@@ -20,7 +20,7 @@ class Scope(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @Scope.Validators.root
+            @Scope.Validators.root()
             def validate(values: Scope.Partial) -> Scope.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_stack_frame.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_stack_frame.py
@@ -24,7 +24,7 @@ class StackFrame(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @StackFrame.Validators.root
+            @StackFrame.Validators.root()
             def validate(values: StackFrame.Partial) -> StackFrame.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_stack_information.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_stack_information.py
@@ -22,7 +22,7 @@ class StackInformation(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @StackInformation.Validators.root
+            @StackInformation.Validators.root()
             def validate(values: StackInformation.Partial) -> StackInformation.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_stderr_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_stderr_response.py
@@ -22,7 +22,7 @@ class StderrResponse(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @StderrResponse.Validators.root
+            @StderrResponse.Validators.root()
             def validate(values: StderrResponse.Partial) -> StderrResponse.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_stdout_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_stdout_response.py
@@ -22,7 +22,7 @@ class StdoutResponse(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @StdoutResponse.Validators.root
+            @StdoutResponse.Validators.root()
             def validate(values: StdoutResponse.Partial) -> StdoutResponse.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_stop_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_stop_request.py
@@ -20,7 +20,7 @@ class StopRequest(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @StopRequest.Validators.root
+            @StopRequest.Validators.root()
             def validate(values: StopRequest.Partial) -> StopRequest.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_stopped_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_stopped_response.py
@@ -20,7 +20,7 @@ class StoppedResponse(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @StoppedResponse.Validators.root
+            @StoppedResponse.Validators.root()
             def validate(values: StoppedResponse.Partial) -> StoppedResponse.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_submission_file_info.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_submission_file_info.py
@@ -22,7 +22,7 @@ class SubmissionFileInfo(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @SubmissionFileInfo.Validators.root
+            @SubmissionFileInfo.Validators.root()
             def validate(values: SubmissionFileInfo.Partial) -> SubmissionFileInfo.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_submission_id_not_found.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_submission_id_not_found.py
@@ -20,7 +20,7 @@ class SubmissionIdNotFound(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @SubmissionIdNotFound.Validators.root
+            @SubmissionIdNotFound.Validators.root()
             def validate(values: SubmissionIdNotFound.Partial) -> SubmissionIdNotFound.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_submit_request_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_submit_request_v_2.py
@@ -33,7 +33,7 @@ class SubmitRequestV2(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @SubmitRequestV2.Validators.root
+            @SubmitRequestV2.Validators.root()
             def validate(values: SubmitRequestV2.Partial) -> SubmitRequestV2.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_terminated_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_terminated_response.py
@@ -16,7 +16,7 @@ class TerminatedResponse(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TerminatedResponse.Validators.root
+            @TerminatedResponse.Validators.root()
             def validate(values: TerminatedResponse.Partial) -> TerminatedResponse.Partial:
                 ...
         """

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_test_case_hidden_grade.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_test_case_hidden_grade.py
@@ -18,7 +18,7 @@ class TestCaseHiddenGrade(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TestCaseHiddenGrade.Validators.root
+            @TestCaseHiddenGrade.Validators.root()
             def validate(values: TestCaseHiddenGrade.Partial) -> TestCaseHiddenGrade.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_test_case_non_hidden_grade.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_test_case_non_hidden_grade.py
@@ -27,7 +27,7 @@ class TestCaseNonHiddenGrade(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TestCaseNonHiddenGrade.Validators.root
+            @TestCaseNonHiddenGrade.Validators.root()
             def validate(values: TestCaseNonHiddenGrade.Partial) -> TestCaseNonHiddenGrade.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_test_case_result.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_test_case_result.py
@@ -25,7 +25,7 @@ class TestCaseResult(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TestCaseResult.Validators.root
+            @TestCaseResult.Validators.root()
             def validate(values: TestCaseResult.Partial) -> TestCaseResult.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_test_case_result_with_stdout.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_test_case_result_with_stdout.py
@@ -22,7 +22,7 @@ class TestCaseResultWithStdout(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TestCaseResultWithStdout.Validators.root
+            @TestCaseResultWithStdout.Validators.root()
             def validate(values: TestCaseResultWithStdout.Partial) -> TestCaseResultWithStdout.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_test_submission_state.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_test_submission_state.py
@@ -28,7 +28,7 @@ class TestSubmissionState(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TestSubmissionState.Validators.root
+            @TestSubmissionState.Validators.root()
             def validate(values: TestSubmissionState.Partial) -> TestSubmissionState.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_test_submission_status_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_test_submission_status_v_2.py
@@ -28,7 +28,7 @@ class TestSubmissionStatusV2(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TestSubmissionStatusV2.Validators.root
+            @TestSubmissionStatusV2.Validators.root()
             def validate(values: TestSubmissionStatusV2.Partial) -> TestSubmissionStatusV2.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_test_submission_update.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_test_submission_update.py
@@ -23,7 +23,7 @@ class TestSubmissionUpdate(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TestSubmissionUpdate.Validators.root
+            @TestSubmissionUpdate.Validators.root()
             def validate(values: TestSubmissionUpdate.Partial) -> TestSubmissionUpdate.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_trace_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_trace_response.py
@@ -33,7 +33,7 @@ class TraceResponse(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TraceResponse.Validators.root
+            @TraceResponse.Validators.root()
             def validate(values: TraceResponse.Partial) -> TraceResponse.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_trace_response_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_trace_response_v_2.py
@@ -36,7 +36,7 @@ class TraceResponseV2(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TraceResponseV2.Validators.root
+            @TraceResponseV2.Validators.root()
             def validate(values: TraceResponseV2.Partial) -> TraceResponseV2.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_trace_responses_page.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_trace_responses_page.py
@@ -27,7 +27,7 @@ class TraceResponsesPage(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TraceResponsesPage.Validators.root
+            @TraceResponsesPage.Validators.root()
             def validate(values: TraceResponsesPage.Partial) -> TraceResponsesPage.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_trace_responses_page_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_trace_responses_page_v_2.py
@@ -27,7 +27,7 @@ class TraceResponsesPageV2(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TraceResponsesPageV2.Validators.root
+            @TraceResponsesPageV2.Validators.root()
             def validate(values: TraceResponsesPageV2.Partial) -> TraceResponsesPageV2.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_traced_file.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_traced_file.py
@@ -20,7 +20,7 @@ class TracedFile(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TracedFile.Validators.root
+            @TracedFile.Validators.root()
             def validate(values: TracedFile.Partial) -> TracedFile.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_traced_test_case.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_traced_test_case.py
@@ -22,7 +22,7 @@ class TracedTestCase(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TracedTestCase.Validators.root
+            @TracedTestCase.Validators.root()
             def validate(values: TracedTestCase.Partial) -> TracedTestCase.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_unexpected_language_error.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_unexpected_language_error.py
@@ -22,7 +22,7 @@ class UnexpectedLanguageError(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @UnexpectedLanguageError.Validators.root
+            @UnexpectedLanguageError.Validators.root()
             def validate(values: UnexpectedLanguageError.Partial) -> UnexpectedLanguageError.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_workspace_files.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_workspace_files.py
@@ -22,7 +22,7 @@ class WorkspaceFiles(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @WorkspaceFiles.Validators.root
+            @WorkspaceFiles.Validators.root()
             def validate(values: WorkspaceFiles.Partial) -> WorkspaceFiles.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_workspace_ran_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_workspace_ran_response.py
@@ -23,7 +23,7 @@ class WorkspaceRanResponse(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @WorkspaceRanResponse.Validators.root
+            @WorkspaceRanResponse.Validators.root()
             def validate(values: WorkspaceRanResponse.Partial) -> WorkspaceRanResponse.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_workspace_run_details.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_workspace_run_details.py
@@ -25,7 +25,7 @@ class WorkspaceRunDetails(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @WorkspaceRunDetails.Validators.root
+            @WorkspaceRunDetails.Validators.root()
             def validate(values: WorkspaceRunDetails.Partial) -> WorkspaceRunDetails.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_workspace_starter_files_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_workspace_starter_files_response.py
@@ -21,7 +21,7 @@ class WorkspaceStarterFilesResponse(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @WorkspaceStarterFilesResponse.Validators.root
+            @WorkspaceStarterFilesResponse.Validators.root()
             def validate(values: WorkspaceStarterFilesResponse.Partial) -> WorkspaceStarterFilesResponse.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_workspace_starter_files_response_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_workspace_starter_files_response_v_2.py
@@ -21,7 +21,7 @@ class WorkspaceStarterFilesResponseV2(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @WorkspaceStarterFilesResponseV2.Validators.root
+            @WorkspaceStarterFilesResponseV2.Validators.root()
             def validate(values: WorkspaceStarterFilesResponseV2.Partial) -> WorkspaceStarterFilesResponseV2.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_workspace_submission_state.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_workspace_submission_state.py
@@ -20,7 +20,7 @@ class WorkspaceSubmissionState(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @WorkspaceSubmissionState.Validators.root
+            @WorkspaceSubmissionState.Validators.root()
             def validate(values: WorkspaceSubmissionState.Partial) -> WorkspaceSubmissionState.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_workspace_submission_status_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_workspace_submission_status_v_2.py
@@ -20,7 +20,7 @@ class WorkspaceSubmissionStatusV2(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @WorkspaceSubmissionStatusV2.Validators.root
+            @WorkspaceSubmissionStatusV2.Validators.root()
             def validate(values: WorkspaceSubmissionStatusV2.Partial) -> WorkspaceSubmissionStatusV2.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_workspace_submission_update.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_workspace_submission_update.py
@@ -23,7 +23,7 @@ class WorkspaceSubmissionUpdate(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @WorkspaceSubmissionUpdate.Validators.root
+            @WorkspaceSubmissionUpdate.Validators.root()
             def validate(values: WorkspaceSubmissionUpdate.Partial) -> WorkspaceSubmissionUpdate.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_workspace_submit_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_workspace_submit_request.py
@@ -28,7 +28,7 @@ class WorkspaceSubmitRequest(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @WorkspaceSubmitRequest.Validators.root
+            @WorkspaceSubmitRequest.Validators.root()
             def validate(values: WorkspaceSubmitRequest.Partial) -> WorkspaceSubmitRequest.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_workspace_traced_update.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model submission_workspace_traced_update.py
@@ -18,7 +18,7 @@ class WorkspaceTracedUpdate(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @WorkspaceTracedUpdate.Validators.root
+            @WorkspaceTracedUpdate.Validators.root()
             def validate(values: WorkspaceTracedUpdate.Partial) -> WorkspaceTracedUpdate.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_basic_custom_files.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_basic_custom_files.py
@@ -29,7 +29,7 @@ class BasicCustomFiles(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @BasicCustomFiles.Validators.root
+            @BasicCustomFiles.Validators.root()
             def validate(values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_basic_test_case_template.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_basic_test_case_template.py
@@ -28,7 +28,7 @@ class BasicTestCaseTemplate(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @BasicTestCaseTemplate.Validators.root
+            @BasicTestCaseTemplate.Validators.root()
             def validate(values: BasicTestCaseTemplate.Partial) -> BasicTestCaseTemplate.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_create_problem_request_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_create_problem_request_v_2.py
@@ -36,7 +36,7 @@ class CreateProblemRequestV2(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @CreateProblemRequestV2.Validators.root
+            @CreateProblemRequestV2.Validators.root()
             def validate(values: CreateProblemRequestV2.Partial) -> CreateProblemRequestV2.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_deep_equality_correctness_check.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_deep_equality_correctness_check.py
@@ -20,7 +20,7 @@ class DeepEqualityCorrectnessCheck(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @DeepEqualityCorrectnessCheck.Validators.root
+            @DeepEqualityCorrectnessCheck.Validators.root()
             def validate(values: DeepEqualityCorrectnessCheck.Partial) -> DeepEqualityCorrectnessCheck.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_default_provided_file.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_default_provided_file.py
@@ -23,7 +23,7 @@ class DefaultProvidedFile(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @DefaultProvidedFile.Validators.root
+            @DefaultProvidedFile.Validators.root()
             def validate(values: DefaultProvidedFile.Partial) -> DefaultProvidedFile.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_file_info_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_file_info_v_2.py
@@ -24,7 +24,7 @@ class FileInfoV2(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @FileInfoV2.Validators.root
+            @FileInfoV2.Validators.root()
             def validate(values: FileInfoV2.Partial) -> FileInfoV2.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_files.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_files.py
@@ -20,7 +20,7 @@ class Files(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @Files.Validators.root
+            @Files.Validators.root()
             def validate(values: Files.Partial) -> Files.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_function_implementation.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_function_implementation.py
@@ -20,7 +20,7 @@ class FunctionImplementation(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @FunctionImplementation.Validators.root
+            @FunctionImplementation.Validators.root()
             def validate(values: FunctionImplementation.Partial) -> FunctionImplementation.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_function_implementation_for_multiple_languages.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_function_implementation_for_multiple_languages.py
@@ -21,7 +21,7 @@ class FunctionImplementationForMultipleLanguages(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @FunctionImplementationForMultipleLanguages.Validators.root
+            @FunctionImplementationForMultipleLanguages.Validators.root()
             def validate(values: FunctionImplementationForMultipleLanguages.Partial) -> FunctionImplementationForMultipleLanguages.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_generated_files.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_generated_files.py
@@ -25,7 +25,7 @@ class GeneratedFiles(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @GeneratedFiles.Validators.root
+            @GeneratedFiles.Validators.root()
             def validate(values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_get_basic_solution_file_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_get_basic_solution_file_request.py
@@ -22,7 +22,7 @@ class GetBasicSolutionFileRequest(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @GetBasicSolutionFileRequest.Validators.root
+            @GetBasicSolutionFileRequest.Validators.root()
             def validate(values: GetBasicSolutionFileRequest.Partial) -> GetBasicSolutionFileRequest.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_get_basic_solution_file_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_get_basic_solution_file_response.py
@@ -21,7 +21,7 @@ class GetBasicSolutionFileResponse(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @GetBasicSolutionFileResponse.Validators.root
+            @GetBasicSolutionFileResponse.Validators.root()
             def validate(values: GetBasicSolutionFileResponse.Partial) -> GetBasicSolutionFileResponse.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_get_function_signature_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_get_function_signature_request.py
@@ -20,7 +20,7 @@ class GetFunctionSignatureRequest(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @GetFunctionSignatureRequest.Validators.root
+            @GetFunctionSignatureRequest.Validators.root()
             def validate(values: GetFunctionSignatureRequest.Partial) -> GetFunctionSignatureRequest.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_get_function_signature_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_get_function_signature_response.py
@@ -20,7 +20,7 @@ class GetFunctionSignatureResponse(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @GetFunctionSignatureResponse.Validators.root
+            @GetFunctionSignatureResponse.Validators.root()
             def validate(values: GetFunctionSignatureResponse.Partial) -> GetFunctionSignatureResponse.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_get_generated_test_case_file_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_get_generated_test_case_file_request.py
@@ -23,7 +23,7 @@ class GetGeneratedTestCaseFileRequest(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @GetGeneratedTestCaseFileRequest.Validators.root
+            @GetGeneratedTestCaseFileRequest.Validators.root()
             def validate(values: GetGeneratedTestCaseFileRequest.Partial) -> GetGeneratedTestCaseFileRequest.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_get_generated_test_case_template_file_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_get_generated_test_case_template_file_request.py
@@ -20,7 +20,7 @@ class GetGeneratedTestCaseTemplateFileRequest(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @GetGeneratedTestCaseTemplateFileRequest.Validators.root
+            @GetGeneratedTestCaseTemplateFileRequest.Validators.root()
             def validate(values: GetGeneratedTestCaseTemplateFileRequest.Partial) -> GetGeneratedTestCaseTemplateFileRequest.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_lightweight_problem_info_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_lightweight_problem_info_v_2.py
@@ -27,7 +27,7 @@ class LightweightProblemInfoV2(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @LightweightProblemInfoV2.Validators.root
+            @LightweightProblemInfoV2.Validators.root()
             def validate(values: LightweightProblemInfoV2.Partial) -> LightweightProblemInfoV2.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_non_void_function_definition.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_non_void_function_definition.py
@@ -23,7 +23,7 @@ class NonVoidFunctionDefinition(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @NonVoidFunctionDefinition.Validators.root
+            @NonVoidFunctionDefinition.Validators.root()
             def validate(values: NonVoidFunctionDefinition.Partial) -> NonVoidFunctionDefinition.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_non_void_function_signature.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_non_void_function_signature.py
@@ -23,7 +23,7 @@ class NonVoidFunctionSignature(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @NonVoidFunctionSignature.Validators.root
+            @NonVoidFunctionSignature.Validators.root()
             def validate(values: NonVoidFunctionSignature.Partial) -> NonVoidFunctionSignature.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_parameter.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_parameter.py
@@ -25,7 +25,7 @@ class Parameter(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @Parameter.Validators.root
+            @Parameter.Validators.root()
             def validate(values: Parameter.Partial) -> Parameter.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_problem_info_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_problem_info_v_2.py
@@ -44,7 +44,7 @@ class ProblemInfoV2(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @ProblemInfoV2.Validators.root
+            @ProblemInfoV2.Validators.root()
             def validate(values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_test_case_expects.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_test_case_expects.py
@@ -18,7 +18,7 @@ class TestCaseExpects(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TestCaseExpects.Validators.root
+            @TestCaseExpects.Validators.root()
             def validate(values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_test_case_implementation.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_test_case_implementation.py
@@ -23,7 +23,7 @@ class TestCaseImplementation(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TestCaseImplementation.Validators.root
+            @TestCaseImplementation.Validators.root()
             def validate(values: TestCaseImplementation.Partial) -> TestCaseImplementation.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_test_case_implementation_description.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_test_case_implementation_description.py
@@ -20,7 +20,7 @@ class TestCaseImplementationDescription(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TestCaseImplementationDescription.Validators.root
+            @TestCaseImplementationDescription.Validators.root()
             def validate(values: TestCaseImplementationDescription.Partial) -> TestCaseImplementationDescription.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_test_case_metadata.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_test_case_metadata.py
@@ -24,7 +24,7 @@ class TestCaseMetadata(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TestCaseMetadata.Validators.root
+            @TestCaseMetadata.Validators.root()
             def validate(values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_test_case_template.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_test_case_template.py
@@ -25,7 +25,7 @@ class TestCaseTemplate(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TestCaseTemplate.Validators.root
+            @TestCaseTemplate.Validators.root()
             def validate(values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_test_case_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_test_case_v_2.py
@@ -30,7 +30,7 @@ class TestCaseV2(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TestCaseV2.Validators.root
+            @TestCaseV2.Validators.root()
             def validate(values: TestCaseV2.Partial) -> TestCaseV2.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_test_case_with_actual_result_implementation.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_test_case_with_actual_result_implementation.py
@@ -23,7 +23,7 @@ class TestCaseWithActualResultImplementation(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TestCaseWithActualResultImplementation.Validators.root
+            @TestCaseWithActualResultImplementation.Validators.root()
             def validate(values: TestCaseWithActualResultImplementation.Partial) -> TestCaseWithActualResultImplementation.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_void_function_definition.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_void_function_definition.py
@@ -23,7 +23,7 @@ class VoidFunctionDefinition(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @VoidFunctionDefinition.Validators.root
+            @VoidFunctionDefinition.Validators.root()
             def validate(values: VoidFunctionDefinition.Partial) -> VoidFunctionDefinition.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_void_function_definition_that_takes_actual_result.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_void_function_definition_that_takes_actual_result.py
@@ -27,7 +27,7 @@ class VoidFunctionDefinitionThatTakesActualResult(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @VoidFunctionDefinitionThatTakesActualResult.Validators.root
+            @VoidFunctionDefinitionThatTakesActualResult.Validators.root()
             def validate(values: VoidFunctionDefinitionThatTakesActualResult.Partial) -> VoidFunctionDefinitionThatTakesActualResult.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_void_function_signature.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_void_function_signature.py
@@ -20,7 +20,7 @@ class VoidFunctionSignature(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @VoidFunctionSignature.Validators.root
+            @VoidFunctionSignature.Validators.root()
             def validate(values: VoidFunctionSignature.Partial) -> VoidFunctionSignature.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_void_function_signature_that_takes_actual_result.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_problem_void_function_signature_that_takes_actual_result.py
@@ -23,7 +23,7 @@ class VoidFunctionSignatureThatTakesActualResult(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @VoidFunctionSignatureThatTakesActualResult.Validators.root
+            @VoidFunctionSignatureThatTakesActualResult.Validators.root()
             def validate(values: VoidFunctionSignatureThatTakesActualResult.Partial) -> VoidFunctionSignatureThatTakesActualResult.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_basic_custom_files.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_basic_custom_files.py
@@ -29,7 +29,7 @@ class BasicCustomFiles(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @BasicCustomFiles.Validators.root
+            @BasicCustomFiles.Validators.root()
             def validate(values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_basic_test_case_template.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_basic_test_case_template.py
@@ -28,7 +28,7 @@ class BasicTestCaseTemplate(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @BasicTestCaseTemplate.Validators.root
+            @BasicTestCaseTemplate.Validators.root()
             def validate(values: BasicTestCaseTemplate.Partial) -> BasicTestCaseTemplate.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_create_problem_request_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_create_problem_request_v_2.py
@@ -36,7 +36,7 @@ class CreateProblemRequestV2(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @CreateProblemRequestV2.Validators.root
+            @CreateProblemRequestV2.Validators.root()
             def validate(values: CreateProblemRequestV2.Partial) -> CreateProblemRequestV2.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_deep_equality_correctness_check.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_deep_equality_correctness_check.py
@@ -20,7 +20,7 @@ class DeepEqualityCorrectnessCheck(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @DeepEqualityCorrectnessCheck.Validators.root
+            @DeepEqualityCorrectnessCheck.Validators.root()
             def validate(values: DeepEqualityCorrectnessCheck.Partial) -> DeepEqualityCorrectnessCheck.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_default_provided_file.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_default_provided_file.py
@@ -23,7 +23,7 @@ class DefaultProvidedFile(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @DefaultProvidedFile.Validators.root
+            @DefaultProvidedFile.Validators.root()
             def validate(values: DefaultProvidedFile.Partial) -> DefaultProvidedFile.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_file_info_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_file_info_v_2.py
@@ -24,7 +24,7 @@ class FileInfoV2(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @FileInfoV2.Validators.root
+            @FileInfoV2.Validators.root()
             def validate(values: FileInfoV2.Partial) -> FileInfoV2.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_files.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_files.py
@@ -20,7 +20,7 @@ class Files(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @Files.Validators.root
+            @Files.Validators.root()
             def validate(values: Files.Partial) -> Files.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_function_implementation.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_function_implementation.py
@@ -20,7 +20,7 @@ class FunctionImplementation(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @FunctionImplementation.Validators.root
+            @FunctionImplementation.Validators.root()
             def validate(values: FunctionImplementation.Partial) -> FunctionImplementation.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_function_implementation_for_multiple_languages.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_function_implementation_for_multiple_languages.py
@@ -21,7 +21,7 @@ class FunctionImplementationForMultipleLanguages(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @FunctionImplementationForMultipleLanguages.Validators.root
+            @FunctionImplementationForMultipleLanguages.Validators.root()
             def validate(values: FunctionImplementationForMultipleLanguages.Partial) -> FunctionImplementationForMultipleLanguages.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_generated_files.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_generated_files.py
@@ -25,7 +25,7 @@ class GeneratedFiles(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @GeneratedFiles.Validators.root
+            @GeneratedFiles.Validators.root()
             def validate(values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_get_basic_solution_file_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_get_basic_solution_file_request.py
@@ -22,7 +22,7 @@ class GetBasicSolutionFileRequest(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @GetBasicSolutionFileRequest.Validators.root
+            @GetBasicSolutionFileRequest.Validators.root()
             def validate(values: GetBasicSolutionFileRequest.Partial) -> GetBasicSolutionFileRequest.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_get_basic_solution_file_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_get_basic_solution_file_response.py
@@ -21,7 +21,7 @@ class GetBasicSolutionFileResponse(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @GetBasicSolutionFileResponse.Validators.root
+            @GetBasicSolutionFileResponse.Validators.root()
             def validate(values: GetBasicSolutionFileResponse.Partial) -> GetBasicSolutionFileResponse.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_get_function_signature_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_get_function_signature_request.py
@@ -20,7 +20,7 @@ class GetFunctionSignatureRequest(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @GetFunctionSignatureRequest.Validators.root
+            @GetFunctionSignatureRequest.Validators.root()
             def validate(values: GetFunctionSignatureRequest.Partial) -> GetFunctionSignatureRequest.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_get_function_signature_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_get_function_signature_response.py
@@ -20,7 +20,7 @@ class GetFunctionSignatureResponse(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @GetFunctionSignatureResponse.Validators.root
+            @GetFunctionSignatureResponse.Validators.root()
             def validate(values: GetFunctionSignatureResponse.Partial) -> GetFunctionSignatureResponse.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_get_generated_test_case_file_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_get_generated_test_case_file_request.py
@@ -23,7 +23,7 @@ class GetGeneratedTestCaseFileRequest(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @GetGeneratedTestCaseFileRequest.Validators.root
+            @GetGeneratedTestCaseFileRequest.Validators.root()
             def validate(values: GetGeneratedTestCaseFileRequest.Partial) -> GetGeneratedTestCaseFileRequest.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_get_generated_test_case_template_file_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_get_generated_test_case_template_file_request.py
@@ -20,7 +20,7 @@ class GetGeneratedTestCaseTemplateFileRequest(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @GetGeneratedTestCaseTemplateFileRequest.Validators.root
+            @GetGeneratedTestCaseTemplateFileRequest.Validators.root()
             def validate(values: GetGeneratedTestCaseTemplateFileRequest.Partial) -> GetGeneratedTestCaseTemplateFileRequest.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_lightweight_problem_info_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_lightweight_problem_info_v_2.py
@@ -27,7 +27,7 @@ class LightweightProblemInfoV2(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @LightweightProblemInfoV2.Validators.root
+            @LightweightProblemInfoV2.Validators.root()
             def validate(values: LightweightProblemInfoV2.Partial) -> LightweightProblemInfoV2.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_non_void_function_definition.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_non_void_function_definition.py
@@ -23,7 +23,7 @@ class NonVoidFunctionDefinition(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @NonVoidFunctionDefinition.Validators.root
+            @NonVoidFunctionDefinition.Validators.root()
             def validate(values: NonVoidFunctionDefinition.Partial) -> NonVoidFunctionDefinition.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_non_void_function_signature.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_non_void_function_signature.py
@@ -23,7 +23,7 @@ class NonVoidFunctionSignature(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @NonVoidFunctionSignature.Validators.root
+            @NonVoidFunctionSignature.Validators.root()
             def validate(values: NonVoidFunctionSignature.Partial) -> NonVoidFunctionSignature.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_parameter.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_parameter.py
@@ -25,7 +25,7 @@ class Parameter(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @Parameter.Validators.root
+            @Parameter.Validators.root()
             def validate(values: Parameter.Partial) -> Parameter.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_problem_info_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_problem_info_v_2.py
@@ -44,7 +44,7 @@ class ProblemInfoV2(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @ProblemInfoV2.Validators.root
+            @ProblemInfoV2.Validators.root()
             def validate(values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_test_case_expects.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_test_case_expects.py
@@ -18,7 +18,7 @@ class TestCaseExpects(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TestCaseExpects.Validators.root
+            @TestCaseExpects.Validators.root()
             def validate(values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_test_case_implementation.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_test_case_implementation.py
@@ -23,7 +23,7 @@ class TestCaseImplementation(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TestCaseImplementation.Validators.root
+            @TestCaseImplementation.Validators.root()
             def validate(values: TestCaseImplementation.Partial) -> TestCaseImplementation.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_test_case_implementation_description.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_test_case_implementation_description.py
@@ -20,7 +20,7 @@ class TestCaseImplementationDescription(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TestCaseImplementationDescription.Validators.root
+            @TestCaseImplementationDescription.Validators.root()
             def validate(values: TestCaseImplementationDescription.Partial) -> TestCaseImplementationDescription.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_test_case_metadata.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_test_case_metadata.py
@@ -24,7 +24,7 @@ class TestCaseMetadata(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TestCaseMetadata.Validators.root
+            @TestCaseMetadata.Validators.root()
             def validate(values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_test_case_template.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_test_case_template.py
@@ -25,7 +25,7 @@ class TestCaseTemplate(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TestCaseTemplate.Validators.root
+            @TestCaseTemplate.Validators.root()
             def validate(values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_test_case_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_test_case_v_2.py
@@ -30,7 +30,7 @@ class TestCaseV2(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TestCaseV2.Validators.root
+            @TestCaseV2.Validators.root()
             def validate(values: TestCaseV2.Partial) -> TestCaseV2.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_test_case_with_actual_result_implementation.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_test_case_with_actual_result_implementation.py
@@ -23,7 +23,7 @@ class TestCaseWithActualResultImplementation(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @TestCaseWithActualResultImplementation.Validators.root
+            @TestCaseWithActualResultImplementation.Validators.root()
             def validate(values: TestCaseWithActualResultImplementation.Partial) -> TestCaseWithActualResultImplementation.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_void_function_definition.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_void_function_definition.py
@@ -23,7 +23,7 @@ class VoidFunctionDefinition(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @VoidFunctionDefinition.Validators.root
+            @VoidFunctionDefinition.Validators.root()
             def validate(values: VoidFunctionDefinition.Partial) -> VoidFunctionDefinition.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_void_function_definition_that_takes_actual_result.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_void_function_definition_that_takes_actual_result.py
@@ -27,7 +27,7 @@ class VoidFunctionDefinitionThatTakesActualResult(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @VoidFunctionDefinitionThatTakesActualResult.Validators.root
+            @VoidFunctionDefinitionThatTakesActualResult.Validators.root()
             def validate(values: VoidFunctionDefinitionThatTakesActualResult.Partial) -> VoidFunctionDefinitionThatTakesActualResult.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_void_function_signature.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_void_function_signature.py
@@ -20,7 +20,7 @@ class VoidFunctionSignature(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @VoidFunctionSignature.Validators.root
+            @VoidFunctionSignature.Validators.root()
             def validate(values: VoidFunctionSignature.Partial) -> VoidFunctionSignature.Partial:
                 ...
 

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_void_function_signature_that_takes_actual_result.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model v_2_v_3_problem_void_function_signature_that_takes_actual_result.py
@@ -23,7 +23,7 @@ class VoidFunctionSignatureThatTakesActualResult(pydantic.BaseModel):
         """
         Use this class to add validators to the Pydantic model.
 
-            @VoidFunctionSignatureThatTakesActualResult.Validators.root
+            @VoidFunctionSignatureThatTakesActualResult.Validators.root()
             def validate(values: VoidFunctionSignatureThatTakesActualResult.Partial) -> VoidFunctionSignatureThatTakesActualResult.Partial:
                 ...
 


### PR DESCRIPTION
Attaching a root validator looks something like `@MyType.Validators.root()` instead of `@MyType.Validators.root`