### PR TITLE
fix: prefix python model published package with api name

### DIFF
--- a/src/fern_python/generators/pydantic_model/pydantic_filepath_creator.py
+++ b/src/fern_python/generators/pydantic_model/pydantic_filepath_creator.py
@@ -1,5 +1,14 @@
+from typing import Tuple
+
+from fern_python.codegen import ExportStrategy, Filepath
 from fern_python.declaration_referencer import FernFilepathCreator
 
 
 class PydanticFilepathCreator(FernFilepathCreator):
-    pass
+    def _get_filepath_prefix_for_published_package(self) -> Tuple[Filepath.DirectoryFilepathPart, ...]:
+        return (
+            Filepath.DirectoryFilepathPart(
+                module_name=self._ir.api_name.snake_case.unsafe_name,
+                export_strategy=ExportStrategy(export_all=True),
+            ),
+        )


### PR DESCRIPTION
The `resources` and `core` directory should live under `<org>.<api>` for a model package