### PR TITLE
Serialize UTC datetimes with Z

### DIFF
--- a/core_utilities/fastapi/datetime_utils.py
+++ b/core_utilities/fastapi/datetime_utils.py
@@ -11,7 +11,7 @@ def serialize_datetime(v: dt.datetime) -> str:
     """
 
     def _serialize_zoned_datetime(v: dt.datetime) -> str:
-        if v.tzinfo.tzname(None) == "UTC":
+        if v.tzinfo.tzname(None) == dt.timezone.utc.tzname(None):
             # UTC is a special case where we use "Z" at the end instead of "+00:00"
             return v.isoformat().replace("+00:00", "Z")
         else:

--- a/core_utilities/fastapi/datetime_utils.py
+++ b/core_utilities/fastapi/datetime_utils.py
@@ -2,8 +2,25 @@ import datetime as dt
 
 
 def serialize_datetime(v: dt.datetime) -> str:
+    """
+    Serialize a datetime including timezone info.
+
+    Uses the timezone info provided if present, otherwise uses the current runtime's timezone info.
+
+    UTC datetimes end in "Z" while all other timezones are represented as offset from UTC, e.g. +05:00.
+    """
+
+    def _serialize_zoned_datetime(v: dt.datetime) -> str:
+        if v.tzinfo.tzname(None) == "UTC":
+            # UTC is a special case where we use "Z" at the end instead of "+00:00"
+            return v.isoformat().replace("+00:00", "Z")
+        else:
+            # Delegate to the typical +/- offset format
+            return v.isoformat()
+
     if v.tzinfo is not None:
-        return v.isoformat()
+        return _serialize_zoned_datetime(v)
     else:
         local_tz = dt.datetime.now().astimezone().tzinfo
-        return v.replace(tzinfo=local_tz).isoformat()
+        localized_dt = v.replace(tzinfo=local_tz)
+        return _serialize_zoned_datetime(localized_dt)

--- a/core_utilities/fastapi/datetime_utils.py
+++ b/core_utilities/fastapi/datetime_utils.py
@@ -11,7 +11,7 @@ def serialize_datetime(v: dt.datetime) -> str:
     """
 
     def _serialize_zoned_datetime(v: dt.datetime) -> str:
-        if v.tzinfo.tzname(None) == dt.timezone.utc.tzname(None):
+        if v.tzinfo is not None and v.tzinfo.tzname(None) == dt.timezone.utc.tzname(None):
             # UTC is a special case where we use "Z" at the end instead of "+00:00"
             return v.isoformat().replace("+00:00", "Z")
         else:

--- a/core_utilities/pydantic/datetime_utils.py
+++ b/core_utilities/pydantic/datetime_utils.py
@@ -11,7 +11,7 @@ def serialize_datetime(v: dt.datetime) -> str:
     """
 
     def _serialize_zoned_datetime(v: dt.datetime) -> str:
-        if v.tzinfo.tzname(None) == "UTC":
+        if v.tzinfo.tzname(None) == dt.timezone.utc.tzname(None):
             # UTC is a special case where we use "Z" at the end instead of "+00:00"
             return v.isoformat().replace("+00:00", "Z")
         else:

--- a/core_utilities/pydantic/datetime_utils.py
+++ b/core_utilities/pydantic/datetime_utils.py
@@ -2,8 +2,25 @@ import datetime as dt
 
 
 def serialize_datetime(v: dt.datetime) -> str:
+    """
+    Serialize a datetime including timezone info.
+
+    Uses the timezone info provided if present, otherwise uses the current runtime's timezone info.
+
+    UTC datetimes end in "Z" while all other timezones are represented as offset from UTC, e.g. +05:00.
+    """
+
+    def _serialize_zoned_datetime(v: dt.datetime) -> str:
+        if v.tzinfo.tzname(None) == "UTC":
+            # UTC is a special case where we use "Z" at the end instead of "+00:00"
+            return v.isoformat().replace("+00:00", "Z")
+        else:
+            # Delegate to the typical +/- offset format
+            return v.isoformat()
+
     if v.tzinfo is not None:
-        return v.isoformat()
+        return _serialize_zoned_datetime(v)
     else:
         local_tz = dt.datetime.now().astimezone().tzinfo
-        return v.replace(tzinfo=local_tz).isoformat()
+        localized_dt = v.replace(tzinfo=local_tz)
+        return _serialize_zoned_datetime(localized_dt)

--- a/core_utilities/pydantic/datetime_utils.py
+++ b/core_utilities/pydantic/datetime_utils.py
@@ -11,7 +11,7 @@ def serialize_datetime(v: dt.datetime) -> str:
     """
 
     def _serialize_zoned_datetime(v: dt.datetime) -> str:
-        if v.tzinfo.tzname(None) == dt.timezone.utc.tzname(None):
+        if v.tzinfo is not None and v.tzinfo.tzname(None) == dt.timezone.utc.tzname(None):
             # UTC is a special case where we use "Z" at the end instead of "+00:00"
             return v.isoformat().replace("+00:00", "Z")
         else:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi core_datetime_utils.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi core_datetime_utils.py
@@ -4,8 +4,25 @@ import datetime as dt
 
 
 def serialize_datetime(v: dt.datetime) -> str:
+    """
+    Serialize a datetime including timezone info.
+
+    Uses the timezone info provided if present, otherwise uses the current runtime's timezone info.
+
+    UTC datetimes end in "Z" while all other timezones are represented as offset from UTC, e.g. +05:00.
+    """
+
+    def _serialize_zoned_datetime(v: dt.datetime) -> str:
+        if v.tzinfo.tzname(None) == dt.timezone.utc.tzname(None):
+            # UTC is a special case where we use "Z" at the end instead of "+00:00"
+            return v.isoformat().replace("+00:00", "Z")
+        else:
+            # Delegate to the typical +/- offset format
+            return v.isoformat()
+
     if v.tzinfo is not None:
-        return v.isoformat()
+        return _serialize_zoned_datetime(v)
     else:
         local_tz = dt.datetime.now().astimezone().tzinfo
-        return v.replace(tzinfo=local_tz).isoformat()
+        localized_dt = v.replace(tzinfo=local_tz)
+        return _serialize_zoned_datetime(localized_dt)

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi core_datetime_utils.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi core_datetime_utils.py
@@ -13,7 +13,7 @@ def serialize_datetime(v: dt.datetime) -> str:
     """
 
     def _serialize_zoned_datetime(v: dt.datetime) -> str:
-        if v.tzinfo.tzname(None) == dt.timezone.utc.tzname(None):
+        if v.tzinfo is not None and v.tzinfo.tzname(None) == dt.timezone.utc.tzname(None):
             # UTC is a special case where we use "Z" at the end instead of "+00:00"
             return v.isoformat().replace("+00:00", "Z")
         else:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model core_datetime_utils.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model core_datetime_utils.py
@@ -4,8 +4,25 @@ import datetime as dt
 
 
 def serialize_datetime(v: dt.datetime) -> str:
+    """
+    Serialize a datetime including timezone info.
+
+    Uses the timezone info provided if present, otherwise uses the current runtime's timezone info.
+
+    UTC datetimes end in "Z" while all other timezones are represented as offset from UTC, e.g. +05:00.
+    """
+
+    def _serialize_zoned_datetime(v: dt.datetime) -> str:
+        if v.tzinfo.tzname(None) == dt.timezone.utc.tzname(None):
+            # UTC is a special case where we use "Z" at the end instead of "+00:00"
+            return v.isoformat().replace("+00:00", "Z")
+        else:
+            # Delegate to the typical +/- offset format
+            return v.isoformat()
+
     if v.tzinfo is not None:
-        return v.isoformat()
+        return _serialize_zoned_datetime(v)
     else:
         local_tz = dt.datetime.now().astimezone().tzinfo
-        return v.replace(tzinfo=local_tz).isoformat()
+        localized_dt = v.replace(tzinfo=local_tz)
+        return _serialize_zoned_datetime(localized_dt)

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model core_datetime_utils.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model core_datetime_utils.py
@@ -13,7 +13,7 @@ def serialize_datetime(v: dt.datetime) -> str:
     """
 
     def _serialize_zoned_datetime(v: dt.datetime) -> str:
-        if v.tzinfo.tzname(None) == dt.timezone.utc.tzname(None):
+        if v.tzinfo is not None and v.tzinfo.tzname(None) == dt.timezone.utc.tzname(None):
             # UTC is a special case where we use "Z" at the end instead of "+00:00"
             return v.isoformat().replace("+00:00", "Z")
         else:


### PR DESCRIPTION
Fixes https://github.com/fern-api/fern-python/issues/172

This slightly amends the behavior added in https://github.com/fern-api/fern-python/pull/171 to end UTC datetimes in Z, while keeping the same behavior for all other timezones (including GMT, or other +00:00 offset timezones). We did this for three reasons:

- This allows us to differentiate between UTC and GMT / other +00:00 offset timezones
- This makes wire payloads smaller
- We found the Z to be more idiomatic