### PR TITLE
Fix visitor calls for samePropertiesAsObject variants

### DIFF
--- a/src/fern_python/generators/pydantic_model/type_declaration_handler/discriminated_union_with_utils_generator.py
+++ b/src/fern_python/generators/pydantic_model/type_declaration_handler/discriminated_union_with_utils_generator.py
@@ -182,7 +182,19 @@ class DiscriminatedUnionWithUtilsGenerator(AbstractTypeGenerator):
                             expected_value=f'"{single_union_type.discriminant_value.wire_value}"',
                             visitor_argument=single_union_type.shape.visit(
                                 same_properties_as_object=lambda type_name: VisitorArgument(
-                                    expression=AST.Expression("self.__root__"),
+                                    expression=AST.Expression(
+                                        AST.FunctionInvocation(
+                                            function_definition=self._context.get_class_reference_for_type_name(
+                                                type_name
+                                            ),
+                                            args=[
+                                                AST.Expression(
+                                                    "self.__root__.dict(exclude_unset=True)",
+                                                    spread=AST.ExpressionSpread.TWO_ASTERISKS,
+                                                )
+                                            ],
+                                        )
+                                    ),
                                     type=external_pydantic_model.get_type_hint_for_type_reference(
                                         ir_types.TypeReference.factory.named(type_name)
                                     ),
@@ -235,12 +247,7 @@ class DiscriminatedUnionWithUtilsGenerator(AbstractTypeGenerator):
                 args=single_union_type.shape.visit(
                     same_properties_as_object=lambda type_name: [
                         AST.Expression(
-                            AST.FunctionInvocation(
-                                function_definition=AST.Reference(
-                                    qualified_name_excluding_import=(f"{BUILDER_ARGUMENT_NAME}.dict",)
-                                ),
-                                args=[AST.Expression("exclude_unset=True")],
-                            ),
+                            f"{BUILDER_ARGUMENT_NAME}.dict(exclude_unset=True)",
                             spread=AST.ExpressionSpread.TWO_ASTERISKS,
                         )
                     ],

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_debug_variable_value.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_debug_variable_value.py
@@ -123,21 +123,27 @@ class DebugVariableValue(pydantic.BaseModel):
         if self.__root__.type == "charValue":
             return char_value(self.__root__.value)
         if self.__root__.type == "mapValue":
-            return map_value(self.__root__)
+            return map_value(DebugMapValue(**self.__root__.dict(exclude_unset=True)))
         if self.__root__.type == "listValue":
             return list_value(self.__root__.value)
         if self.__root__.type == "binaryTreeNodeValue":
-            return binary_tree_node_value(self.__root__)
+            return binary_tree_node_value(BinaryTreeNodeAndTreeValue(**self.__root__.dict(exclude_unset=True)))
         if self.__root__.type == "singlyLinkedListNodeValue":
-            return singly_linked_list_node_value(self.__root__)
+            return singly_linked_list_node_value(
+                SinglyLinkedListNodeAndListValue(**self.__root__.dict(exclude_unset=True))
+            )
         if self.__root__.type == "doublyLinkedListNodeValue":
-            return doubly_linked_list_node_value(self.__root__)
+            return doubly_linked_list_node_value(
+                DoublyLinkedListNodeAndListValue(**self.__root__.dict(exclude_unset=True))
+            )
         if self.__root__.type == "undefinedValue":
             return undefined_value()
         if self.__root__.type == "nullValue":
             return null_value()
         if self.__root__.type == "genericValue":
-            return generic_value(self.__root__)
+            return generic_value(
+                resources_commons_types_generic_value_GenericValue(**self.__root__.dict(exclude_unset=True))
+            )
 
     __root__: typing_extensions.Annotated[
         typing.Union[

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_variable_type.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_variable_type.py
@@ -88,9 +88,9 @@ class VariableType(pydantic.BaseModel):
         if self.__root__.type == "charType":
             return char_type()
         if self.__root__.type == "listType":
-            return list_type(self.__root__)
+            return list_type(resources_commons_types_list_type_ListType(**self.__root__.dict(exclude_unset=True)))
         if self.__root__.type == "mapType":
-            return map_type(self.__root__)
+            return map_type(resources_commons_types_map_type_MapType(**self.__root__.dict(exclude_unset=True)))
         if self.__root__.type == "binaryTreeType":
             return binary_tree_type()
         if self.__root__.type == "singlyLinkedListType":

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_variable_value.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_variable_value.py
@@ -118,15 +118,25 @@ class VariableValue(pydantic.BaseModel):
         if self.__root__.type == "charValue":
             return char_value(self.__root__.value)
         if self.__root__.type == "mapValue":
-            return map_value(self.__root__)
+            return map_value(resources_commons_types_map_value_MapValue(**self.__root__.dict(exclude_unset=True)))
         if self.__root__.type == "listValue":
             return list_value(self.__root__.value)
         if self.__root__.type == "binaryTreeValue":
-            return binary_tree_value(self.__root__)
+            return binary_tree_value(
+                resources_commons_types_binary_tree_value_BinaryTreeValue(**self.__root__.dict(exclude_unset=True))
+            )
         if self.__root__.type == "singlyLinkedListValue":
-            return singly_linked_list_value(self.__root__)
+            return singly_linked_list_value(
+                resources_commons_types_singly_linked_list_value_SinglyLinkedListValue(
+                    **self.__root__.dict(exclude_unset=True)
+                )
+            )
         if self.__root__.type == "doublyLinkedListValue":
-            return doubly_linked_list_value(self.__root__)
+            return doubly_linked_list_value(
+                resources_commons_types_doubly_linked_list_value_DoublyLinkedListValue(
+                    **self.__root__.dict(exclude_unset=True)
+                )
+            )
         if self.__root__.type == "nullValue":
             return null_value()
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_create_problem_error.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_create_problem_error.py
@@ -29,7 +29,7 @@ class CreateProblemError(pydantic.BaseModel):
 
     def visit(self, generic: typing.Callable[[GenericCreateProblemError], T_Result]) -> T_Result:
         if self.__root__.error_type == "generic":
-            return generic(self.__root__)
+            return generic(GenericCreateProblemError(**self.__root__.dict(exclude_unset=True)))
 
     __root__: typing_extensions.Annotated[
         typing.Union[_CreateProblemError.Generic], pydantic.Field(discriminator="error_type")

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_actual_result.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_actual_result.py
@@ -42,7 +42,7 @@ class ActualResult(pydantic.BaseModel):
         if self.__root__.type == "value":
             return value(self.__root__.value)
         if self.__root__.type == "exception":
-            return exception(self.__root__)
+            return exception(ExceptionInfo(**self.__root__.dict(exclude_unset=True)))
         if self.__root__.type == "exceptionV2":
             return exception_v_2(self.__root__.value)
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_code_execution_update.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_code_execution_update.py
@@ -119,27 +119,27 @@ class CodeExecutionUpdate(pydantic.BaseModel):
         finished: typing.Callable[[FinishedResponse], T_Result],
     ) -> T_Result:
         if self.__root__.type == "buildingExecutor":
-            return building_executor(self.__root__)
+            return building_executor(BuildingExecutorResponse(**self.__root__.dict(exclude_unset=True)))
         if self.__root__.type == "running":
-            return running(self.__root__)
+            return running(RunningResponse(**self.__root__.dict(exclude_unset=True)))
         if self.__root__.type == "errored":
-            return errored(self.__root__)
+            return errored(ErroredResponse(**self.__root__.dict(exclude_unset=True)))
         if self.__root__.type == "stopped":
-            return stopped(self.__root__)
+            return stopped(StoppedResponse(**self.__root__.dict(exclude_unset=True)))
         if self.__root__.type == "graded":
-            return graded(self.__root__)
+            return graded(GradedResponse(**self.__root__.dict(exclude_unset=True)))
         if self.__root__.type == "gradedV2":
-            return graded_v_2(self.__root__)
+            return graded_v_2(GradedResponseV2(**self.__root__.dict(exclude_unset=True)))
         if self.__root__.type == "workspaceRan":
-            return workspace_ran(self.__root__)
+            return workspace_ran(WorkspaceRanResponse(**self.__root__.dict(exclude_unset=True)))
         if self.__root__.type == "recording":
-            return recording(self.__root__)
+            return recording(RecordingResponseNotification(**self.__root__.dict(exclude_unset=True)))
         if self.__root__.type == "recorded":
-            return recorded(self.__root__)
+            return recorded(RecordedResponseNotification(**self.__root__.dict(exclude_unset=True)))
         if self.__root__.type == "invalidRequest":
-            return invalid_request(self.__root__)
+            return invalid_request(InvalidRequestResponse(**self.__root__.dict(exclude_unset=True)))
         if self.__root__.type == "finished":
-            return finished(self.__root__)
+            return finished(FinishedResponse(**self.__root__.dict(exclude_unset=True)))
 
     __root__: typing_extensions.Annotated[
         typing.Union[

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_error_info.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_error_info.py
@@ -40,11 +40,17 @@ class ErrorInfo(pydantic.BaseModel):
         internal_error: typing.Callable[[resources_submission_types_internal_error_InternalError], T_Result],
     ) -> T_Result:
         if self.__root__.type == "compileError":
-            return compile_error(self.__root__)
+            return compile_error(
+                resources_submission_types_compile_error_CompileError(**self.__root__.dict(exclude_unset=True))
+            )
         if self.__root__.type == "runtimeError":
-            return runtime_error(self.__root__)
+            return runtime_error(
+                resources_submission_types_runtime_error_RuntimeError(**self.__root__.dict(exclude_unset=True))
+            )
         if self.__root__.type == "internalError":
-            return internal_error(self.__root__)
+            return internal_error(
+                resources_submission_types_internal_error_InternalError(**self.__root__.dict(exclude_unset=True))
+            )
 
     __root__: typing_extensions.Annotated[
         typing.Union[_ErrorInfo.CompileError, _ErrorInfo.RuntimeError, _ErrorInfo.InternalError],

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_exception_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_exception_v_2.py
@@ -32,7 +32,7 @@ class ExceptionV2(pydantic.BaseModel):
         self, generic: typing.Callable[[ExceptionInfo], T_Result], timeout: typing.Callable[[], T_Result]
     ) -> T_Result:
         if self.__root__.type == "generic":
-            return generic(self.__root__)
+            return generic(ExceptionInfo(**self.__root__.dict(exclude_unset=True)))
         if self.__root__.type == "timeout":
             return timeout()
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_invalid_request_cause.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_invalid_request_cause.py
@@ -70,11 +70,19 @@ class InvalidRequestCause(pydantic.BaseModel):
         unexpected_language: typing.Callable[[UnexpectedLanguageError], T_Result],
     ) -> T_Result:
         if self.__root__.type == "submissionIdNotFound":
-            return submission_id_not_found(self.__root__)
+            return submission_id_not_found(
+                resources_submission_types_submission_id_not_found_SubmissionIdNotFound(
+                    **self.__root__.dict(exclude_unset=True)
+                )
+            )
         if self.__root__.type == "customTestCasesUnsupported":
-            return custom_test_cases_unsupported(self.__root__)
+            return custom_test_cases_unsupported(
+                resources_submission_types_custom_test_cases_unsupported_CustomTestCasesUnsupported(
+                    **self.__root__.dict(exclude_unset=True)
+                )
+            )
         if self.__root__.type == "unexpectedLanguage":
-            return unexpected_language(self.__root__)
+            return unexpected_language(UnexpectedLanguageError(**self.__root__.dict(exclude_unset=True)))
 
     __root__: typing_extensions.Annotated[
         typing.Union[

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_submission_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_submission_request.py
@@ -73,15 +73,19 @@ class SubmissionRequest(pydantic.BaseModel):
         stop: typing.Callable[[StopRequest], T_Result],
     ) -> T_Result:
         if self.__root__.type == "initializeProblemRequest":
-            return initialize_problem_request(self.__root__)
+            return initialize_problem_request(
+                resources_submission_types_initialize_problem_request_InitializeProblemRequest(
+                    **self.__root__.dict(exclude_unset=True)
+                )
+            )
         if self.__root__.type == "initializeWorkspaceRequest":
             return initialize_workspace_request()
         if self.__root__.type == "submitV2":
-            return submit_v_2(self.__root__)
+            return submit_v_2(SubmitRequestV2(**self.__root__.dict(exclude_unset=True)))
         if self.__root__.type == "workspaceSubmit":
-            return workspace_submit(self.__root__)
+            return workspace_submit(WorkspaceSubmitRequest(**self.__root__.dict(exclude_unset=True)))
         if self.__root__.type == "stop":
-            return stop(self.__root__)
+            return stop(StopRequest(**self.__root__.dict(exclude_unset=True)))
 
     __root__: typing_extensions.Annotated[
         typing.Union[

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_submission_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_submission_response.py
@@ -82,11 +82,11 @@ class SubmissionResponse(pydantic.BaseModel):
         if self.__root__.type == "workspaceInitialized":
             return workspace_initialized()
         if self.__root__.type == "serverErrored":
-            return server_errored(self.__root__)
+            return server_errored(ExceptionInfo(**self.__root__.dict(exclude_unset=True)))
         if self.__root__.type == "codeExecutionUpdate":
             return code_execution_update(self.__root__.value)
         if self.__root__.type == "terminated":
-            return terminated(self.__root__)
+            return terminated(TerminatedResponse(**self.__root__.dict(exclude_unset=True)))
 
     __root__: typing_extensions.Annotated[
         typing.Union[

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_submission_status_for_test_case.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_submission_status_for_test_case.py
@@ -51,11 +51,11 @@ class SubmissionStatusForTestCase(pydantic.BaseModel):
         traced: typing.Callable[[TracedTestCase], T_Result],
     ) -> T_Result:
         if self.__root__.type == "graded":
-            return graded(self.__root__)
+            return graded(TestCaseResultWithStdout(**self.__root__.dict(exclude_unset=True)))
         if self.__root__.type == "gradedV2":
             return graded_v_2(self.__root__.value)
         if self.__root__.type == "traced":
-            return traced(self.__root__)
+            return traced(TracedTestCase(**self.__root__.dict(exclude_unset=True)))
 
     __root__: typing_extensions.Annotated[
         typing.Union[

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_submission_status_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_submission_status_v_2.py
@@ -43,9 +43,9 @@ class SubmissionStatusV2(pydantic.BaseModel):
         workspace: typing.Callable[[WorkspaceSubmissionStatusV2], T_Result],
     ) -> T_Result:
         if self.__root__.type == "test":
-            return test(self.__root__)
+            return test(TestSubmissionStatusV2(**self.__root__.dict(exclude_unset=True)))
         if self.__root__.type == "workspace":
-            return workspace(self.__root__)
+            return workspace(WorkspaceSubmissionStatusV2(**self.__root__.dict(exclude_unset=True)))
 
     __root__: typing_extensions.Annotated[
         typing.Union[_SubmissionStatusV2.Test, _SubmissionStatusV2.Workspace], pydantic.Field(discriminator="type")

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_submission_type_state.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_submission_type_state.py
@@ -40,9 +40,9 @@ class SubmissionTypeState(pydantic.BaseModel):
         workspace: typing.Callable[[WorkspaceSubmissionState], T_Result],
     ) -> T_Result:
         if self.__root__.type == "test":
-            return test(self.__root__)
+            return test(TestSubmissionState(**self.__root__.dict(exclude_unset=True)))
         if self.__root__.type == "workspace":
-            return workspace(self.__root__)
+            return workspace(WorkspaceSubmissionState(**self.__root__.dict(exclude_unset=True)))
 
     __root__: typing_extensions.Annotated[
         typing.Union[_SubmissionTypeState.Test, _SubmissionTypeState.Workspace], pydantic.Field(discriminator="type")

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_case_grade.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_case_grade.py
@@ -38,9 +38,9 @@ class TestCaseGrade(pydantic.BaseModel):
         non_hidden: typing.Callable[[TestCaseNonHiddenGrade], T_Result],
     ) -> T_Result:
         if self.__root__.type == "hidden":
-            return hidden(self.__root__)
+            return hidden(TestCaseHiddenGrade(**self.__root__.dict(exclude_unset=True)))
         if self.__root__.type == "nonHidden":
-            return non_hidden(self.__root__)
+            return non_hidden(TestCaseNonHiddenGrade(**self.__root__.dict(exclude_unset=True)))
 
     __root__: typing_extensions.Annotated[
         typing.Union[_TestCaseGrade.Hidden, _TestCaseGrade.NonHidden], pydantic.Field(discriminator="type")

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_submission_update_info.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_submission_update_info.py
@@ -77,9 +77,9 @@ class TestSubmissionUpdateInfo(pydantic.BaseModel):
         if self.__root__.type == "errored":
             return errored(self.__root__.value)
         if self.__root__.type == "gradedTestCase":
-            return graded_test_case(self.__root__)
+            return graded_test_case(GradedTestCaseUpdate(**self.__root__.dict(exclude_unset=True)))
         if self.__root__.type == "recordedTestCase":
-            return recorded_test_case(self.__root__)
+            return recorded_test_case(RecordedTestCaseUpdate(**self.__root__.dict(exclude_unset=True)))
         if self.__root__.type == "finished":
             return finished()
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_submission_status.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_submission_status.py
@@ -66,9 +66,9 @@ class WorkspaceSubmissionStatus(pydantic.BaseModel):
         if self.__root__.type == "running":
             return running(self.__root__.value)
         if self.__root__.type == "ran":
-            return ran(self.__root__)
+            return ran(WorkspaceRunDetails(**self.__root__.dict(exclude_unset=True)))
         if self.__root__.type == "traced":
-            return traced(self.__root__)
+            return traced(WorkspaceRunDetails(**self.__root__.dict(exclude_unset=True)))
 
     __root__: typing_extensions.Annotated[
         typing.Union[

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_submission_update_info.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_submission_update_info.py
@@ -77,13 +77,13 @@ class WorkspaceSubmissionUpdateInfo(pydantic.BaseModel):
         if self.__root__.type == "running":
             return running(self.__root__.value)
         if self.__root__.type == "ran":
-            return ran(self.__root__)
+            return ran(WorkspaceRunDetails(**self.__root__.dict(exclude_unset=True)))
         if self.__root__.type == "stopped":
             return stopped()
         if self.__root__.type == "traced":
             return traced()
         if self.__root__.type == "tracedV2":
-            return traced_v_2(self.__root__)
+            return traced_v_2(WorkspaceTracedUpdate(**self.__root__.dict(exclude_unset=True)))
         if self.__root__.type == "errored":
             return errored(self.__root__.value)
         if self.__root__.type == "finished":

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_assert_correctness_check.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_assert_correctness_check.py
@@ -42,9 +42,9 @@ class AssertCorrectnessCheck(pydantic.BaseModel):
         custom: typing.Callable[[VoidFunctionDefinitionThatTakesActualResult], T_Result],
     ) -> T_Result:
         if self.__root__.type == "deepEquality":
-            return deep_equality(self.__root__)
+            return deep_equality(DeepEqualityCorrectnessCheck(**self.__root__.dict(exclude_unset=True)))
         if self.__root__.type == "custom":
-            return custom(self.__root__)
+            return custom(VoidFunctionDefinitionThatTakesActualResult(**self.__root__.dict(exclude_unset=True)))
 
     __root__: typing_extensions.Annotated[
         typing.Union[_AssertCorrectnessCheck.DeepEquality, _AssertCorrectnessCheck.Custom],

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_custom_files.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_custom_files.py
@@ -39,7 +39,7 @@ class CustomFiles(pydantic.BaseModel):
         custom: typing.Callable[[typing.Dict[Language, Files]], T_Result],
     ) -> T_Result:
         if self.__root__.type == "basic":
-            return basic(self.__root__)
+            return basic(BasicCustomFiles(**self.__root__.dict(exclude_unset=True)))
         if self.__root__.type == "custom":
             return custom(self.__root__.value)
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_function_signature.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_function_signature.py
@@ -51,11 +51,13 @@ class FunctionSignature(pydantic.BaseModel):
         void_that_takes_actual_result: typing.Callable[[VoidFunctionSignatureThatTakesActualResult], T_Result],
     ) -> T_Result:
         if self.__root__.type == "void":
-            return void(self.__root__)
+            return void(VoidFunctionSignature(**self.__root__.dict(exclude_unset=True)))
         if self.__root__.type == "nonVoid":
-            return non_void(self.__root__)
+            return non_void(NonVoidFunctionSignature(**self.__root__.dict(exclude_unset=True)))
         if self.__root__.type == "voidThatTakesActualResult":
-            return void_that_takes_actual_result(self.__root__)
+            return void_that_takes_actual_result(
+                VoidFunctionSignatureThatTakesActualResult(**self.__root__.dict(exclude_unset=True))
+            )
 
     __root__: typing_extensions.Annotated[
         typing.Union[_FunctionSignature.Void, _FunctionSignature.NonVoid, _FunctionSignature.VoidThatTakesActualResult],

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_test_case_function.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_test_case_function.py
@@ -40,9 +40,9 @@ class TestCaseFunction(pydantic.BaseModel):
         custom: typing.Callable[[VoidFunctionDefinition], T_Result],
     ) -> T_Result:
         if self.__root__.type == "withActualResult":
-            return with_actual_result(self.__root__)
+            return with_actual_result(TestCaseWithActualResultImplementation(**self.__root__.dict(exclude_unset=True)))
         if self.__root__.type == "custom":
-            return custom(self.__root__)
+            return custom(VoidFunctionDefinition(**self.__root__.dict(exclude_unset=True)))
 
     __root__: typing_extensions.Annotated[
         typing.Union[_TestCaseFunction.WithActualResult, _TestCaseFunction.Custom], pydantic.Field(discriminator="type")

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_test_case_implementation_reference.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_test_case_implementation_reference.py
@@ -48,7 +48,7 @@ class TestCaseImplementationReference(pydantic.BaseModel):
         if self.__root__.type == "templateId":
             return template_id(self.__root__.value)
         if self.__root__.type == "implementation":
-            return implementation(self.__root__)
+            return implementation(TestCaseImplementation(**self.__root__.dict(exclude_unset=True)))
 
     __root__: typing_extensions.Annotated[
         typing.Union[_TestCaseImplementationReference.TemplateId, _TestCaseImplementationReference.Implementation],

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_assert_correctness_check.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_assert_correctness_check.py
@@ -42,9 +42,9 @@ class AssertCorrectnessCheck(pydantic.BaseModel):
         custom: typing.Callable[[VoidFunctionDefinitionThatTakesActualResult], T_Result],
     ) -> T_Result:
         if self.__root__.type == "deepEquality":
-            return deep_equality(self.__root__)
+            return deep_equality(DeepEqualityCorrectnessCheck(**self.__root__.dict(exclude_unset=True)))
         if self.__root__.type == "custom":
-            return custom(self.__root__)
+            return custom(VoidFunctionDefinitionThatTakesActualResult(**self.__root__.dict(exclude_unset=True)))
 
     __root__: typing_extensions.Annotated[
         typing.Union[_AssertCorrectnessCheck.DeepEquality, _AssertCorrectnessCheck.Custom],

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_custom_files.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_custom_files.py
@@ -39,7 +39,7 @@ class CustomFiles(pydantic.BaseModel):
         custom: typing.Callable[[typing.Dict[Language, Files]], T_Result],
     ) -> T_Result:
         if self.__root__.type == "basic":
-            return basic(self.__root__)
+            return basic(BasicCustomFiles(**self.__root__.dict(exclude_unset=True)))
         if self.__root__.type == "custom":
             return custom(self.__root__.value)
 

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_function_signature.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_function_signature.py
@@ -51,11 +51,13 @@ class FunctionSignature(pydantic.BaseModel):
         void_that_takes_actual_result: typing.Callable[[VoidFunctionSignatureThatTakesActualResult], T_Result],
     ) -> T_Result:
         if self.__root__.type == "void":
-            return void(self.__root__)
+            return void(VoidFunctionSignature(**self.__root__.dict(exclude_unset=True)))
         if self.__root__.type == "nonVoid":
-            return non_void(self.__root__)
+            return non_void(NonVoidFunctionSignature(**self.__root__.dict(exclude_unset=True)))
         if self.__root__.type == "voidThatTakesActualResult":
-            return void_that_takes_actual_result(self.__root__)
+            return void_that_takes_actual_result(
+                VoidFunctionSignatureThatTakesActualResult(**self.__root__.dict(exclude_unset=True))
+            )
 
     __root__: typing_extensions.Annotated[
         typing.Union[_FunctionSignature.Void, _FunctionSignature.NonVoid, _FunctionSignature.VoidThatTakesActualResult],

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_test_case_function.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_test_case_function.py
@@ -40,9 +40,9 @@ class TestCaseFunction(pydantic.BaseModel):
         custom: typing.Callable[[VoidFunctionDefinition], T_Result],
     ) -> T_Result:
         if self.__root__.type == "withActualResult":
-            return with_actual_result(self.__root__)
+            return with_actual_result(TestCaseWithActualResultImplementation(**self.__root__.dict(exclude_unset=True)))
         if self.__root__.type == "custom":
-            return custom(self.__root__)
+            return custom(VoidFunctionDefinition(**self.__root__.dict(exclude_unset=True)))
 
     __root__: typing_extensions.Annotated[
         typing.Union[_TestCaseFunction.WithActualResult, _TestCaseFunction.Custom], pydantic.Field(discriminator="type")

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_test_case_implementation_reference.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_test_case_implementation_reference.py
@@ -48,7 +48,7 @@ class TestCaseImplementationReference(pydantic.BaseModel):
         if self.__root__.type == "templateId":
             return template_id(self.__root__.value)
         if self.__root__.type == "implementation":
-            return implementation(self.__root__)
+            return implementation(TestCaseImplementation(**self.__root__.dict(exclude_unset=True)))
 
     __root__: typing_extensions.Annotated[
         typing.Union[_TestCaseImplementationReference.TemplateId, _TestCaseImplementationReference.Implementation],


### PR DESCRIPTION
Here's an example `visit` implementation generated by fern

```py
    def visit(
        self,
        same_properties_as_object: typing.Callable[[DeclaredTypeName], T_Result],
        single_property: typing.Callable[[SingleUnionTypeProperty], T_Result],
        no_properties: typing.Callable[[], T_Result],
    ) -> T_Result:
        if self.__root__.properties_type == "samePropertiesAsObject":
            return same_properties_as_object(self.__root__)
        if self.__root__.properties_type == "singleProperty":
            return single_property(self.__root__)
        if self.__root__.properties_type == "noProperties":
            return no_properties()
```

in the `same_properties_as_object` case, we just pass the entire `__root__` , which is a `SamePropertiesAsObject`. The function we're calling is a `typing.Callable[[DeclaredTypeName], T_Result]` (i.e. the arg is a `DeclaredTypeName`), but that's technically okay, because `SamePropertiesAsObject` extends `DeclaredTypeName`:

```py
class SamePropertiesAsObject(DeclaredTypeName):
  ...
```

However, including these ghost properties can cause weirdness down the line. Calling `dict()` on the value will include the discriminant in the dict (not just the properties on `DeclaredTypeName`).

With this PR, we explicitly only pass the `DeclaredTypeName` to the visit function:

```py
if self.__root__.properties_type == "samePropertiesAsObject":
  return same_properties_as_object(
    DeclaredTypeName(**self.__root__.dict(exclude_unset=True))
  )
```