### PR TITLE
fix: uniquely name root validators to make sure they run

### DIFF
--- a/src/fern_python/generators/pydantic_model/fern_aware_pydantic_model.py
+++ b/src/fern_python/generators/pydantic_model/fern_aware_pydantic_model.py
@@ -209,9 +209,14 @@ class FernAwarePydanticModel:
                 root_type=root_type,
             )
         else:
+            unique_name = []
+            if self._type_name is not None:
+                unique_name = [path.snake_case.unsafe_name for path in self._type_name.fern_filepath.package_path]
+                unique_name.append(self._type_name.name.snake_case.unsafe_name)
             return PydanticValidatorsGenerator(
                 model=self._pydantic_model,
                 extended_pydantic_fields=self._get_extended_pydantic_fields(self._extends or []),
+                unique_name=unique_name
             )
 
     def _get_extended_pydantic_fields(self, extends: Sequence[ir_types.DeclaredTypeName]) -> List[PydanticField]:

--- a/src/fern_python/generators/pydantic_model/fern_aware_pydantic_model.py
+++ b/src/fern_python/generators/pydantic_model/fern_aware_pydantic_model.py
@@ -216,7 +216,7 @@ class FernAwarePydanticModel:
             return PydanticValidatorsGenerator(
                 model=self._pydantic_model,
                 extended_pydantic_fields=self._get_extended_pydantic_fields(self._extends or []),
-                unique_name=unique_name
+                unique_name=unique_name,
             )
 
     def _get_extended_pydantic_fields(self, extends: Sequence[ir_types.DeclaredTypeName]) -> List[PydanticField]:

--- a/src/fern_python/generators/pydantic_model/validators/pydantic_validators_generator.py
+++ b/src/fern_python/generators/pydantic_model/validators/pydantic_validators_generator.py
@@ -15,7 +15,7 @@ from .validators_generator import ValidatorsGenerator
 class PydanticValidatorsGenerator(ValidatorsGenerator):
     _DECORATOR_FUNCTION_NAME = "field"
 
-    def __init__(self, model: PydanticModel, extended_pydantic_fields: List[PydanticField]):
+    def __init__(self, model: PydanticModel, extended_pydantic_fields: List[PydanticField], unique_name: List[str]):
         super().__init__(model=model)
         reference_to_validators_class = self._get_reference_to_validators_class()
 
@@ -39,6 +39,7 @@ class PydanticValidatorsGenerator(ValidatorsGenerator):
         self._root_validator_generator = RootValidatorGenerator(
             model=self._model,
             reference_to_validators_class=reference_to_validators_class,
+            unique_model_name=unique_name,
         )
 
     def _populate_validators_class(self, validators_class: AST.ClassDeclaration) -> None:

--- a/src/fern_python/generators/pydantic_model/validators/validator_generators/root_validator_generator.py
+++ b/src/fern_python/generators/pydantic_model/validators/validator_generators/root_validator_generator.py
@@ -25,7 +25,9 @@ class RootValidatorGenerator(ValidatorGenerator):
             prefix = "pre" if pre else "post"
             joined_model_name = "_".join(self._unique_model_name)
             self._model.add_root_validator(
-                validator_name=f"_{prefix}_validate_{joined_model_name}" if len(joined_model_name) > 0 else f"_{prefix}_validate",
+                validator_name=f"_{prefix}_validate_{joined_model_name}"
+                if len(joined_model_name) > 0
+                else f"_{prefix}_validate",
                 body=AST.CodeWriter(self._get_write_validator_body(pre)),
                 should_use_partial_type=True,
                 pre=pre,

--- a/src/fern_python/generators/pydantic_model/validators/validator_generators/root_validator_generator.py
+++ b/src/fern_python/generators/pydantic_model/validators/validator_generators/root_validator_generator.py
@@ -21,10 +21,8 @@ class RootValidatorGenerator(ValidatorGenerator):
         for pre in [True, False]:
             prefix = "pre" if pre else "post"
             joined_model_name = "_".join(self._unique_model_name)
-            if len(joined_model_name) != 0:
-                prefix += f"_{joined_model_name}"
             self._model.add_root_validator(
-                validator_name=f"_{prefix}_validate",
+                validator_name=f"_{prefix}_validate_{joined_model_name}",
                 body=AST.CodeWriter(self._get_write_validator_body(pre)),
                 should_use_partial_type=True,
                 pre=pre,

--- a/src/fern_python/generators/pydantic_model/validators/validator_generators/root_validator_generator.py
+++ b/src/fern_python/generators/pydantic_model/validators/validator_generators/root_validator_generator.py
@@ -3,6 +3,7 @@ from fern_python.codegen.ast.nodes.code_writer.code_writer import CodeWriterFunc
 from fern_python.pydantic_codegen import PydanticModel
 
 from .validator_generator import ValidatorGenerator
+from typing import List, Tuple
 
 
 class RootValidatorGenerator(ValidatorGenerator):
@@ -12,9 +13,14 @@ class RootValidatorGenerator(ValidatorGenerator):
     _CALLABLE_PARAMETER_PREFIX = "__"
     _VALIDATOR_PARAMETER_NAME = "validator"
 
+    def __init__(self, model: PydanticModel, reference_to_validators_class: Tuple[str, ...], unique_model_name: List[str]):
+        super().__init__(model, reference_to_validators_class)
+        self._unique_model_name = unique_model_name
+
     def add_validator_to_model(self) -> None:
         for pre in [True, False]:
             prefix = "pre" if pre else "post"
+            prefix += "_".join(self._unique_model_name)
             self._model.add_root_validator(
                 validator_name=f"_{prefix}_validate",
                 body=AST.CodeWriter(self._get_write_validator_body(pre)),

--- a/src/fern_python/generators/pydantic_model/validators/validator_generators/root_validator_generator.py
+++ b/src/fern_python/generators/pydantic_model/validators/validator_generators/root_validator_generator.py
@@ -1,9 +1,10 @@
+from typing import List, Tuple
+
 from fern_python.codegen import AST
 from fern_python.codegen.ast.nodes.code_writer.code_writer import CodeWriterFunction
 from fern_python.pydantic_codegen import PydanticModel
 
 from .validator_generator import ValidatorGenerator
-from typing import List, Tuple
 
 
 class RootValidatorGenerator(ValidatorGenerator):
@@ -13,7 +14,9 @@ class RootValidatorGenerator(ValidatorGenerator):
     _CALLABLE_PARAMETER_PREFIX = "__"
     _VALIDATOR_PARAMETER_NAME = "validator"
 
-    def __init__(self, model: PydanticModel, reference_to_validators_class: Tuple[str, ...], unique_model_name: List[str]):
+    def __init__(
+        self, model: PydanticModel, reference_to_validators_class: Tuple[str, ...], unique_model_name: List[str]
+    ):
         super().__init__(model, reference_to_validators_class)
         self._unique_model_name = unique_model_name
 

--- a/src/fern_python/generators/pydantic_model/validators/validator_generators/root_validator_generator.py
+++ b/src/fern_python/generators/pydantic_model/validators/validator_generators/root_validator_generator.py
@@ -25,7 +25,7 @@ class RootValidatorGenerator(ValidatorGenerator):
             prefix = "pre" if pre else "post"
             joined_model_name = "_".join(self._unique_model_name)
             self._model.add_root_validator(
-                validator_name=f"_{prefix}_validate_{joined_model_name}",
+                validator_name=f"_{prefix}_validate_{joined_model_name}" if len(joined_model_name) > 0 else f"_{prefix}_validate",
                 body=AST.CodeWriter(self._get_write_validator_body(pre)),
                 should_use_partial_type=True,
                 pre=pre,

--- a/src/fern_python/generators/pydantic_model/validators/validator_generators/root_validator_generator.py
+++ b/src/fern_python/generators/pydantic_model/validators/validator_generators/root_validator_generator.py
@@ -20,7 +20,9 @@ class RootValidatorGenerator(ValidatorGenerator):
     def add_validator_to_model(self) -> None:
         for pre in [True, False]:
             prefix = "pre" if pre else "post"
-            prefix += "_".join(self._unique_model_name)
+            joined_model_name = "_".join(self._unique_model_name)
+            if len(joined_model_name) != 0:
+                prefix += f"_{joined_model_name}"
             self._model.add_root_validator(
                 validator_name=f"_{prefix}_validate",
                 body=AST.CodeWriter(self._get_write_validator_body(pre)),

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_admin_service_store_traced_test_case_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_admin_service_store_traced_test_case_request.py
@@ -172,13 +172,13 @@ class StoreTracedTestCaseRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate_(cls, values: StoreTracedTestCaseRequest.Partial) -> StoreTracedTestCaseRequest.Partial:
+    def _pre_validate(cls, values: StoreTracedTestCaseRequest.Partial) -> StoreTracedTestCaseRequest.Partial:
         for validator in StoreTracedTestCaseRequest.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate_(cls, values: StoreTracedTestCaseRequest.Partial) -> StoreTracedTestCaseRequest.Partial:
+    def _post_validate(cls, values: StoreTracedTestCaseRequest.Partial) -> StoreTracedTestCaseRequest.Partial:
         for validator in StoreTracedTestCaseRequest.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_admin_service_store_traced_test_case_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_admin_service_store_traced_test_case_request.py
@@ -172,13 +172,13 @@ class StoreTracedTestCaseRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: StoreTracedTestCaseRequest.Partial) -> StoreTracedTestCaseRequest.Partial:
+    def _pre_validate_(cls, values: StoreTracedTestCaseRequest.Partial) -> StoreTracedTestCaseRequest.Partial:
         for validator in StoreTracedTestCaseRequest.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: StoreTracedTestCaseRequest.Partial) -> StoreTracedTestCaseRequest.Partial:
+    def _post_validate_(cls, values: StoreTracedTestCaseRequest.Partial) -> StoreTracedTestCaseRequest.Partial:
         for validator in StoreTracedTestCaseRequest.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_admin_service_store_traced_workspace_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_admin_service_store_traced_workspace_request.py
@@ -176,13 +176,13 @@ class StoreTracedWorkspaceRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: StoreTracedWorkspaceRequest.Partial) -> StoreTracedWorkspaceRequest.Partial:
+    def _pre_validate_(cls, values: StoreTracedWorkspaceRequest.Partial) -> StoreTracedWorkspaceRequest.Partial:
         for validator in StoreTracedWorkspaceRequest.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: StoreTracedWorkspaceRequest.Partial) -> StoreTracedWorkspaceRequest.Partial:
+    def _post_validate_(cls, values: StoreTracedWorkspaceRequest.Partial) -> StoreTracedWorkspaceRequest.Partial:
         for validator in StoreTracedWorkspaceRequest.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_admin_service_store_traced_workspace_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_admin_service_store_traced_workspace_request.py
@@ -176,13 +176,13 @@ class StoreTracedWorkspaceRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate_(cls, values: StoreTracedWorkspaceRequest.Partial) -> StoreTracedWorkspaceRequest.Partial:
+    def _pre_validate(cls, values: StoreTracedWorkspaceRequest.Partial) -> StoreTracedWorkspaceRequest.Partial:
         for validator in StoreTracedWorkspaceRequest.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate_(cls, values: StoreTracedWorkspaceRequest.Partial) -> StoreTracedWorkspaceRequest.Partial:
+    def _post_validate(cls, values: StoreTracedWorkspaceRequest.Partial) -> StoreTracedWorkspaceRequest.Partial:
         for validator in StoreTracedWorkspaceRequest.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_binary_tree_node_and_tree_value.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_binary_tree_node_and_tree_value.py
@@ -165,13 +165,17 @@ class BinaryTreeNodeAndTreeValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: BinaryTreeNodeAndTreeValue.Partial) -> BinaryTreeNodeAndTreeValue.Partial:
+    def _prebinary_tree_node_and_tree_value_validate(
+        cls, values: BinaryTreeNodeAndTreeValue.Partial
+    ) -> BinaryTreeNodeAndTreeValue.Partial:
         for validator in BinaryTreeNodeAndTreeValue.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: BinaryTreeNodeAndTreeValue.Partial) -> BinaryTreeNodeAndTreeValue.Partial:
+    def _postbinary_tree_node_and_tree_value_validate(
+        cls, values: BinaryTreeNodeAndTreeValue.Partial
+    ) -> BinaryTreeNodeAndTreeValue.Partial:
         for validator in BinaryTreeNodeAndTreeValue.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_binary_tree_node_and_tree_value.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_binary_tree_node_and_tree_value.py
@@ -165,7 +165,7 @@ class BinaryTreeNodeAndTreeValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prebinary_tree_node_and_tree_value_validate(
+    def _pre_binary_tree_node_and_tree_value_validate(
         cls, values: BinaryTreeNodeAndTreeValue.Partial
     ) -> BinaryTreeNodeAndTreeValue.Partial:
         for validator in BinaryTreeNodeAndTreeValue.Validators._pre_validators:
@@ -173,7 +173,7 @@ class BinaryTreeNodeAndTreeValue(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postbinary_tree_node_and_tree_value_validate(
+    def _post_binary_tree_node_and_tree_value_validate(
         cls, values: BinaryTreeNodeAndTreeValue.Partial
     ) -> BinaryTreeNodeAndTreeValue.Partial:
         for validator in BinaryTreeNodeAndTreeValue.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_binary_tree_node_and_tree_value.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_binary_tree_node_and_tree_value.py
@@ -165,7 +165,7 @@ class BinaryTreeNodeAndTreeValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_binary_tree_node_and_tree_value_validate(
+    def _pre_validate_binary_tree_node_and_tree_value(
         cls, values: BinaryTreeNodeAndTreeValue.Partial
     ) -> BinaryTreeNodeAndTreeValue.Partial:
         for validator in BinaryTreeNodeAndTreeValue.Validators._pre_validators:
@@ -173,7 +173,7 @@ class BinaryTreeNodeAndTreeValue(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_binary_tree_node_and_tree_value_validate(
+    def _post_validate_binary_tree_node_and_tree_value(
         cls, values: BinaryTreeNodeAndTreeValue.Partial
     ) -> BinaryTreeNodeAndTreeValue.Partial:
         for validator in BinaryTreeNodeAndTreeValue.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_binary_tree_node_value.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_binary_tree_node_value.py
@@ -233,13 +233,13 @@ class BinaryTreeNodeValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: BinaryTreeNodeValue.Partial) -> BinaryTreeNodeValue.Partial:
+    def _prebinary_tree_node_value_validate(cls, values: BinaryTreeNodeValue.Partial) -> BinaryTreeNodeValue.Partial:
         for validator in BinaryTreeNodeValue.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: BinaryTreeNodeValue.Partial) -> BinaryTreeNodeValue.Partial:
+    def _postbinary_tree_node_value_validate(cls, values: BinaryTreeNodeValue.Partial) -> BinaryTreeNodeValue.Partial:
         for validator in BinaryTreeNodeValue.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_binary_tree_node_value.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_binary_tree_node_value.py
@@ -233,13 +233,13 @@ class BinaryTreeNodeValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prebinary_tree_node_value_validate(cls, values: BinaryTreeNodeValue.Partial) -> BinaryTreeNodeValue.Partial:
+    def _pre_binary_tree_node_value_validate(cls, values: BinaryTreeNodeValue.Partial) -> BinaryTreeNodeValue.Partial:
         for validator in BinaryTreeNodeValue.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postbinary_tree_node_value_validate(cls, values: BinaryTreeNodeValue.Partial) -> BinaryTreeNodeValue.Partial:
+    def _post_binary_tree_node_value_validate(cls, values: BinaryTreeNodeValue.Partial) -> BinaryTreeNodeValue.Partial:
         for validator in BinaryTreeNodeValue.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_binary_tree_node_value.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_binary_tree_node_value.py
@@ -233,13 +233,13 @@ class BinaryTreeNodeValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_binary_tree_node_value_validate(cls, values: BinaryTreeNodeValue.Partial) -> BinaryTreeNodeValue.Partial:
+    def _pre_validate_binary_tree_node_value(cls, values: BinaryTreeNodeValue.Partial) -> BinaryTreeNodeValue.Partial:
         for validator in BinaryTreeNodeValue.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_binary_tree_node_value_validate(cls, values: BinaryTreeNodeValue.Partial) -> BinaryTreeNodeValue.Partial:
+    def _post_validate_binary_tree_node_value(cls, values: BinaryTreeNodeValue.Partial) -> BinaryTreeNodeValue.Partial:
         for validator in BinaryTreeNodeValue.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_binary_tree_value.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_binary_tree_value.py
@@ -150,13 +150,13 @@ class BinaryTreeValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_binary_tree_value_validate(cls, values: BinaryTreeValue.Partial) -> BinaryTreeValue.Partial:
+    def _pre_validate_binary_tree_value(cls, values: BinaryTreeValue.Partial) -> BinaryTreeValue.Partial:
         for validator in BinaryTreeValue.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_binary_tree_value_validate(cls, values: BinaryTreeValue.Partial) -> BinaryTreeValue.Partial:
+    def _post_validate_binary_tree_value(cls, values: BinaryTreeValue.Partial) -> BinaryTreeValue.Partial:
         for validator in BinaryTreeValue.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_binary_tree_value.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_binary_tree_value.py
@@ -150,13 +150,13 @@ class BinaryTreeValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prebinary_tree_value_validate(cls, values: BinaryTreeValue.Partial) -> BinaryTreeValue.Partial:
+    def _pre_binary_tree_value_validate(cls, values: BinaryTreeValue.Partial) -> BinaryTreeValue.Partial:
         for validator in BinaryTreeValue.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postbinary_tree_value_validate(cls, values: BinaryTreeValue.Partial) -> BinaryTreeValue.Partial:
+    def _post_binary_tree_value_validate(cls, values: BinaryTreeValue.Partial) -> BinaryTreeValue.Partial:
         for validator in BinaryTreeValue.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_binary_tree_value.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_binary_tree_value.py
@@ -150,13 +150,13 @@ class BinaryTreeValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: BinaryTreeValue.Partial) -> BinaryTreeValue.Partial:
+    def _prebinary_tree_value_validate(cls, values: BinaryTreeValue.Partial) -> BinaryTreeValue.Partial:
         for validator in BinaryTreeValue.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: BinaryTreeValue.Partial) -> BinaryTreeValue.Partial:
+    def _postbinary_tree_value_validate(cls, values: BinaryTreeValue.Partial) -> BinaryTreeValue.Partial:
         for validator in BinaryTreeValue.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_debug_key_value_pairs.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_debug_key_value_pairs.py
@@ -148,13 +148,13 @@ class DebugKeyValuePairs(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: DebugKeyValuePairs.Partial) -> DebugKeyValuePairs.Partial:
+    def _predebug_key_value_pairs_validate(cls, values: DebugKeyValuePairs.Partial) -> DebugKeyValuePairs.Partial:
         for validator in DebugKeyValuePairs.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: DebugKeyValuePairs.Partial) -> DebugKeyValuePairs.Partial:
+    def _postdebug_key_value_pairs_validate(cls, values: DebugKeyValuePairs.Partial) -> DebugKeyValuePairs.Partial:
         for validator in DebugKeyValuePairs.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_debug_key_value_pairs.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_debug_key_value_pairs.py
@@ -148,13 +148,13 @@ class DebugKeyValuePairs(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _predebug_key_value_pairs_validate(cls, values: DebugKeyValuePairs.Partial) -> DebugKeyValuePairs.Partial:
+    def _pre_debug_key_value_pairs_validate(cls, values: DebugKeyValuePairs.Partial) -> DebugKeyValuePairs.Partial:
         for validator in DebugKeyValuePairs.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postdebug_key_value_pairs_validate(cls, values: DebugKeyValuePairs.Partial) -> DebugKeyValuePairs.Partial:
+    def _post_debug_key_value_pairs_validate(cls, values: DebugKeyValuePairs.Partial) -> DebugKeyValuePairs.Partial:
         for validator in DebugKeyValuePairs.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_debug_key_value_pairs.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_debug_key_value_pairs.py
@@ -148,13 +148,13 @@ class DebugKeyValuePairs(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_debug_key_value_pairs_validate(cls, values: DebugKeyValuePairs.Partial) -> DebugKeyValuePairs.Partial:
+    def _pre_validate_debug_key_value_pairs(cls, values: DebugKeyValuePairs.Partial) -> DebugKeyValuePairs.Partial:
         for validator in DebugKeyValuePairs.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_debug_key_value_pairs_validate(cls, values: DebugKeyValuePairs.Partial) -> DebugKeyValuePairs.Partial:
+    def _post_validate_debug_key_value_pairs(cls, values: DebugKeyValuePairs.Partial) -> DebugKeyValuePairs.Partial:
         for validator in DebugKeyValuePairs.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_debug_map_value.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_debug_map_value.py
@@ -116,13 +116,13 @@ class DebugMapValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _predebug_map_value_validate(cls, values: DebugMapValue.Partial) -> DebugMapValue.Partial:
+    def _pre_debug_map_value_validate(cls, values: DebugMapValue.Partial) -> DebugMapValue.Partial:
         for validator in DebugMapValue.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postdebug_map_value_validate(cls, values: DebugMapValue.Partial) -> DebugMapValue.Partial:
+    def _post_debug_map_value_validate(cls, values: DebugMapValue.Partial) -> DebugMapValue.Partial:
         for validator in DebugMapValue.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_debug_map_value.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_debug_map_value.py
@@ -116,13 +116,13 @@ class DebugMapValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_debug_map_value_validate(cls, values: DebugMapValue.Partial) -> DebugMapValue.Partial:
+    def _pre_validate_debug_map_value(cls, values: DebugMapValue.Partial) -> DebugMapValue.Partial:
         for validator in DebugMapValue.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_debug_map_value_validate(cls, values: DebugMapValue.Partial) -> DebugMapValue.Partial:
+    def _post_validate_debug_map_value(cls, values: DebugMapValue.Partial) -> DebugMapValue.Partial:
         for validator in DebugMapValue.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_debug_map_value.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_debug_map_value.py
@@ -116,13 +116,13 @@ class DebugMapValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: DebugMapValue.Partial) -> DebugMapValue.Partial:
+    def _predebug_map_value_validate(cls, values: DebugMapValue.Partial) -> DebugMapValue.Partial:
         for validator in DebugMapValue.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: DebugMapValue.Partial) -> DebugMapValue.Partial:
+    def _postdebug_map_value_validate(cls, values: DebugMapValue.Partial) -> DebugMapValue.Partial:
         for validator in DebugMapValue.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_doubly_linked_list_node_and_list_value.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_doubly_linked_list_node_and_list_value.py
@@ -172,7 +172,7 @@ class DoublyLinkedListNodeAndListValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(
+    def _predoubly_linked_list_node_and_list_value_validate(
         cls, values: DoublyLinkedListNodeAndListValue.Partial
     ) -> DoublyLinkedListNodeAndListValue.Partial:
         for validator in DoublyLinkedListNodeAndListValue.Validators._pre_validators:
@@ -180,7 +180,7 @@ class DoublyLinkedListNodeAndListValue(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(
+    def _postdoubly_linked_list_node_and_list_value_validate(
         cls, values: DoublyLinkedListNodeAndListValue.Partial
     ) -> DoublyLinkedListNodeAndListValue.Partial:
         for validator in DoublyLinkedListNodeAndListValue.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_doubly_linked_list_node_and_list_value.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_doubly_linked_list_node_and_list_value.py
@@ -172,7 +172,7 @@ class DoublyLinkedListNodeAndListValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _predoubly_linked_list_node_and_list_value_validate(
+    def _pre_doubly_linked_list_node_and_list_value_validate(
         cls, values: DoublyLinkedListNodeAndListValue.Partial
     ) -> DoublyLinkedListNodeAndListValue.Partial:
         for validator in DoublyLinkedListNodeAndListValue.Validators._pre_validators:
@@ -180,7 +180,7 @@ class DoublyLinkedListNodeAndListValue(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postdoubly_linked_list_node_and_list_value_validate(
+    def _post_doubly_linked_list_node_and_list_value_validate(
         cls, values: DoublyLinkedListNodeAndListValue.Partial
     ) -> DoublyLinkedListNodeAndListValue.Partial:
         for validator in DoublyLinkedListNodeAndListValue.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_doubly_linked_list_node_and_list_value.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_doubly_linked_list_node_and_list_value.py
@@ -172,7 +172,7 @@ class DoublyLinkedListNodeAndListValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_doubly_linked_list_node_and_list_value_validate(
+    def _pre_validate_doubly_linked_list_node_and_list_value(
         cls, values: DoublyLinkedListNodeAndListValue.Partial
     ) -> DoublyLinkedListNodeAndListValue.Partial:
         for validator in DoublyLinkedListNodeAndListValue.Validators._pre_validators:
@@ -180,7 +180,7 @@ class DoublyLinkedListNodeAndListValue(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_doubly_linked_list_node_and_list_value_validate(
+    def _post_validate_doubly_linked_list_node_and_list_value(
         cls, values: DoublyLinkedListNodeAndListValue.Partial
     ) -> DoublyLinkedListNodeAndListValue.Partial:
         for validator in DoublyLinkedListNodeAndListValue.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_doubly_linked_list_node_value.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_doubly_linked_list_node_value.py
@@ -241,7 +241,7 @@ class DoublyLinkedListNodeValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_doubly_linked_list_node_value_validate(
+    def _pre_validate_doubly_linked_list_node_value(
         cls, values: DoublyLinkedListNodeValue.Partial
     ) -> DoublyLinkedListNodeValue.Partial:
         for validator in DoublyLinkedListNodeValue.Validators._pre_validators:
@@ -249,7 +249,7 @@ class DoublyLinkedListNodeValue(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_doubly_linked_list_node_value_validate(
+    def _post_validate_doubly_linked_list_node_value(
         cls, values: DoublyLinkedListNodeValue.Partial
     ) -> DoublyLinkedListNodeValue.Partial:
         for validator in DoublyLinkedListNodeValue.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_doubly_linked_list_node_value.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_doubly_linked_list_node_value.py
@@ -241,13 +241,17 @@ class DoublyLinkedListNodeValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: DoublyLinkedListNodeValue.Partial) -> DoublyLinkedListNodeValue.Partial:
+    def _predoubly_linked_list_node_value_validate(
+        cls, values: DoublyLinkedListNodeValue.Partial
+    ) -> DoublyLinkedListNodeValue.Partial:
         for validator in DoublyLinkedListNodeValue.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: DoublyLinkedListNodeValue.Partial) -> DoublyLinkedListNodeValue.Partial:
+    def _postdoubly_linked_list_node_value_validate(
+        cls, values: DoublyLinkedListNodeValue.Partial
+    ) -> DoublyLinkedListNodeValue.Partial:
         for validator in DoublyLinkedListNodeValue.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_doubly_linked_list_node_value.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_doubly_linked_list_node_value.py
@@ -241,7 +241,7 @@ class DoublyLinkedListNodeValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _predoubly_linked_list_node_value_validate(
+    def _pre_doubly_linked_list_node_value_validate(
         cls, values: DoublyLinkedListNodeValue.Partial
     ) -> DoublyLinkedListNodeValue.Partial:
         for validator in DoublyLinkedListNodeValue.Validators._pre_validators:
@@ -249,7 +249,7 @@ class DoublyLinkedListNodeValue(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postdoubly_linked_list_node_value_validate(
+    def _post_doubly_linked_list_node_value_validate(
         cls, values: DoublyLinkedListNodeValue.Partial
     ) -> DoublyLinkedListNodeValue.Partial:
         for validator in DoublyLinkedListNodeValue.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_doubly_linked_list_value.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_doubly_linked_list_value.py
@@ -156,7 +156,7 @@ class DoublyLinkedListValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_doubly_linked_list_value_validate(
+    def _pre_validate_doubly_linked_list_value(
         cls, values: DoublyLinkedListValue.Partial
     ) -> DoublyLinkedListValue.Partial:
         for validator in DoublyLinkedListValue.Validators._pre_validators:
@@ -164,7 +164,7 @@ class DoublyLinkedListValue(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_doubly_linked_list_value_validate(
+    def _post_validate_doubly_linked_list_value(
         cls, values: DoublyLinkedListValue.Partial
     ) -> DoublyLinkedListValue.Partial:
         for validator in DoublyLinkedListValue.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_doubly_linked_list_value.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_doubly_linked_list_value.py
@@ -156,7 +156,7 @@ class DoublyLinkedListValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _predoubly_linked_list_value_validate(
+    def _pre_doubly_linked_list_value_validate(
         cls, values: DoublyLinkedListValue.Partial
     ) -> DoublyLinkedListValue.Partial:
         for validator in DoublyLinkedListValue.Validators._pre_validators:
@@ -164,7 +164,7 @@ class DoublyLinkedListValue(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postdoubly_linked_list_value_validate(
+    def _post_doubly_linked_list_value_validate(
         cls, values: DoublyLinkedListValue.Partial
     ) -> DoublyLinkedListValue.Partial:
         for validator in DoublyLinkedListValue.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_doubly_linked_list_value.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_doubly_linked_list_value.py
@@ -156,13 +156,17 @@ class DoublyLinkedListValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: DoublyLinkedListValue.Partial) -> DoublyLinkedListValue.Partial:
+    def _predoubly_linked_list_value_validate(
+        cls, values: DoublyLinkedListValue.Partial
+    ) -> DoublyLinkedListValue.Partial:
         for validator in DoublyLinkedListValue.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: DoublyLinkedListValue.Partial) -> DoublyLinkedListValue.Partial:
+    def _postdoubly_linked_list_value_validate(
+        cls, values: DoublyLinkedListValue.Partial
+    ) -> DoublyLinkedListValue.Partial:
         for validator in DoublyLinkedListValue.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_file_info.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_file_info.py
@@ -138,13 +138,13 @@ class FileInfo(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_file_info_validate(cls, values: FileInfo.Partial) -> FileInfo.Partial:
+    def _pre_validate_file_info(cls, values: FileInfo.Partial) -> FileInfo.Partial:
         for validator in FileInfo.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_file_info_validate(cls, values: FileInfo.Partial) -> FileInfo.Partial:
+    def _post_validate_file_info(cls, values: FileInfo.Partial) -> FileInfo.Partial:
         for validator in FileInfo.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_file_info.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_file_info.py
@@ -138,13 +138,13 @@ class FileInfo(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prefile_info_validate(cls, values: FileInfo.Partial) -> FileInfo.Partial:
+    def _pre_file_info_validate(cls, values: FileInfo.Partial) -> FileInfo.Partial:
         for validator in FileInfo.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postfile_info_validate(cls, values: FileInfo.Partial) -> FileInfo.Partial:
+    def _post_file_info_validate(cls, values: FileInfo.Partial) -> FileInfo.Partial:
         for validator in FileInfo.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_file_info.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_file_info.py
@@ -138,13 +138,13 @@ class FileInfo(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: FileInfo.Partial) -> FileInfo.Partial:
+    def _prefile_info_validate(cls, values: FileInfo.Partial) -> FileInfo.Partial:
         for validator in FileInfo.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: FileInfo.Partial) -> FileInfo.Partial:
+    def _postfile_info_validate(cls, values: FileInfo.Partial) -> FileInfo.Partial:
         for validator in FileInfo.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_generic_value.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_generic_value.py
@@ -160,13 +160,13 @@ class GenericValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_generic_value_validate(cls, values: GenericValue.Partial) -> GenericValue.Partial:
+    def _pre_validate_generic_value(cls, values: GenericValue.Partial) -> GenericValue.Partial:
         for validator in GenericValue.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_generic_value_validate(cls, values: GenericValue.Partial) -> GenericValue.Partial:
+    def _post_validate_generic_value(cls, values: GenericValue.Partial) -> GenericValue.Partial:
         for validator in GenericValue.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_generic_value.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_generic_value.py
@@ -160,13 +160,13 @@ class GenericValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: GenericValue.Partial) -> GenericValue.Partial:
+    def _pregeneric_value_validate(cls, values: GenericValue.Partial) -> GenericValue.Partial:
         for validator in GenericValue.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: GenericValue.Partial) -> GenericValue.Partial:
+    def _postgeneric_value_validate(cls, values: GenericValue.Partial) -> GenericValue.Partial:
         for validator in GenericValue.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_generic_value.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_generic_value.py
@@ -160,13 +160,13 @@ class GenericValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pregeneric_value_validate(cls, values: GenericValue.Partial) -> GenericValue.Partial:
+    def _pre_generic_value_validate(cls, values: GenericValue.Partial) -> GenericValue.Partial:
         for validator in GenericValue.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postgeneric_value_validate(cls, values: GenericValue.Partial) -> GenericValue.Partial:
+    def _post_generic_value_validate(cls, values: GenericValue.Partial) -> GenericValue.Partial:
         for validator in GenericValue.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_key_value_pair.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_key_value_pair.py
@@ -138,13 +138,13 @@ class KeyValuePair(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prekey_value_pair_validate(cls, values: KeyValuePair.Partial) -> KeyValuePair.Partial:
+    def _pre_key_value_pair_validate(cls, values: KeyValuePair.Partial) -> KeyValuePair.Partial:
         for validator in KeyValuePair.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postkey_value_pair_validate(cls, values: KeyValuePair.Partial) -> KeyValuePair.Partial:
+    def _post_key_value_pair_validate(cls, values: KeyValuePair.Partial) -> KeyValuePair.Partial:
         for validator in KeyValuePair.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_key_value_pair.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_key_value_pair.py
@@ -138,13 +138,13 @@ class KeyValuePair(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: KeyValuePair.Partial) -> KeyValuePair.Partial:
+    def _prekey_value_pair_validate(cls, values: KeyValuePair.Partial) -> KeyValuePair.Partial:
         for validator in KeyValuePair.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: KeyValuePair.Partial) -> KeyValuePair.Partial:
+    def _postkey_value_pair_validate(cls, values: KeyValuePair.Partial) -> KeyValuePair.Partial:
         for validator in KeyValuePair.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_key_value_pair.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_key_value_pair.py
@@ -138,13 +138,13 @@ class KeyValuePair(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_key_value_pair_validate(cls, values: KeyValuePair.Partial) -> KeyValuePair.Partial:
+    def _pre_validate_key_value_pair(cls, values: KeyValuePair.Partial) -> KeyValuePair.Partial:
         for validator in KeyValuePair.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_key_value_pair_validate(cls, values: KeyValuePair.Partial) -> KeyValuePair.Partial:
+    def _post_validate_key_value_pair(cls, values: KeyValuePair.Partial) -> KeyValuePair.Partial:
         for validator in KeyValuePair.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_list_type.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_list_type.py
@@ -150,13 +150,13 @@ class ListType(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: ListType.Partial) -> ListType.Partial:
+    def _prelist_type_validate(cls, values: ListType.Partial) -> ListType.Partial:
         for validator in ListType.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: ListType.Partial) -> ListType.Partial:
+    def _postlist_type_validate(cls, values: ListType.Partial) -> ListType.Partial:
         for validator in ListType.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_list_type.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_list_type.py
@@ -150,13 +150,13 @@ class ListType(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prelist_type_validate(cls, values: ListType.Partial) -> ListType.Partial:
+    def _pre_list_type_validate(cls, values: ListType.Partial) -> ListType.Partial:
         for validator in ListType.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postlist_type_validate(cls, values: ListType.Partial) -> ListType.Partial:
+    def _post_list_type_validate(cls, values: ListType.Partial) -> ListType.Partial:
         for validator in ListType.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_list_type.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_list_type.py
@@ -150,13 +150,13 @@ class ListType(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_list_type_validate(cls, values: ListType.Partial) -> ListType.Partial:
+    def _pre_validate_list_type(cls, values: ListType.Partial) -> ListType.Partial:
         for validator in ListType.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_list_type_validate(cls, values: ListType.Partial) -> ListType.Partial:
+    def _post_validate_list_type(cls, values: ListType.Partial) -> ListType.Partial:
         for validator in ListType.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_map_type.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_map_type.py
@@ -138,13 +138,13 @@ class MapType(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_map_type_validate(cls, values: MapType.Partial) -> MapType.Partial:
+    def _pre_validate_map_type(cls, values: MapType.Partial) -> MapType.Partial:
         for validator in MapType.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_map_type_validate(cls, values: MapType.Partial) -> MapType.Partial:
+    def _post_validate_map_type(cls, values: MapType.Partial) -> MapType.Partial:
         for validator in MapType.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_map_type.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_map_type.py
@@ -138,13 +138,13 @@ class MapType(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _premap_type_validate(cls, values: MapType.Partial) -> MapType.Partial:
+    def _pre_map_type_validate(cls, values: MapType.Partial) -> MapType.Partial:
         for validator in MapType.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postmap_type_validate(cls, values: MapType.Partial) -> MapType.Partial:
+    def _post_map_type_validate(cls, values: MapType.Partial) -> MapType.Partial:
         for validator in MapType.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_map_type.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_map_type.py
@@ -138,13 +138,13 @@ class MapType(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: MapType.Partial) -> MapType.Partial:
+    def _premap_type_validate(cls, values: MapType.Partial) -> MapType.Partial:
         for validator in MapType.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: MapType.Partial) -> MapType.Partial:
+    def _postmap_type_validate(cls, values: MapType.Partial) -> MapType.Partial:
         for validator in MapType.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_map_value.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_map_value.py
@@ -110,13 +110,13 @@ class MapValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: MapValue.Partial) -> MapValue.Partial:
+    def _premap_value_validate(cls, values: MapValue.Partial) -> MapValue.Partial:
         for validator in MapValue.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: MapValue.Partial) -> MapValue.Partial:
+    def _postmap_value_validate(cls, values: MapValue.Partial) -> MapValue.Partial:
         for validator in MapValue.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_map_value.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_map_value.py
@@ -110,13 +110,13 @@ class MapValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _premap_value_validate(cls, values: MapValue.Partial) -> MapValue.Partial:
+    def _pre_map_value_validate(cls, values: MapValue.Partial) -> MapValue.Partial:
         for validator in MapValue.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postmap_value_validate(cls, values: MapValue.Partial) -> MapValue.Partial:
+    def _post_map_value_validate(cls, values: MapValue.Partial) -> MapValue.Partial:
         for validator in MapValue.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_map_value.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_map_value.py
@@ -110,13 +110,13 @@ class MapValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_map_value_validate(cls, values: MapValue.Partial) -> MapValue.Partial:
+    def _pre_validate_map_value(cls, values: MapValue.Partial) -> MapValue.Partial:
         for validator in MapValue.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_map_value_validate(cls, values: MapValue.Partial) -> MapValue.Partial:
+    def _post_validate_map_value(cls, values: MapValue.Partial) -> MapValue.Partial:
         for validator in MapValue.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_singly_linked_list_node_and_list_value.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_singly_linked_list_node_and_list_value.py
@@ -172,7 +172,7 @@ class SinglyLinkedListNodeAndListValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(
+    def _presingly_linked_list_node_and_list_value_validate(
         cls, values: SinglyLinkedListNodeAndListValue.Partial
     ) -> SinglyLinkedListNodeAndListValue.Partial:
         for validator in SinglyLinkedListNodeAndListValue.Validators._pre_validators:
@@ -180,7 +180,7 @@ class SinglyLinkedListNodeAndListValue(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(
+    def _postsingly_linked_list_node_and_list_value_validate(
         cls, values: SinglyLinkedListNodeAndListValue.Partial
     ) -> SinglyLinkedListNodeAndListValue.Partial:
         for validator in SinglyLinkedListNodeAndListValue.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_singly_linked_list_node_and_list_value.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_singly_linked_list_node_and_list_value.py
@@ -172,7 +172,7 @@ class SinglyLinkedListNodeAndListValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_singly_linked_list_node_and_list_value_validate(
+    def _pre_validate_singly_linked_list_node_and_list_value(
         cls, values: SinglyLinkedListNodeAndListValue.Partial
     ) -> SinglyLinkedListNodeAndListValue.Partial:
         for validator in SinglyLinkedListNodeAndListValue.Validators._pre_validators:
@@ -180,7 +180,7 @@ class SinglyLinkedListNodeAndListValue(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_singly_linked_list_node_and_list_value_validate(
+    def _post_validate_singly_linked_list_node_and_list_value(
         cls, values: SinglyLinkedListNodeAndListValue.Partial
     ) -> SinglyLinkedListNodeAndListValue.Partial:
         for validator in SinglyLinkedListNodeAndListValue.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_singly_linked_list_node_and_list_value.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_singly_linked_list_node_and_list_value.py
@@ -172,7 +172,7 @@ class SinglyLinkedListNodeAndListValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _presingly_linked_list_node_and_list_value_validate(
+    def _pre_singly_linked_list_node_and_list_value_validate(
         cls, values: SinglyLinkedListNodeAndListValue.Partial
     ) -> SinglyLinkedListNodeAndListValue.Partial:
         for validator in SinglyLinkedListNodeAndListValue.Validators._pre_validators:
@@ -180,7 +180,7 @@ class SinglyLinkedListNodeAndListValue(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postsingly_linked_list_node_and_list_value_validate(
+    def _post_singly_linked_list_node_and_list_value_validate(
         cls, values: SinglyLinkedListNodeAndListValue.Partial
     ) -> SinglyLinkedListNodeAndListValue.Partial:
         for validator in SinglyLinkedListNodeAndListValue.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_singly_linked_list_node_value.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_singly_linked_list_node_value.py
@@ -199,13 +199,17 @@ class SinglyLinkedListNodeValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: SinglyLinkedListNodeValue.Partial) -> SinglyLinkedListNodeValue.Partial:
+    def _presingly_linked_list_node_value_validate(
+        cls, values: SinglyLinkedListNodeValue.Partial
+    ) -> SinglyLinkedListNodeValue.Partial:
         for validator in SinglyLinkedListNodeValue.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: SinglyLinkedListNodeValue.Partial) -> SinglyLinkedListNodeValue.Partial:
+    def _postsingly_linked_list_node_value_validate(
+        cls, values: SinglyLinkedListNodeValue.Partial
+    ) -> SinglyLinkedListNodeValue.Partial:
         for validator in SinglyLinkedListNodeValue.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_singly_linked_list_node_value.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_singly_linked_list_node_value.py
@@ -199,7 +199,7 @@ class SinglyLinkedListNodeValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _presingly_linked_list_node_value_validate(
+    def _pre_singly_linked_list_node_value_validate(
         cls, values: SinglyLinkedListNodeValue.Partial
     ) -> SinglyLinkedListNodeValue.Partial:
         for validator in SinglyLinkedListNodeValue.Validators._pre_validators:
@@ -207,7 +207,7 @@ class SinglyLinkedListNodeValue(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postsingly_linked_list_node_value_validate(
+    def _post_singly_linked_list_node_value_validate(
         cls, values: SinglyLinkedListNodeValue.Partial
     ) -> SinglyLinkedListNodeValue.Partial:
         for validator in SinglyLinkedListNodeValue.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_singly_linked_list_node_value.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_singly_linked_list_node_value.py
@@ -199,7 +199,7 @@ class SinglyLinkedListNodeValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_singly_linked_list_node_value_validate(
+    def _pre_validate_singly_linked_list_node_value(
         cls, values: SinglyLinkedListNodeValue.Partial
     ) -> SinglyLinkedListNodeValue.Partial:
         for validator in SinglyLinkedListNodeValue.Validators._pre_validators:
@@ -207,7 +207,7 @@ class SinglyLinkedListNodeValue(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_singly_linked_list_node_value_validate(
+    def _post_validate_singly_linked_list_node_value(
         cls, values: SinglyLinkedListNodeValue.Partial
     ) -> SinglyLinkedListNodeValue.Partial:
         for validator in SinglyLinkedListNodeValue.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_singly_linked_list_value.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_singly_linked_list_value.py
@@ -156,7 +156,7 @@ class SinglyLinkedListValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_singly_linked_list_value_validate(
+    def _pre_validate_singly_linked_list_value(
         cls, values: SinglyLinkedListValue.Partial
     ) -> SinglyLinkedListValue.Partial:
         for validator in SinglyLinkedListValue.Validators._pre_validators:
@@ -164,7 +164,7 @@ class SinglyLinkedListValue(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_singly_linked_list_value_validate(
+    def _post_validate_singly_linked_list_value(
         cls, values: SinglyLinkedListValue.Partial
     ) -> SinglyLinkedListValue.Partial:
         for validator in SinglyLinkedListValue.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_singly_linked_list_value.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_singly_linked_list_value.py
@@ -156,7 +156,7 @@ class SinglyLinkedListValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _presingly_linked_list_value_validate(
+    def _pre_singly_linked_list_value_validate(
         cls, values: SinglyLinkedListValue.Partial
     ) -> SinglyLinkedListValue.Partial:
         for validator in SinglyLinkedListValue.Validators._pre_validators:
@@ -164,7 +164,7 @@ class SinglyLinkedListValue(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postsingly_linked_list_value_validate(
+    def _post_singly_linked_list_value_validate(
         cls, values: SinglyLinkedListValue.Partial
     ) -> SinglyLinkedListValue.Partial:
         for validator in SinglyLinkedListValue.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_singly_linked_list_value.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_singly_linked_list_value.py
@@ -156,13 +156,17 @@ class SinglyLinkedListValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: SinglyLinkedListValue.Partial) -> SinglyLinkedListValue.Partial:
+    def _presingly_linked_list_value_validate(
+        cls, values: SinglyLinkedListValue.Partial
+    ) -> SinglyLinkedListValue.Partial:
         for validator in SinglyLinkedListValue.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: SinglyLinkedListValue.Partial) -> SinglyLinkedListValue.Partial:
+    def _postsingly_linked_list_value_validate(
+        cls, values: SinglyLinkedListValue.Partial
+    ) -> SinglyLinkedListValue.Partial:
         for validator in SinglyLinkedListValue.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_test_case.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_test_case.py
@@ -141,13 +141,13 @@ class TestCase(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pretest_case_validate(cls, values: TestCase.Partial) -> TestCase.Partial:
+    def _pre_test_case_validate(cls, values: TestCase.Partial) -> TestCase.Partial:
         for validator in TestCase.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _posttest_case_validate(cls, values: TestCase.Partial) -> TestCase.Partial:
+    def _post_test_case_validate(cls, values: TestCase.Partial) -> TestCase.Partial:
         for validator in TestCase.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_test_case.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_test_case.py
@@ -141,13 +141,13 @@ class TestCase(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_test_case_validate(cls, values: TestCase.Partial) -> TestCase.Partial:
+    def _pre_validate_test_case(cls, values: TestCase.Partial) -> TestCase.Partial:
         for validator in TestCase.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_test_case_validate(cls, values: TestCase.Partial) -> TestCase.Partial:
+    def _post_validate_test_case(cls, values: TestCase.Partial) -> TestCase.Partial:
         for validator in TestCase.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_test_case.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_test_case.py
@@ -141,13 +141,13 @@ class TestCase(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TestCase.Partial) -> TestCase.Partial:
+    def _pretest_case_validate(cls, values: TestCase.Partial) -> TestCase.Partial:
         for validator in TestCase.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TestCase.Partial) -> TestCase.Partial:
+    def _posttest_case_validate(cls, values: TestCase.Partial) -> TestCase.Partial:
         for validator in TestCase.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_test_case_with_expected_result.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_test_case_with_expected_result.py
@@ -168,7 +168,7 @@ class TestCaseWithExpectedResult(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pretest_case_with_expected_result_validate(
+    def _pre_test_case_with_expected_result_validate(
         cls, values: TestCaseWithExpectedResult.Partial
     ) -> TestCaseWithExpectedResult.Partial:
         for validator in TestCaseWithExpectedResult.Validators._pre_validators:
@@ -176,7 +176,7 @@ class TestCaseWithExpectedResult(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _posttest_case_with_expected_result_validate(
+    def _post_test_case_with_expected_result_validate(
         cls, values: TestCaseWithExpectedResult.Partial
     ) -> TestCaseWithExpectedResult.Partial:
         for validator in TestCaseWithExpectedResult.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_test_case_with_expected_result.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_test_case_with_expected_result.py
@@ -168,13 +168,17 @@ class TestCaseWithExpectedResult(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TestCaseWithExpectedResult.Partial) -> TestCaseWithExpectedResult.Partial:
+    def _pretest_case_with_expected_result_validate(
+        cls, values: TestCaseWithExpectedResult.Partial
+    ) -> TestCaseWithExpectedResult.Partial:
         for validator in TestCaseWithExpectedResult.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TestCaseWithExpectedResult.Partial) -> TestCaseWithExpectedResult.Partial:
+    def _posttest_case_with_expected_result_validate(
+        cls, values: TestCaseWithExpectedResult.Partial
+    ) -> TestCaseWithExpectedResult.Partial:
         for validator in TestCaseWithExpectedResult.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_test_case_with_expected_result.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_commons_types_test_case_with_expected_result.py
@@ -168,7 +168,7 @@ class TestCaseWithExpectedResult(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_test_case_with_expected_result_validate(
+    def _pre_validate_test_case_with_expected_result(
         cls, values: TestCaseWithExpectedResult.Partial
     ) -> TestCaseWithExpectedResult.Partial:
         for validator in TestCaseWithExpectedResult.Validators._pre_validators:
@@ -176,7 +176,7 @@ class TestCaseWithExpectedResult(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_test_case_with_expected_result_validate(
+    def _post_validate_test_case_with_expected_result(
         cls, values: TestCaseWithExpectedResult.Partial
     ) -> TestCaseWithExpectedResult.Partial:
         for validator in TestCaseWithExpectedResult.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_lang_server_types_lang_server_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_lang_server_types_lang_server_request.py
@@ -111,13 +111,13 @@ class LangServerRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: LangServerRequest.Partial) -> LangServerRequest.Partial:
+    def _prelang_server_request_validate(cls, values: LangServerRequest.Partial) -> LangServerRequest.Partial:
         for validator in LangServerRequest.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: LangServerRequest.Partial) -> LangServerRequest.Partial:
+    def _postlang_server_request_validate(cls, values: LangServerRequest.Partial) -> LangServerRequest.Partial:
         for validator in LangServerRequest.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_lang_server_types_lang_server_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_lang_server_types_lang_server_request.py
@@ -111,13 +111,13 @@ class LangServerRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_lang_server_request_validate(cls, values: LangServerRequest.Partial) -> LangServerRequest.Partial:
+    def _pre_validate_lang_server_request(cls, values: LangServerRequest.Partial) -> LangServerRequest.Partial:
         for validator in LangServerRequest.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_lang_server_request_validate(cls, values: LangServerRequest.Partial) -> LangServerRequest.Partial:
+    def _post_validate_lang_server_request(cls, values: LangServerRequest.Partial) -> LangServerRequest.Partial:
         for validator in LangServerRequest.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_lang_server_types_lang_server_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_lang_server_types_lang_server_request.py
@@ -111,13 +111,13 @@ class LangServerRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prelang_server_request_validate(cls, values: LangServerRequest.Partial) -> LangServerRequest.Partial:
+    def _pre_lang_server_request_validate(cls, values: LangServerRequest.Partial) -> LangServerRequest.Partial:
         for validator in LangServerRequest.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postlang_server_request_validate(cls, values: LangServerRequest.Partial) -> LangServerRequest.Partial:
+    def _post_lang_server_request_validate(cls, values: LangServerRequest.Partial) -> LangServerRequest.Partial:
         for validator in LangServerRequest.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_lang_server_types_lang_server_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_lang_server_types_lang_server_response.py
@@ -111,13 +111,13 @@ class LangServerResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_lang_server_response_validate(cls, values: LangServerResponse.Partial) -> LangServerResponse.Partial:
+    def _pre_validate_lang_server_response(cls, values: LangServerResponse.Partial) -> LangServerResponse.Partial:
         for validator in LangServerResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_lang_server_response_validate(cls, values: LangServerResponse.Partial) -> LangServerResponse.Partial:
+    def _post_validate_lang_server_response(cls, values: LangServerResponse.Partial) -> LangServerResponse.Partial:
         for validator in LangServerResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_lang_server_types_lang_server_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_lang_server_types_lang_server_response.py
@@ -111,13 +111,13 @@ class LangServerResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prelang_server_response_validate(cls, values: LangServerResponse.Partial) -> LangServerResponse.Partial:
+    def _pre_lang_server_response_validate(cls, values: LangServerResponse.Partial) -> LangServerResponse.Partial:
         for validator in LangServerResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postlang_server_response_validate(cls, values: LangServerResponse.Partial) -> LangServerResponse.Partial:
+    def _post_lang_server_response_validate(cls, values: LangServerResponse.Partial) -> LangServerResponse.Partial:
         for validator in LangServerResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_lang_server_types_lang_server_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_lang_server_types_lang_server_response.py
@@ -111,13 +111,13 @@ class LangServerResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: LangServerResponse.Partial) -> LangServerResponse.Partial:
+    def _prelang_server_response_validate(cls, values: LangServerResponse.Partial) -> LangServerResponse.Partial:
         for validator in LangServerResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: LangServerResponse.Partial) -> LangServerResponse.Partial:
+    def _postlang_server_response_validate(cls, values: LangServerResponse.Partial) -> LangServerResponse.Partial:
         for validator in LangServerResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_migration_types_migration.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_migration_types_migration.py
@@ -139,13 +139,13 @@ class Migration(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _premigration_validate(cls, values: Migration.Partial) -> Migration.Partial:
+    def _pre_migration_validate(cls, values: Migration.Partial) -> Migration.Partial:
         for validator in Migration.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postmigration_validate(cls, values: Migration.Partial) -> Migration.Partial:
+    def _post_migration_validate(cls, values: Migration.Partial) -> Migration.Partial:
         for validator in Migration.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_migration_types_migration.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_migration_types_migration.py
@@ -139,13 +139,13 @@ class Migration(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: Migration.Partial) -> Migration.Partial:
+    def _premigration_validate(cls, values: Migration.Partial) -> Migration.Partial:
         for validator in Migration.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: Migration.Partial) -> Migration.Partial:
+    def _postmigration_validate(cls, values: Migration.Partial) -> Migration.Partial:
         for validator in Migration.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_migration_types_migration.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_migration_types_migration.py
@@ -139,13 +139,13 @@ class Migration(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_migration_validate(cls, values: Migration.Partial) -> Migration.Partial:
+    def _pre_validate_migration(cls, values: Migration.Partial) -> Migration.Partial:
         for validator in Migration.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_migration_validate(cls, values: Migration.Partial) -> Migration.Partial:
+    def _post_validate_migration(cls, values: Migration.Partial) -> Migration.Partial:
         for validator in Migration.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_playlist_types_playlist.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_playlist_types_playlist.py
@@ -208,13 +208,13 @@ class Playlist(PlaylistCreateRequest):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_playlist_validate(cls, values: Playlist.Partial) -> Playlist.Partial:
+    def _pre_validate_playlist(cls, values: Playlist.Partial) -> Playlist.Partial:
         for validator in Playlist.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_playlist_validate(cls, values: Playlist.Partial) -> Playlist.Partial:
+    def _post_validate_playlist(cls, values: Playlist.Partial) -> Playlist.Partial:
         for validator in Playlist.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_playlist_types_playlist.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_playlist_types_playlist.py
@@ -208,13 +208,13 @@ class Playlist(PlaylistCreateRequest):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preplaylist_validate(cls, values: Playlist.Partial) -> Playlist.Partial:
+    def _pre_playlist_validate(cls, values: Playlist.Partial) -> Playlist.Partial:
         for validator in Playlist.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postplaylist_validate(cls, values: Playlist.Partial) -> Playlist.Partial:
+    def _post_playlist_validate(cls, values: Playlist.Partial) -> Playlist.Partial:
         for validator in Playlist.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_playlist_types_playlist.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_playlist_types_playlist.py
@@ -208,13 +208,13 @@ class Playlist(PlaylistCreateRequest):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: Playlist.Partial) -> Playlist.Partial:
+    def _preplaylist_validate(cls, values: Playlist.Partial) -> Playlist.Partial:
         for validator in Playlist.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: Playlist.Partial) -> Playlist.Partial:
+    def _postplaylist_validate(cls, values: Playlist.Partial) -> Playlist.Partial:
         for validator in Playlist.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_playlist_types_playlist_create_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_playlist_types_playlist_create_request.py
@@ -156,7 +156,7 @@ class PlaylistCreateRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preplaylist_create_request_validate(
+    def _pre_playlist_create_request_validate(
         cls, values: PlaylistCreateRequest.Partial
     ) -> PlaylistCreateRequest.Partial:
         for validator in PlaylistCreateRequest.Validators._pre_validators:
@@ -164,7 +164,7 @@ class PlaylistCreateRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postplaylist_create_request_validate(
+    def _post_playlist_create_request_validate(
         cls, values: PlaylistCreateRequest.Partial
     ) -> PlaylistCreateRequest.Partial:
         for validator in PlaylistCreateRequest.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_playlist_types_playlist_create_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_playlist_types_playlist_create_request.py
@@ -156,7 +156,7 @@ class PlaylistCreateRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_playlist_create_request_validate(
+    def _pre_validate_playlist_create_request(
         cls, values: PlaylistCreateRequest.Partial
     ) -> PlaylistCreateRequest.Partial:
         for validator in PlaylistCreateRequest.Validators._pre_validators:
@@ -164,7 +164,7 @@ class PlaylistCreateRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_playlist_create_request_validate(
+    def _post_validate_playlist_create_request(
         cls, values: PlaylistCreateRequest.Partial
     ) -> PlaylistCreateRequest.Partial:
         for validator in PlaylistCreateRequest.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_playlist_types_playlist_create_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_playlist_types_playlist_create_request.py
@@ -156,13 +156,17 @@ class PlaylistCreateRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: PlaylistCreateRequest.Partial) -> PlaylistCreateRequest.Partial:
+    def _preplaylist_create_request_validate(
+        cls, values: PlaylistCreateRequest.Partial
+    ) -> PlaylistCreateRequest.Partial:
         for validator in PlaylistCreateRequest.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: PlaylistCreateRequest.Partial) -> PlaylistCreateRequest.Partial:
+    def _postplaylist_create_request_validate(
+        cls, values: PlaylistCreateRequest.Partial
+    ) -> PlaylistCreateRequest.Partial:
         for validator in PlaylistCreateRequest.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_playlist_types_update_playlist_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_playlist_types_update_playlist_request.py
@@ -156,7 +156,7 @@ class UpdatePlaylistRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preupdate_playlist_request_validate(
+    def _pre_update_playlist_request_validate(
         cls, values: UpdatePlaylistRequest.Partial
     ) -> UpdatePlaylistRequest.Partial:
         for validator in UpdatePlaylistRequest.Validators._pre_validators:
@@ -164,7 +164,7 @@ class UpdatePlaylistRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postupdate_playlist_request_validate(
+    def _post_update_playlist_request_validate(
         cls, values: UpdatePlaylistRequest.Partial
     ) -> UpdatePlaylistRequest.Partial:
         for validator in UpdatePlaylistRequest.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_playlist_types_update_playlist_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_playlist_types_update_playlist_request.py
@@ -156,13 +156,17 @@ class UpdatePlaylistRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: UpdatePlaylistRequest.Partial) -> UpdatePlaylistRequest.Partial:
+    def _preupdate_playlist_request_validate(
+        cls, values: UpdatePlaylistRequest.Partial
+    ) -> UpdatePlaylistRequest.Partial:
         for validator in UpdatePlaylistRequest.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: UpdatePlaylistRequest.Partial) -> UpdatePlaylistRequest.Partial:
+    def _postupdate_playlist_request_validate(
+        cls, values: UpdatePlaylistRequest.Partial
+    ) -> UpdatePlaylistRequest.Partial:
         for validator in UpdatePlaylistRequest.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_playlist_types_update_playlist_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_playlist_types_update_playlist_request.py
@@ -156,7 +156,7 @@ class UpdatePlaylistRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_update_playlist_request_validate(
+    def _pre_validate_update_playlist_request(
         cls, values: UpdatePlaylistRequest.Partial
     ) -> UpdatePlaylistRequest.Partial:
         for validator in UpdatePlaylistRequest.Validators._pre_validators:
@@ -164,7 +164,7 @@ class UpdatePlaylistRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_update_playlist_request_validate(
+    def _post_validate_update_playlist_request(
         cls, values: UpdatePlaylistRequest.Partial
     ) -> UpdatePlaylistRequest.Partial:
         for validator in UpdatePlaylistRequest.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_service_get_default_starter_files_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_service_get_default_starter_files_request.py
@@ -225,13 +225,13 @@ class GetDefaultStarterFilesRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: GetDefaultStarterFilesRequest.Partial) -> GetDefaultStarterFilesRequest.Partial:
+    def _pre_validate_(cls, values: GetDefaultStarterFilesRequest.Partial) -> GetDefaultStarterFilesRequest.Partial:
         for validator in GetDefaultStarterFilesRequest.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: GetDefaultStarterFilesRequest.Partial) -> GetDefaultStarterFilesRequest.Partial:
+    def _post_validate_(cls, values: GetDefaultStarterFilesRequest.Partial) -> GetDefaultStarterFilesRequest.Partial:
         for validator in GetDefaultStarterFilesRequest.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_service_get_default_starter_files_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_service_get_default_starter_files_request.py
@@ -225,13 +225,13 @@ class GetDefaultStarterFilesRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate_(cls, values: GetDefaultStarterFilesRequest.Partial) -> GetDefaultStarterFilesRequest.Partial:
+    def _pre_validate(cls, values: GetDefaultStarterFilesRequest.Partial) -> GetDefaultStarterFilesRequest.Partial:
         for validator in GetDefaultStarterFilesRequest.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate_(cls, values: GetDefaultStarterFilesRequest.Partial) -> GetDefaultStarterFilesRequest.Partial:
+    def _post_validate(cls, values: GetDefaultStarterFilesRequest.Partial) -> GetDefaultStarterFilesRequest.Partial:
         for validator in GetDefaultStarterFilesRequest.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_create_problem_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_create_problem_request.py
@@ -391,13 +391,13 @@ class CreateProblemRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: CreateProblemRequest.Partial) -> CreateProblemRequest.Partial:
+    def _precreate_problem_request_validate(cls, values: CreateProblemRequest.Partial) -> CreateProblemRequest.Partial:
         for validator in CreateProblemRequest.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: CreateProblemRequest.Partial) -> CreateProblemRequest.Partial:
+    def _postcreate_problem_request_validate(cls, values: CreateProblemRequest.Partial) -> CreateProblemRequest.Partial:
         for validator in CreateProblemRequest.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_create_problem_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_create_problem_request.py
@@ -391,13 +391,15 @@ class CreateProblemRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _precreate_problem_request_validate(cls, values: CreateProblemRequest.Partial) -> CreateProblemRequest.Partial:
+    def _pre_create_problem_request_validate(cls, values: CreateProblemRequest.Partial) -> CreateProblemRequest.Partial:
         for validator in CreateProblemRequest.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postcreate_problem_request_validate(cls, values: CreateProblemRequest.Partial) -> CreateProblemRequest.Partial:
+    def _post_create_problem_request_validate(
+        cls, values: CreateProblemRequest.Partial
+    ) -> CreateProblemRequest.Partial:
         for validator in CreateProblemRequest.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_create_problem_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_create_problem_request.py
@@ -391,13 +391,13 @@ class CreateProblemRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_create_problem_request_validate(cls, values: CreateProblemRequest.Partial) -> CreateProblemRequest.Partial:
+    def _pre_validate_create_problem_request(cls, values: CreateProblemRequest.Partial) -> CreateProblemRequest.Partial:
         for validator in CreateProblemRequest.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_create_problem_request_validate(
+    def _post_validate_create_problem_request(
         cls, values: CreateProblemRequest.Partial
     ) -> CreateProblemRequest.Partial:
         for validator in CreateProblemRequest.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_generic_create_problem_error.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_generic_create_problem_error.py
@@ -203,13 +203,17 @@ class GenericCreateProblemError(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: GenericCreateProblemError.Partial) -> GenericCreateProblemError.Partial:
+    def _pregeneric_create_problem_error_validate(
+        cls, values: GenericCreateProblemError.Partial
+    ) -> GenericCreateProblemError.Partial:
         for validator in GenericCreateProblemError.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: GenericCreateProblemError.Partial) -> GenericCreateProblemError.Partial:
+    def _postgeneric_create_problem_error_validate(
+        cls, values: GenericCreateProblemError.Partial
+    ) -> GenericCreateProblemError.Partial:
         for validator in GenericCreateProblemError.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_generic_create_problem_error.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_generic_create_problem_error.py
@@ -203,7 +203,7 @@ class GenericCreateProblemError(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pregeneric_create_problem_error_validate(
+    def _pre_generic_create_problem_error_validate(
         cls, values: GenericCreateProblemError.Partial
     ) -> GenericCreateProblemError.Partial:
         for validator in GenericCreateProblemError.Validators._pre_validators:
@@ -211,7 +211,7 @@ class GenericCreateProblemError(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postgeneric_create_problem_error_validate(
+    def _post_generic_create_problem_error_validate(
         cls, values: GenericCreateProblemError.Partial
     ) -> GenericCreateProblemError.Partial:
         for validator in GenericCreateProblemError.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_generic_create_problem_error.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_generic_create_problem_error.py
@@ -203,7 +203,7 @@ class GenericCreateProblemError(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_generic_create_problem_error_validate(
+    def _pre_validate_generic_create_problem_error(
         cls, values: GenericCreateProblemError.Partial
     ) -> GenericCreateProblemError.Partial:
         for validator in GenericCreateProblemError.Validators._pre_validators:
@@ -211,7 +211,7 @@ class GenericCreateProblemError(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_generic_create_problem_error_validate(
+    def _post_validate_generic_create_problem_error(
         cls, values: GenericCreateProblemError.Partial
     ) -> GenericCreateProblemError.Partial:
         for validator in GenericCreateProblemError.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_get_default_starter_files_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_get_default_starter_files_response.py
@@ -125,7 +125,7 @@ class GetDefaultStarterFilesResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preget_default_starter_files_response_validate(
+    def _pre_get_default_starter_files_response_validate(
         cls, values: GetDefaultStarterFilesResponse.Partial
     ) -> GetDefaultStarterFilesResponse.Partial:
         for validator in GetDefaultStarterFilesResponse.Validators._pre_validators:
@@ -133,7 +133,7 @@ class GetDefaultStarterFilesResponse(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postget_default_starter_files_response_validate(
+    def _post_get_default_starter_files_response_validate(
         cls, values: GetDefaultStarterFilesResponse.Partial
     ) -> GetDefaultStarterFilesResponse.Partial:
         for validator in GetDefaultStarterFilesResponse.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_get_default_starter_files_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_get_default_starter_files_response.py
@@ -125,7 +125,7 @@ class GetDefaultStarterFilesResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_get_default_starter_files_response_validate(
+    def _pre_validate_get_default_starter_files_response(
         cls, values: GetDefaultStarterFilesResponse.Partial
     ) -> GetDefaultStarterFilesResponse.Partial:
         for validator in GetDefaultStarterFilesResponse.Validators._pre_validators:
@@ -133,7 +133,7 @@ class GetDefaultStarterFilesResponse(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_get_default_starter_files_response_validate(
+    def _post_validate_get_default_starter_files_response(
         cls, values: GetDefaultStarterFilesResponse.Partial
     ) -> GetDefaultStarterFilesResponse.Partial:
         for validator in GetDefaultStarterFilesResponse.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_get_default_starter_files_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_get_default_starter_files_response.py
@@ -125,13 +125,17 @@ class GetDefaultStarterFilesResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: GetDefaultStarterFilesResponse.Partial) -> GetDefaultStarterFilesResponse.Partial:
+    def _preget_default_starter_files_response_validate(
+        cls, values: GetDefaultStarterFilesResponse.Partial
+    ) -> GetDefaultStarterFilesResponse.Partial:
         for validator in GetDefaultStarterFilesResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: GetDefaultStarterFilesResponse.Partial) -> GetDefaultStarterFilesResponse.Partial:
+    def _postget_default_starter_files_response_validate(
+        cls, values: GetDefaultStarterFilesResponse.Partial
+    ) -> GetDefaultStarterFilesResponse.Partial:
         for validator in GetDefaultStarterFilesResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_problem_description.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_problem_description.py
@@ -114,13 +114,13 @@ class ProblemDescription(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_problem_description_validate(cls, values: ProblemDescription.Partial) -> ProblemDescription.Partial:
+    def _pre_validate_problem_description(cls, values: ProblemDescription.Partial) -> ProblemDescription.Partial:
         for validator in ProblemDescription.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_problem_description_validate(cls, values: ProblemDescription.Partial) -> ProblemDescription.Partial:
+    def _post_validate_problem_description(cls, values: ProblemDescription.Partial) -> ProblemDescription.Partial:
         for validator in ProblemDescription.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_problem_description.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_problem_description.py
@@ -114,13 +114,13 @@ class ProblemDescription(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: ProblemDescription.Partial) -> ProblemDescription.Partial:
+    def _preproblem_description_validate(cls, values: ProblemDescription.Partial) -> ProblemDescription.Partial:
         for validator in ProblemDescription.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: ProblemDescription.Partial) -> ProblemDescription.Partial:
+    def _postproblem_description_validate(cls, values: ProblemDescription.Partial) -> ProblemDescription.Partial:
         for validator in ProblemDescription.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_problem_description.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_problem_description.py
@@ -114,13 +114,13 @@ class ProblemDescription(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preproblem_description_validate(cls, values: ProblemDescription.Partial) -> ProblemDescription.Partial:
+    def _pre_problem_description_validate(cls, values: ProblemDescription.Partial) -> ProblemDescription.Partial:
         for validator in ProblemDescription.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postproblem_description_validate(cls, values: ProblemDescription.Partial) -> ProblemDescription.Partial:
+    def _post_problem_description_validate(cls, values: ProblemDescription.Partial) -> ProblemDescription.Partial:
         for validator in ProblemDescription.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_problem_files.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_problem_files.py
@@ -159,13 +159,13 @@ class ProblemFiles(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preproblem_files_validate(cls, values: ProblemFiles.Partial) -> ProblemFiles.Partial:
+    def _pre_problem_files_validate(cls, values: ProblemFiles.Partial) -> ProblemFiles.Partial:
         for validator in ProblemFiles.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postproblem_files_validate(cls, values: ProblemFiles.Partial) -> ProblemFiles.Partial:
+    def _post_problem_files_validate(cls, values: ProblemFiles.Partial) -> ProblemFiles.Partial:
         for validator in ProblemFiles.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_problem_files.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_problem_files.py
@@ -159,13 +159,13 @@ class ProblemFiles(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_problem_files_validate(cls, values: ProblemFiles.Partial) -> ProblemFiles.Partial:
+    def _pre_validate_problem_files(cls, values: ProblemFiles.Partial) -> ProblemFiles.Partial:
         for validator in ProblemFiles.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_problem_files_validate(cls, values: ProblemFiles.Partial) -> ProblemFiles.Partial:
+    def _post_validate_problem_files(cls, values: ProblemFiles.Partial) -> ProblemFiles.Partial:
         for validator in ProblemFiles.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_problem_files.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_problem_files.py
@@ -159,13 +159,13 @@ class ProblemFiles(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: ProblemFiles.Partial) -> ProblemFiles.Partial:
+    def _preproblem_files_validate(cls, values: ProblemFiles.Partial) -> ProblemFiles.Partial:
         for validator in ProblemFiles.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: ProblemFiles.Partial) -> ProblemFiles.Partial:
+    def _postproblem_files_validate(cls, values: ProblemFiles.Partial) -> ProblemFiles.Partial:
         for validator in ProblemFiles.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_problem_info.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_problem_info.py
@@ -486,13 +486,13 @@ class ProblemInfo(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: ProblemInfo.Partial) -> ProblemInfo.Partial:
+    def _preproblem_info_validate(cls, values: ProblemInfo.Partial) -> ProblemInfo.Partial:
         for validator in ProblemInfo.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: ProblemInfo.Partial) -> ProblemInfo.Partial:
+    def _postproblem_info_validate(cls, values: ProblemInfo.Partial) -> ProblemInfo.Partial:
         for validator in ProblemInfo.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_problem_info.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_problem_info.py
@@ -486,13 +486,13 @@ class ProblemInfo(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_problem_info_validate(cls, values: ProblemInfo.Partial) -> ProblemInfo.Partial:
+    def _pre_validate_problem_info(cls, values: ProblemInfo.Partial) -> ProblemInfo.Partial:
         for validator in ProblemInfo.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_problem_info_validate(cls, values: ProblemInfo.Partial) -> ProblemInfo.Partial:
+    def _post_validate_problem_info(cls, values: ProblemInfo.Partial) -> ProblemInfo.Partial:
         for validator in ProblemInfo.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_problem_info.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_problem_info.py
@@ -486,13 +486,13 @@ class ProblemInfo(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preproblem_info_validate(cls, values: ProblemInfo.Partial) -> ProblemInfo.Partial:
+    def _pre_problem_info_validate(cls, values: ProblemInfo.Partial) -> ProblemInfo.Partial:
         for validator in ProblemInfo.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postproblem_info_validate(cls, values: ProblemInfo.Partial) -> ProblemInfo.Partial:
+    def _post_problem_info_validate(cls, values: ProblemInfo.Partial) -> ProblemInfo.Partial:
         for validator in ProblemInfo.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_update_problem_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_update_problem_response.py
@@ -120,7 +120,7 @@ class UpdateProblemResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preupdate_problem_response_validate(
+    def _pre_update_problem_response_validate(
         cls, values: UpdateProblemResponse.Partial
     ) -> UpdateProblemResponse.Partial:
         for validator in UpdateProblemResponse.Validators._pre_validators:
@@ -128,7 +128,7 @@ class UpdateProblemResponse(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postupdate_problem_response_validate(
+    def _post_update_problem_response_validate(
         cls, values: UpdateProblemResponse.Partial
     ) -> UpdateProblemResponse.Partial:
         for validator in UpdateProblemResponse.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_update_problem_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_update_problem_response.py
@@ -120,7 +120,7 @@ class UpdateProblemResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_update_problem_response_validate(
+    def _pre_validate_update_problem_response(
         cls, values: UpdateProblemResponse.Partial
     ) -> UpdateProblemResponse.Partial:
         for validator in UpdateProblemResponse.Validators._pre_validators:
@@ -128,7 +128,7 @@ class UpdateProblemResponse(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_update_problem_response_validate(
+    def _post_validate_update_problem_response(
         cls, values: UpdateProblemResponse.Partial
     ) -> UpdateProblemResponse.Partial:
         for validator in UpdateProblemResponse.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_update_problem_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_update_problem_response.py
@@ -120,13 +120,17 @@ class UpdateProblemResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: UpdateProblemResponse.Partial) -> UpdateProblemResponse.Partial:
+    def _preupdate_problem_response_validate(
+        cls, values: UpdateProblemResponse.Partial
+    ) -> UpdateProblemResponse.Partial:
         for validator in UpdateProblemResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: UpdateProblemResponse.Partial) -> UpdateProblemResponse.Partial:
+    def _postupdate_problem_response_validate(
+        cls, values: UpdateProblemResponse.Partial
+    ) -> UpdateProblemResponse.Partial:
         for validator in UpdateProblemResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_variable_type_and_name.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_variable_type_and_name.py
@@ -159,13 +159,13 @@ class VariableTypeAndName(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_variable_type_and_name_validate(cls, values: VariableTypeAndName.Partial) -> VariableTypeAndName.Partial:
+    def _pre_validate_variable_type_and_name(cls, values: VariableTypeAndName.Partial) -> VariableTypeAndName.Partial:
         for validator in VariableTypeAndName.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_variable_type_and_name_validate(cls, values: VariableTypeAndName.Partial) -> VariableTypeAndName.Partial:
+    def _post_validate_variable_type_and_name(cls, values: VariableTypeAndName.Partial) -> VariableTypeAndName.Partial:
         for validator in VariableTypeAndName.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_variable_type_and_name.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_variable_type_and_name.py
@@ -159,13 +159,13 @@ class VariableTypeAndName(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: VariableTypeAndName.Partial) -> VariableTypeAndName.Partial:
+    def _prevariable_type_and_name_validate(cls, values: VariableTypeAndName.Partial) -> VariableTypeAndName.Partial:
         for validator in VariableTypeAndName.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: VariableTypeAndName.Partial) -> VariableTypeAndName.Partial:
+    def _postvariable_type_and_name_validate(cls, values: VariableTypeAndName.Partial) -> VariableTypeAndName.Partial:
         for validator in VariableTypeAndName.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_variable_type_and_name.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_problem_types_variable_type_and_name.py
@@ -159,13 +159,13 @@ class VariableTypeAndName(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prevariable_type_and_name_validate(cls, values: VariableTypeAndName.Partial) -> VariableTypeAndName.Partial:
+    def _pre_variable_type_and_name_validate(cls, values: VariableTypeAndName.Partial) -> VariableTypeAndName.Partial:
         for validator in VariableTypeAndName.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postvariable_type_and_name_validate(cls, values: VariableTypeAndName.Partial) -> VariableTypeAndName.Partial:
+    def _post_variable_type_and_name_validate(cls, values: VariableTypeAndName.Partial) -> VariableTypeAndName.Partial:
         for validator in VariableTypeAndName.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_building_executor_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_building_executor_response.py
@@ -167,13 +167,17 @@ class BuildingExecutorResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: BuildingExecutorResponse.Partial) -> BuildingExecutorResponse.Partial:
+    def _prebuilding_executor_response_validate(
+        cls, values: BuildingExecutorResponse.Partial
+    ) -> BuildingExecutorResponse.Partial:
         for validator in BuildingExecutorResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: BuildingExecutorResponse.Partial) -> BuildingExecutorResponse.Partial:
+    def _postbuilding_executor_response_validate(
+        cls, values: BuildingExecutorResponse.Partial
+    ) -> BuildingExecutorResponse.Partial:
         for validator in BuildingExecutorResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_building_executor_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_building_executor_response.py
@@ -167,7 +167,7 @@ class BuildingExecutorResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_building_executor_response_validate(
+    def _pre_validate_building_executor_response(
         cls, values: BuildingExecutorResponse.Partial
     ) -> BuildingExecutorResponse.Partial:
         for validator in BuildingExecutorResponse.Validators._pre_validators:
@@ -175,7 +175,7 @@ class BuildingExecutorResponse(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_building_executor_response_validate(
+    def _post_validate_building_executor_response(
         cls, values: BuildingExecutorResponse.Partial
     ) -> BuildingExecutorResponse.Partial:
         for validator in BuildingExecutorResponse.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_building_executor_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_building_executor_response.py
@@ -167,7 +167,7 @@ class BuildingExecutorResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prebuilding_executor_response_validate(
+    def _pre_building_executor_response_validate(
         cls, values: BuildingExecutorResponse.Partial
     ) -> BuildingExecutorResponse.Partial:
         for validator in BuildingExecutorResponse.Validators._pre_validators:
@@ -175,7 +175,7 @@ class BuildingExecutorResponse(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postbuilding_executor_response_validate(
+    def _post_building_executor_response_validate(
         cls, values: BuildingExecutorResponse.Partial
     ) -> BuildingExecutorResponse.Partial:
         for validator in BuildingExecutorResponse.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_compile_error.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_compile_error.py
@@ -105,13 +105,13 @@ class CompileError(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: CompileError.Partial) -> CompileError.Partial:
+    def _precompile_error_validate(cls, values: CompileError.Partial) -> CompileError.Partial:
         for validator in CompileError.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: CompileError.Partial) -> CompileError.Partial:
+    def _postcompile_error_validate(cls, values: CompileError.Partial) -> CompileError.Partial:
         for validator in CompileError.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_compile_error.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_compile_error.py
@@ -105,13 +105,13 @@ class CompileError(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _precompile_error_validate(cls, values: CompileError.Partial) -> CompileError.Partial:
+    def _pre_compile_error_validate(cls, values: CompileError.Partial) -> CompileError.Partial:
         for validator in CompileError.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postcompile_error_validate(cls, values: CompileError.Partial) -> CompileError.Partial:
+    def _post_compile_error_validate(cls, values: CompileError.Partial) -> CompileError.Partial:
         for validator in CompileError.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_compile_error.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_compile_error.py
@@ -105,13 +105,13 @@ class CompileError(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_compile_error_validate(cls, values: CompileError.Partial) -> CompileError.Partial:
+    def _pre_validate_compile_error(cls, values: CompileError.Partial) -> CompileError.Partial:
         for validator in CompileError.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_compile_error_validate(cls, values: CompileError.Partial) -> CompileError.Partial:
+    def _post_validate_compile_error(cls, values: CompileError.Partial) -> CompileError.Partial:
         for validator in CompileError.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_custom_test_cases_unsupported.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_custom_test_cases_unsupported.py
@@ -168,7 +168,7 @@ class CustomTestCasesUnsupported(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _precustom_test_cases_unsupported_validate(
+    def _pre_custom_test_cases_unsupported_validate(
         cls, values: CustomTestCasesUnsupported.Partial
     ) -> CustomTestCasesUnsupported.Partial:
         for validator in CustomTestCasesUnsupported.Validators._pre_validators:
@@ -176,7 +176,7 @@ class CustomTestCasesUnsupported(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postcustom_test_cases_unsupported_validate(
+    def _post_custom_test_cases_unsupported_validate(
         cls, values: CustomTestCasesUnsupported.Partial
     ) -> CustomTestCasesUnsupported.Partial:
         for validator in CustomTestCasesUnsupported.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_custom_test_cases_unsupported.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_custom_test_cases_unsupported.py
@@ -168,13 +168,17 @@ class CustomTestCasesUnsupported(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: CustomTestCasesUnsupported.Partial) -> CustomTestCasesUnsupported.Partial:
+    def _precustom_test_cases_unsupported_validate(
+        cls, values: CustomTestCasesUnsupported.Partial
+    ) -> CustomTestCasesUnsupported.Partial:
         for validator in CustomTestCasesUnsupported.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: CustomTestCasesUnsupported.Partial) -> CustomTestCasesUnsupported.Partial:
+    def _postcustom_test_cases_unsupported_validate(
+        cls, values: CustomTestCasesUnsupported.Partial
+    ) -> CustomTestCasesUnsupported.Partial:
         for validator in CustomTestCasesUnsupported.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_custom_test_cases_unsupported.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_custom_test_cases_unsupported.py
@@ -168,7 +168,7 @@ class CustomTestCasesUnsupported(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_custom_test_cases_unsupported_validate(
+    def _pre_validate_custom_test_cases_unsupported(
         cls, values: CustomTestCasesUnsupported.Partial
     ) -> CustomTestCasesUnsupported.Partial:
         for validator in CustomTestCasesUnsupported.Validators._pre_validators:
@@ -176,7 +176,7 @@ class CustomTestCasesUnsupported(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_custom_test_cases_unsupported_validate(
+    def _post_validate_custom_test_cases_unsupported(
         cls, values: CustomTestCasesUnsupported.Partial
     ) -> CustomTestCasesUnsupported.Partial:
         for validator in CustomTestCasesUnsupported.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_errored_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_errored_response.py
@@ -157,13 +157,13 @@ class ErroredResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: ErroredResponse.Partial) -> ErroredResponse.Partial:
+    def _preerrored_response_validate(cls, values: ErroredResponse.Partial) -> ErroredResponse.Partial:
         for validator in ErroredResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: ErroredResponse.Partial) -> ErroredResponse.Partial:
+    def _posterrored_response_validate(cls, values: ErroredResponse.Partial) -> ErroredResponse.Partial:
         for validator in ErroredResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_errored_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_errored_response.py
@@ -157,13 +157,13 @@ class ErroredResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_errored_response_validate(cls, values: ErroredResponse.Partial) -> ErroredResponse.Partial:
+    def _pre_validate_errored_response(cls, values: ErroredResponse.Partial) -> ErroredResponse.Partial:
         for validator in ErroredResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_errored_response_validate(cls, values: ErroredResponse.Partial) -> ErroredResponse.Partial:
+    def _post_validate_errored_response(cls, values: ErroredResponse.Partial) -> ErroredResponse.Partial:
         for validator in ErroredResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_errored_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_errored_response.py
@@ -157,13 +157,13 @@ class ErroredResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preerrored_response_validate(cls, values: ErroredResponse.Partial) -> ErroredResponse.Partial:
+    def _pre_errored_response_validate(cls, values: ErroredResponse.Partial) -> ErroredResponse.Partial:
         for validator in ErroredResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _posterrored_response_validate(cls, values: ErroredResponse.Partial) -> ErroredResponse.Partial:
+    def _post_errored_response_validate(cls, values: ErroredResponse.Partial) -> ErroredResponse.Partial:
         for validator in ErroredResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_exception_info.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_exception_info.py
@@ -209,13 +209,13 @@ class ExceptionInfo(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: ExceptionInfo.Partial) -> ExceptionInfo.Partial:
+    def _preexception_info_validate(cls, values: ExceptionInfo.Partial) -> ExceptionInfo.Partial:
         for validator in ExceptionInfo.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: ExceptionInfo.Partial) -> ExceptionInfo.Partial:
+    def _postexception_info_validate(cls, values: ExceptionInfo.Partial) -> ExceptionInfo.Partial:
         for validator in ExceptionInfo.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_exception_info.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_exception_info.py
@@ -209,13 +209,13 @@ class ExceptionInfo(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_exception_info_validate(cls, values: ExceptionInfo.Partial) -> ExceptionInfo.Partial:
+    def _pre_validate_exception_info(cls, values: ExceptionInfo.Partial) -> ExceptionInfo.Partial:
         for validator in ExceptionInfo.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_exception_info_validate(cls, values: ExceptionInfo.Partial) -> ExceptionInfo.Partial:
+    def _post_validate_exception_info(cls, values: ExceptionInfo.Partial) -> ExceptionInfo.Partial:
         for validator in ExceptionInfo.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_exception_info.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_exception_info.py
@@ -209,13 +209,13 @@ class ExceptionInfo(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preexception_info_validate(cls, values: ExceptionInfo.Partial) -> ExceptionInfo.Partial:
+    def _pre_exception_info_validate(cls, values: ExceptionInfo.Partial) -> ExceptionInfo.Partial:
         for validator in ExceptionInfo.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postexception_info_validate(cls, values: ExceptionInfo.Partial) -> ExceptionInfo.Partial:
+    def _post_exception_info_validate(cls, values: ExceptionInfo.Partial) -> ExceptionInfo.Partial:
         for validator in ExceptionInfo.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_execution_session_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_execution_session_response.py
@@ -259,7 +259,7 @@ class ExecutionSessionResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preexecution_session_response_validate(
+    def _pre_execution_session_response_validate(
         cls, values: ExecutionSessionResponse.Partial
     ) -> ExecutionSessionResponse.Partial:
         for validator in ExecutionSessionResponse.Validators._pre_validators:
@@ -267,7 +267,7 @@ class ExecutionSessionResponse(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postexecution_session_response_validate(
+    def _post_execution_session_response_validate(
         cls, values: ExecutionSessionResponse.Partial
     ) -> ExecutionSessionResponse.Partial:
         for validator in ExecutionSessionResponse.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_execution_session_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_execution_session_response.py
@@ -259,7 +259,7 @@ class ExecutionSessionResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_execution_session_response_validate(
+    def _pre_validate_execution_session_response(
         cls, values: ExecutionSessionResponse.Partial
     ) -> ExecutionSessionResponse.Partial:
         for validator in ExecutionSessionResponse.Validators._pre_validators:
@@ -267,7 +267,7 @@ class ExecutionSessionResponse(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_execution_session_response_validate(
+    def _post_validate_execution_session_response(
         cls, values: ExecutionSessionResponse.Partial
     ) -> ExecutionSessionResponse.Partial:
         for validator in ExecutionSessionResponse.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_execution_session_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_execution_session_response.py
@@ -259,13 +259,17 @@ class ExecutionSessionResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: ExecutionSessionResponse.Partial) -> ExecutionSessionResponse.Partial:
+    def _preexecution_session_response_validate(
+        cls, values: ExecutionSessionResponse.Partial
+    ) -> ExecutionSessionResponse.Partial:
         for validator in ExecutionSessionResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: ExecutionSessionResponse.Partial) -> ExecutionSessionResponse.Partial:
+    def _postexecution_session_response_validate(
+        cls, values: ExecutionSessionResponse.Partial
+    ) -> ExecutionSessionResponse.Partial:
         for validator in ExecutionSessionResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_execution_session_state.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_execution_session_state.py
@@ -347,7 +347,7 @@ class ExecutionSessionState(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_execution_session_state_validate(
+    def _pre_validate_execution_session_state(
         cls, values: ExecutionSessionState.Partial
     ) -> ExecutionSessionState.Partial:
         for validator in ExecutionSessionState.Validators._pre_validators:
@@ -355,7 +355,7 @@ class ExecutionSessionState(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_execution_session_state_validate(
+    def _post_validate_execution_session_state(
         cls, values: ExecutionSessionState.Partial
     ) -> ExecutionSessionState.Partial:
         for validator in ExecutionSessionState.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_execution_session_state.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_execution_session_state.py
@@ -347,13 +347,17 @@ class ExecutionSessionState(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: ExecutionSessionState.Partial) -> ExecutionSessionState.Partial:
+    def _preexecution_session_state_validate(
+        cls, values: ExecutionSessionState.Partial
+    ) -> ExecutionSessionState.Partial:
         for validator in ExecutionSessionState.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: ExecutionSessionState.Partial) -> ExecutionSessionState.Partial:
+    def _postexecution_session_state_validate(
+        cls, values: ExecutionSessionState.Partial
+    ) -> ExecutionSessionState.Partial:
         for validator in ExecutionSessionState.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_execution_session_state.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_execution_session_state.py
@@ -347,7 +347,7 @@ class ExecutionSessionState(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preexecution_session_state_validate(
+    def _pre_execution_session_state_validate(
         cls, values: ExecutionSessionState.Partial
     ) -> ExecutionSessionState.Partial:
         for validator in ExecutionSessionState.Validators._pre_validators:
@@ -355,7 +355,7 @@ class ExecutionSessionState(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postexecution_session_state_validate(
+    def _post_execution_session_state_validate(
         cls, values: ExecutionSessionState.Partial
     ) -> ExecutionSessionState.Partial:
         for validator in ExecutionSessionState.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_existing_submission_executing.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_existing_submission_executing.py
@@ -123,7 +123,7 @@ class ExistingSubmissionExecuting(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_existing_submission_executing_validate(
+    def _pre_validate_existing_submission_executing(
         cls, values: ExistingSubmissionExecuting.Partial
     ) -> ExistingSubmissionExecuting.Partial:
         for validator in ExistingSubmissionExecuting.Validators._pre_validators:
@@ -131,7 +131,7 @@ class ExistingSubmissionExecuting(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_existing_submission_executing_validate(
+    def _post_validate_existing_submission_executing(
         cls, values: ExistingSubmissionExecuting.Partial
     ) -> ExistingSubmissionExecuting.Partial:
         for validator in ExistingSubmissionExecuting.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_existing_submission_executing.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_existing_submission_executing.py
@@ -123,13 +123,17 @@ class ExistingSubmissionExecuting(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: ExistingSubmissionExecuting.Partial) -> ExistingSubmissionExecuting.Partial:
+    def _preexisting_submission_executing_validate(
+        cls, values: ExistingSubmissionExecuting.Partial
+    ) -> ExistingSubmissionExecuting.Partial:
         for validator in ExistingSubmissionExecuting.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: ExistingSubmissionExecuting.Partial) -> ExistingSubmissionExecuting.Partial:
+    def _postexisting_submission_executing_validate(
+        cls, values: ExistingSubmissionExecuting.Partial
+    ) -> ExistingSubmissionExecuting.Partial:
         for validator in ExistingSubmissionExecuting.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_existing_submission_executing.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_existing_submission_executing.py
@@ -123,7 +123,7 @@ class ExistingSubmissionExecuting(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preexisting_submission_executing_validate(
+    def _pre_existing_submission_executing_validate(
         cls, values: ExistingSubmissionExecuting.Partial
     ) -> ExistingSubmissionExecuting.Partial:
         for validator in ExistingSubmissionExecuting.Validators._pre_validators:
@@ -131,7 +131,7 @@ class ExistingSubmissionExecuting(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postexisting_submission_executing_validate(
+    def _post_existing_submission_executing_validate(
         cls, values: ExistingSubmissionExecuting.Partial
     ) -> ExistingSubmissionExecuting.Partial:
         for validator in ExistingSubmissionExecuting.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_expression_location.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_expression_location.py
@@ -150,13 +150,13 @@ class ExpressionLocation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_expression_location_validate(cls, values: ExpressionLocation.Partial) -> ExpressionLocation.Partial:
+    def _pre_validate_expression_location(cls, values: ExpressionLocation.Partial) -> ExpressionLocation.Partial:
         for validator in ExpressionLocation.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_expression_location_validate(cls, values: ExpressionLocation.Partial) -> ExpressionLocation.Partial:
+    def _post_validate_expression_location(cls, values: ExpressionLocation.Partial) -> ExpressionLocation.Partial:
         for validator in ExpressionLocation.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_expression_location.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_expression_location.py
@@ -150,13 +150,13 @@ class ExpressionLocation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preexpression_location_validate(cls, values: ExpressionLocation.Partial) -> ExpressionLocation.Partial:
+    def _pre_expression_location_validate(cls, values: ExpressionLocation.Partial) -> ExpressionLocation.Partial:
         for validator in ExpressionLocation.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postexpression_location_validate(cls, values: ExpressionLocation.Partial) -> ExpressionLocation.Partial:
+    def _post_expression_location_validate(cls, values: ExpressionLocation.Partial) -> ExpressionLocation.Partial:
         for validator in ExpressionLocation.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_expression_location.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_expression_location.py
@@ -150,13 +150,13 @@ class ExpressionLocation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: ExpressionLocation.Partial) -> ExpressionLocation.Partial:
+    def _preexpression_location_validate(cls, values: ExpressionLocation.Partial) -> ExpressionLocation.Partial:
         for validator in ExpressionLocation.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: ExpressionLocation.Partial) -> ExpressionLocation.Partial:
+    def _postexpression_location_validate(cls, values: ExpressionLocation.Partial) -> ExpressionLocation.Partial:
         for validator in ExpressionLocation.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_finished_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_finished_response.py
@@ -117,13 +117,13 @@ class FinishedResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prefinished_response_validate(cls, values: FinishedResponse.Partial) -> FinishedResponse.Partial:
+    def _pre_finished_response_validate(cls, values: FinishedResponse.Partial) -> FinishedResponse.Partial:
         for validator in FinishedResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postfinished_response_validate(cls, values: FinishedResponse.Partial) -> FinishedResponse.Partial:
+    def _post_finished_response_validate(cls, values: FinishedResponse.Partial) -> FinishedResponse.Partial:
         for validator in FinishedResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_finished_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_finished_response.py
@@ -117,13 +117,13 @@ class FinishedResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: FinishedResponse.Partial) -> FinishedResponse.Partial:
+    def _prefinished_response_validate(cls, values: FinishedResponse.Partial) -> FinishedResponse.Partial:
         for validator in FinishedResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: FinishedResponse.Partial) -> FinishedResponse.Partial:
+    def _postfinished_response_validate(cls, values: FinishedResponse.Partial) -> FinishedResponse.Partial:
         for validator in FinishedResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_finished_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_finished_response.py
@@ -117,13 +117,13 @@ class FinishedResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_finished_response_validate(cls, values: FinishedResponse.Partial) -> FinishedResponse.Partial:
+    def _pre_validate_finished_response(cls, values: FinishedResponse.Partial) -> FinishedResponse.Partial:
         for validator in FinishedResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_finished_response_validate(cls, values: FinishedResponse.Partial) -> FinishedResponse.Partial:
+    def _post_validate_finished_response(cls, values: FinishedResponse.Partial) -> FinishedResponse.Partial:
         for validator in FinishedResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_get_execution_session_state_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_get_execution_session_state_response.py
@@ -226,7 +226,7 @@ class GetExecutionSessionStateResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(
+    def _preget_execution_session_state_response_validate(
         cls, values: GetExecutionSessionStateResponse.Partial
     ) -> GetExecutionSessionStateResponse.Partial:
         for validator in GetExecutionSessionStateResponse.Validators._pre_validators:
@@ -234,7 +234,7 @@ class GetExecutionSessionStateResponse(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(
+    def _postget_execution_session_state_response_validate(
         cls, values: GetExecutionSessionStateResponse.Partial
     ) -> GetExecutionSessionStateResponse.Partial:
         for validator in GetExecutionSessionStateResponse.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_get_execution_session_state_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_get_execution_session_state_response.py
@@ -226,7 +226,7 @@ class GetExecutionSessionStateResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_get_execution_session_state_response_validate(
+    def _pre_validate_get_execution_session_state_response(
         cls, values: GetExecutionSessionStateResponse.Partial
     ) -> GetExecutionSessionStateResponse.Partial:
         for validator in GetExecutionSessionStateResponse.Validators._pre_validators:
@@ -234,7 +234,7 @@ class GetExecutionSessionStateResponse(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_get_execution_session_state_response_validate(
+    def _post_validate_get_execution_session_state_response(
         cls, values: GetExecutionSessionStateResponse.Partial
     ) -> GetExecutionSessionStateResponse.Partial:
         for validator in GetExecutionSessionStateResponse.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_get_execution_session_state_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_get_execution_session_state_response.py
@@ -226,7 +226,7 @@ class GetExecutionSessionStateResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preget_execution_session_state_response_validate(
+    def _pre_get_execution_session_state_response_validate(
         cls, values: GetExecutionSessionStateResponse.Partial
     ) -> GetExecutionSessionStateResponse.Partial:
         for validator in GetExecutionSessionStateResponse.Validators._pre_validators:
@@ -234,7 +234,7 @@ class GetExecutionSessionStateResponse(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postget_execution_session_state_response_validate(
+    def _post_get_execution_session_state_response_validate(
         cls, values: GetExecutionSessionStateResponse.Partial
     ) -> GetExecutionSessionStateResponse.Partial:
         for validator in GetExecutionSessionStateResponse.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_get_submission_state_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_get_submission_state_response.py
@@ -265,13 +265,17 @@ class GetSubmissionStateResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: GetSubmissionStateResponse.Partial) -> GetSubmissionStateResponse.Partial:
+    def _preget_submission_state_response_validate(
+        cls, values: GetSubmissionStateResponse.Partial
+    ) -> GetSubmissionStateResponse.Partial:
         for validator in GetSubmissionStateResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: GetSubmissionStateResponse.Partial) -> GetSubmissionStateResponse.Partial:
+    def _postget_submission_state_response_validate(
+        cls, values: GetSubmissionStateResponse.Partial
+    ) -> GetSubmissionStateResponse.Partial:
         for validator in GetSubmissionStateResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_get_submission_state_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_get_submission_state_response.py
@@ -265,7 +265,7 @@ class GetSubmissionStateResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_get_submission_state_response_validate(
+    def _pre_validate_get_submission_state_response(
         cls, values: GetSubmissionStateResponse.Partial
     ) -> GetSubmissionStateResponse.Partial:
         for validator in GetSubmissionStateResponse.Validators._pre_validators:
@@ -273,7 +273,7 @@ class GetSubmissionStateResponse(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_get_submission_state_response_validate(
+    def _post_validate_get_submission_state_response(
         cls, values: GetSubmissionStateResponse.Partial
     ) -> GetSubmissionStateResponse.Partial:
         for validator in GetSubmissionStateResponse.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_get_submission_state_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_get_submission_state_response.py
@@ -265,7 +265,7 @@ class GetSubmissionStateResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preget_submission_state_response_validate(
+    def _pre_get_submission_state_response_validate(
         cls, values: GetSubmissionStateResponse.Partial
     ) -> GetSubmissionStateResponse.Partial:
         for validator in GetSubmissionStateResponse.Validators._pre_validators:
@@ -273,7 +273,7 @@ class GetSubmissionStateResponse(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postget_submission_state_response_validate(
+    def _post_get_submission_state_response_validate(
         cls, values: GetSubmissionStateResponse.Partial
     ) -> GetSubmissionStateResponse.Partial:
         for validator in GetSubmissionStateResponse.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_get_trace_responses_page_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_get_trace_responses_page_request.py
@@ -121,7 +121,7 @@ class GetTraceResponsesPageRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preget_trace_responses_page_request_validate(
+    def _pre_get_trace_responses_page_request_validate(
         cls, values: GetTraceResponsesPageRequest.Partial
     ) -> GetTraceResponsesPageRequest.Partial:
         for validator in GetTraceResponsesPageRequest.Validators._pre_validators:
@@ -129,7 +129,7 @@ class GetTraceResponsesPageRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postget_trace_responses_page_request_validate(
+    def _post_get_trace_responses_page_request_validate(
         cls, values: GetTraceResponsesPageRequest.Partial
     ) -> GetTraceResponsesPageRequest.Partial:
         for validator in GetTraceResponsesPageRequest.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_get_trace_responses_page_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_get_trace_responses_page_request.py
@@ -121,13 +121,17 @@ class GetTraceResponsesPageRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: GetTraceResponsesPageRequest.Partial) -> GetTraceResponsesPageRequest.Partial:
+    def _preget_trace_responses_page_request_validate(
+        cls, values: GetTraceResponsesPageRequest.Partial
+    ) -> GetTraceResponsesPageRequest.Partial:
         for validator in GetTraceResponsesPageRequest.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: GetTraceResponsesPageRequest.Partial) -> GetTraceResponsesPageRequest.Partial:
+    def _postget_trace_responses_page_request_validate(
+        cls, values: GetTraceResponsesPageRequest.Partial
+    ) -> GetTraceResponsesPageRequest.Partial:
         for validator in GetTraceResponsesPageRequest.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_get_trace_responses_page_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_get_trace_responses_page_request.py
@@ -121,7 +121,7 @@ class GetTraceResponsesPageRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_get_trace_responses_page_request_validate(
+    def _pre_validate_get_trace_responses_page_request(
         cls, values: GetTraceResponsesPageRequest.Partial
     ) -> GetTraceResponsesPageRequest.Partial:
         for validator in GetTraceResponsesPageRequest.Validators._pre_validators:
@@ -129,7 +129,7 @@ class GetTraceResponsesPageRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_get_trace_responses_page_request_validate(
+    def _post_validate_get_trace_responses_page_request(
         cls, values: GetTraceResponsesPageRequest.Partial
     ) -> GetTraceResponsesPageRequest.Partial:
         for validator in GetTraceResponsesPageRequest.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_graded_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_graded_response.py
@@ -159,13 +159,13 @@ class GradedResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: GradedResponse.Partial) -> GradedResponse.Partial:
+    def _pregraded_response_validate(cls, values: GradedResponse.Partial) -> GradedResponse.Partial:
         for validator in GradedResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: GradedResponse.Partial) -> GradedResponse.Partial:
+    def _postgraded_response_validate(cls, values: GradedResponse.Partial) -> GradedResponse.Partial:
         for validator in GradedResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_graded_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_graded_response.py
@@ -159,13 +159,13 @@ class GradedResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_graded_response_validate(cls, values: GradedResponse.Partial) -> GradedResponse.Partial:
+    def _pre_validate_graded_response(cls, values: GradedResponse.Partial) -> GradedResponse.Partial:
         for validator in GradedResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_graded_response_validate(cls, values: GradedResponse.Partial) -> GradedResponse.Partial:
+    def _post_validate_graded_response(cls, values: GradedResponse.Partial) -> GradedResponse.Partial:
         for validator in GradedResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_graded_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_graded_response.py
@@ -159,13 +159,13 @@ class GradedResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pregraded_response_validate(cls, values: GradedResponse.Partial) -> GradedResponse.Partial:
+    def _pre_graded_response_validate(cls, values: GradedResponse.Partial) -> GradedResponse.Partial:
         for validator in GradedResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postgraded_response_validate(cls, values: GradedResponse.Partial) -> GradedResponse.Partial:
+    def _post_graded_response_validate(cls, values: GradedResponse.Partial) -> GradedResponse.Partial:
         for validator in GradedResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_graded_response_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_graded_response_v_2.py
@@ -160,13 +160,13 @@ class GradedResponseV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pregraded_response_v_2_validate(cls, values: GradedResponseV2.Partial) -> GradedResponseV2.Partial:
+    def _pre_graded_response_v_2_validate(cls, values: GradedResponseV2.Partial) -> GradedResponseV2.Partial:
         for validator in GradedResponseV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postgraded_response_v_2_validate(cls, values: GradedResponseV2.Partial) -> GradedResponseV2.Partial:
+    def _post_graded_response_v_2_validate(cls, values: GradedResponseV2.Partial) -> GradedResponseV2.Partial:
         for validator in GradedResponseV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_graded_response_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_graded_response_v_2.py
@@ -160,13 +160,13 @@ class GradedResponseV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_graded_response_v_2_validate(cls, values: GradedResponseV2.Partial) -> GradedResponseV2.Partial:
+    def _pre_validate_graded_response_v_2(cls, values: GradedResponseV2.Partial) -> GradedResponseV2.Partial:
         for validator in GradedResponseV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_graded_response_v_2_validate(cls, values: GradedResponseV2.Partial) -> GradedResponseV2.Partial:
+    def _post_validate_graded_response_v_2(cls, values: GradedResponseV2.Partial) -> GradedResponseV2.Partial:
         for validator in GradedResponseV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_graded_response_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_graded_response_v_2.py
@@ -160,13 +160,13 @@ class GradedResponseV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: GradedResponseV2.Partial) -> GradedResponseV2.Partial:
+    def _pregraded_response_v_2_validate(cls, values: GradedResponseV2.Partial) -> GradedResponseV2.Partial:
         for validator in GradedResponseV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: GradedResponseV2.Partial) -> GradedResponseV2.Partial:
+    def _postgraded_response_v_2_validate(cls, values: GradedResponseV2.Partial) -> GradedResponseV2.Partial:
         for validator in GradedResponseV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_graded_test_case_update.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_graded_test_case_update.py
@@ -157,7 +157,7 @@ class GradedTestCaseUpdate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_graded_test_case_update_validate(
+    def _pre_validate_graded_test_case_update(
         cls, values: GradedTestCaseUpdate.Partial
     ) -> GradedTestCaseUpdate.Partial:
         for validator in GradedTestCaseUpdate.Validators._pre_validators:
@@ -165,7 +165,7 @@ class GradedTestCaseUpdate(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_graded_test_case_update_validate(
+    def _post_validate_graded_test_case_update(
         cls, values: GradedTestCaseUpdate.Partial
     ) -> GradedTestCaseUpdate.Partial:
         for validator in GradedTestCaseUpdate.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_graded_test_case_update.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_graded_test_case_update.py
@@ -157,13 +157,15 @@ class GradedTestCaseUpdate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: GradedTestCaseUpdate.Partial) -> GradedTestCaseUpdate.Partial:
+    def _pregraded_test_case_update_validate(cls, values: GradedTestCaseUpdate.Partial) -> GradedTestCaseUpdate.Partial:
         for validator in GradedTestCaseUpdate.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: GradedTestCaseUpdate.Partial) -> GradedTestCaseUpdate.Partial:
+    def _postgraded_test_case_update_validate(
+        cls, values: GradedTestCaseUpdate.Partial
+    ) -> GradedTestCaseUpdate.Partial:
         for validator in GradedTestCaseUpdate.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_graded_test_case_update.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_graded_test_case_update.py
@@ -157,13 +157,15 @@ class GradedTestCaseUpdate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pregraded_test_case_update_validate(cls, values: GradedTestCaseUpdate.Partial) -> GradedTestCaseUpdate.Partial:
+    def _pre_graded_test_case_update_validate(
+        cls, values: GradedTestCaseUpdate.Partial
+    ) -> GradedTestCaseUpdate.Partial:
         for validator in GradedTestCaseUpdate.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postgraded_test_case_update_validate(
+    def _post_graded_test_case_update_validate(
         cls, values: GradedTestCaseUpdate.Partial
     ) -> GradedTestCaseUpdate.Partial:
         for validator in GradedTestCaseUpdate.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_initialize_problem_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_initialize_problem_request.py
@@ -169,13 +169,17 @@ class InitializeProblemRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: InitializeProblemRequest.Partial) -> InitializeProblemRequest.Partial:
+    def _preinitialize_problem_request_validate(
+        cls, values: InitializeProblemRequest.Partial
+    ) -> InitializeProblemRequest.Partial:
         for validator in InitializeProblemRequest.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: InitializeProblemRequest.Partial) -> InitializeProblemRequest.Partial:
+    def _postinitialize_problem_request_validate(
+        cls, values: InitializeProblemRequest.Partial
+    ) -> InitializeProblemRequest.Partial:
         for validator in InitializeProblemRequest.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_initialize_problem_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_initialize_problem_request.py
@@ -169,7 +169,7 @@ class InitializeProblemRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_initialize_problem_request_validate(
+    def _pre_validate_initialize_problem_request(
         cls, values: InitializeProblemRequest.Partial
     ) -> InitializeProblemRequest.Partial:
         for validator in InitializeProblemRequest.Validators._pre_validators:
@@ -177,7 +177,7 @@ class InitializeProblemRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_initialize_problem_request_validate(
+    def _post_validate_initialize_problem_request(
         cls, values: InitializeProblemRequest.Partial
     ) -> InitializeProblemRequest.Partial:
         for validator in InitializeProblemRequest.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_initialize_problem_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_initialize_problem_request.py
@@ -169,7 +169,7 @@ class InitializeProblemRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preinitialize_problem_request_validate(
+    def _pre_initialize_problem_request_validate(
         cls, values: InitializeProblemRequest.Partial
     ) -> InitializeProblemRequest.Partial:
         for validator in InitializeProblemRequest.Validators._pre_validators:
@@ -177,7 +177,7 @@ class InitializeProblemRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postinitialize_problem_request_validate(
+    def _post_initialize_problem_request_validate(
         cls, values: InitializeProblemRequest.Partial
     ) -> InitializeProblemRequest.Partial:
         for validator in InitializeProblemRequest.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_internal_error.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_internal_error.py
@@ -115,13 +115,13 @@ class InternalError(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: InternalError.Partial) -> InternalError.Partial:
+    def _preinternal_error_validate(cls, values: InternalError.Partial) -> InternalError.Partial:
         for validator in InternalError.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: InternalError.Partial) -> InternalError.Partial:
+    def _postinternal_error_validate(cls, values: InternalError.Partial) -> InternalError.Partial:
         for validator in InternalError.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_internal_error.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_internal_error.py
@@ -115,13 +115,13 @@ class InternalError(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preinternal_error_validate(cls, values: InternalError.Partial) -> InternalError.Partial:
+    def _pre_internal_error_validate(cls, values: InternalError.Partial) -> InternalError.Partial:
         for validator in InternalError.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postinternal_error_validate(cls, values: InternalError.Partial) -> InternalError.Partial:
+    def _post_internal_error_validate(cls, values: InternalError.Partial) -> InternalError.Partial:
         for validator in InternalError.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_internal_error.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_internal_error.py
@@ -115,13 +115,13 @@ class InternalError(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_internal_error_validate(cls, values: InternalError.Partial) -> InternalError.Partial:
+    def _pre_validate_internal_error(cls, values: InternalError.Partial) -> InternalError.Partial:
         for validator in InternalError.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_internal_error_validate(cls, values: InternalError.Partial) -> InternalError.Partial:
+    def _post_validate_internal_error(cls, values: InternalError.Partial) -> InternalError.Partial:
         for validator in InternalError.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_invalid_request_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_invalid_request_response.py
@@ -157,7 +157,7 @@ class InvalidRequestResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_invalid_request_response_validate(
+    def _pre_validate_invalid_request_response(
         cls, values: InvalidRequestResponse.Partial
     ) -> InvalidRequestResponse.Partial:
         for validator in InvalidRequestResponse.Validators._pre_validators:
@@ -165,7 +165,7 @@ class InvalidRequestResponse(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_invalid_request_response_validate(
+    def _post_validate_invalid_request_response(
         cls, values: InvalidRequestResponse.Partial
     ) -> InvalidRequestResponse.Partial:
         for validator in InvalidRequestResponse.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_invalid_request_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_invalid_request_response.py
@@ -157,7 +157,7 @@ class InvalidRequestResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preinvalid_request_response_validate(
+    def _pre_invalid_request_response_validate(
         cls, values: InvalidRequestResponse.Partial
     ) -> InvalidRequestResponse.Partial:
         for validator in InvalidRequestResponse.Validators._pre_validators:
@@ -165,7 +165,7 @@ class InvalidRequestResponse(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postinvalid_request_response_validate(
+    def _post_invalid_request_response_validate(
         cls, values: InvalidRequestResponse.Partial
     ) -> InvalidRequestResponse.Partial:
         for validator in InvalidRequestResponse.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_invalid_request_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_invalid_request_response.py
@@ -157,13 +157,17 @@ class InvalidRequestResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: InvalidRequestResponse.Partial) -> InvalidRequestResponse.Partial:
+    def _preinvalid_request_response_validate(
+        cls, values: InvalidRequestResponse.Partial
+    ) -> InvalidRequestResponse.Partial:
         for validator in InvalidRequestResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: InvalidRequestResponse.Partial) -> InvalidRequestResponse.Partial:
+    def _postinvalid_request_response_validate(
+        cls, values: InvalidRequestResponse.Partial
+    ) -> InvalidRequestResponse.Partial:
         for validator in InvalidRequestResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_lightweight_stackframe_information.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_lightweight_stackframe_information.py
@@ -177,7 +177,7 @@ class LightweightStackframeInformation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_lightweight_stackframe_information_validate(
+    def _pre_validate_lightweight_stackframe_information(
         cls, values: LightweightStackframeInformation.Partial
     ) -> LightweightStackframeInformation.Partial:
         for validator in LightweightStackframeInformation.Validators._pre_validators:
@@ -185,7 +185,7 @@ class LightweightStackframeInformation(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_lightweight_stackframe_information_validate(
+    def _post_validate_lightweight_stackframe_information(
         cls, values: LightweightStackframeInformation.Partial
     ) -> LightweightStackframeInformation.Partial:
         for validator in LightweightStackframeInformation.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_lightweight_stackframe_information.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_lightweight_stackframe_information.py
@@ -177,7 +177,7 @@ class LightweightStackframeInformation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prelightweight_stackframe_information_validate(
+    def _pre_lightweight_stackframe_information_validate(
         cls, values: LightweightStackframeInformation.Partial
     ) -> LightweightStackframeInformation.Partial:
         for validator in LightweightStackframeInformation.Validators._pre_validators:
@@ -185,7 +185,7 @@ class LightweightStackframeInformation(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postlightweight_stackframe_information_validate(
+    def _post_lightweight_stackframe_information_validate(
         cls, values: LightweightStackframeInformation.Partial
     ) -> LightweightStackframeInformation.Partial:
         for validator in LightweightStackframeInformation.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_lightweight_stackframe_information.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_lightweight_stackframe_information.py
@@ -177,7 +177,7 @@ class LightweightStackframeInformation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(
+    def _prelightweight_stackframe_information_validate(
         cls, values: LightweightStackframeInformation.Partial
     ) -> LightweightStackframeInformation.Partial:
         for validator in LightweightStackframeInformation.Validators._pre_validators:
@@ -185,7 +185,7 @@ class LightweightStackframeInformation(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(
+    def _postlightweight_stackframe_information_validate(
         cls, values: LightweightStackframeInformation.Partial
     ) -> LightweightStackframeInformation.Partial:
         for validator in LightweightStackframeInformation.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_recorded_response_notification.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_recorded_response_notification.py
@@ -218,7 +218,7 @@ class RecordedResponseNotification(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prerecorded_response_notification_validate(
+    def _pre_recorded_response_notification_validate(
         cls, values: RecordedResponseNotification.Partial
     ) -> RecordedResponseNotification.Partial:
         for validator in RecordedResponseNotification.Validators._pre_validators:
@@ -226,7 +226,7 @@ class RecordedResponseNotification(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postrecorded_response_notification_validate(
+    def _post_recorded_response_notification_validate(
         cls, values: RecordedResponseNotification.Partial
     ) -> RecordedResponseNotification.Partial:
         for validator in RecordedResponseNotification.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_recorded_response_notification.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_recorded_response_notification.py
@@ -218,7 +218,7 @@ class RecordedResponseNotification(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_recorded_response_notification_validate(
+    def _pre_validate_recorded_response_notification(
         cls, values: RecordedResponseNotification.Partial
     ) -> RecordedResponseNotification.Partial:
         for validator in RecordedResponseNotification.Validators._pre_validators:
@@ -226,7 +226,7 @@ class RecordedResponseNotification(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_recorded_response_notification_validate(
+    def _post_validate_recorded_response_notification(
         cls, values: RecordedResponseNotification.Partial
     ) -> RecordedResponseNotification.Partial:
         for validator in RecordedResponseNotification.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_recorded_response_notification.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_recorded_response_notification.py
@@ -218,13 +218,17 @@ class RecordedResponseNotification(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: RecordedResponseNotification.Partial) -> RecordedResponseNotification.Partial:
+    def _prerecorded_response_notification_validate(
+        cls, values: RecordedResponseNotification.Partial
+    ) -> RecordedResponseNotification.Partial:
         for validator in RecordedResponseNotification.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: RecordedResponseNotification.Partial) -> RecordedResponseNotification.Partial:
+    def _postrecorded_response_notification_validate(
+        cls, values: RecordedResponseNotification.Partial
+    ) -> RecordedResponseNotification.Partial:
         for validator in RecordedResponseNotification.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_recorded_test_case_update.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_recorded_test_case_update.py
@@ -166,13 +166,17 @@ class RecordedTestCaseUpdate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: RecordedTestCaseUpdate.Partial) -> RecordedTestCaseUpdate.Partial:
+    def _prerecorded_test_case_update_validate(
+        cls, values: RecordedTestCaseUpdate.Partial
+    ) -> RecordedTestCaseUpdate.Partial:
         for validator in RecordedTestCaseUpdate.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: RecordedTestCaseUpdate.Partial) -> RecordedTestCaseUpdate.Partial:
+    def _postrecorded_test_case_update_validate(
+        cls, values: RecordedTestCaseUpdate.Partial
+    ) -> RecordedTestCaseUpdate.Partial:
         for validator in RecordedTestCaseUpdate.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_recorded_test_case_update.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_recorded_test_case_update.py
@@ -166,7 +166,7 @@ class RecordedTestCaseUpdate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_recorded_test_case_update_validate(
+    def _pre_validate_recorded_test_case_update(
         cls, values: RecordedTestCaseUpdate.Partial
     ) -> RecordedTestCaseUpdate.Partial:
         for validator in RecordedTestCaseUpdate.Validators._pre_validators:
@@ -174,7 +174,7 @@ class RecordedTestCaseUpdate(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_recorded_test_case_update_validate(
+    def _post_validate_recorded_test_case_update(
         cls, values: RecordedTestCaseUpdate.Partial
     ) -> RecordedTestCaseUpdate.Partial:
         for validator in RecordedTestCaseUpdate.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_recorded_test_case_update.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_recorded_test_case_update.py
@@ -166,7 +166,7 @@ class RecordedTestCaseUpdate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prerecorded_test_case_update_validate(
+    def _pre_recorded_test_case_update_validate(
         cls, values: RecordedTestCaseUpdate.Partial
     ) -> RecordedTestCaseUpdate.Partial:
         for validator in RecordedTestCaseUpdate.Validators._pre_validators:
@@ -174,7 +174,7 @@ class RecordedTestCaseUpdate(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postrecorded_test_case_update_validate(
+    def _post_recorded_test_case_update_validate(
         cls, values: RecordedTestCaseUpdate.Partial
     ) -> RecordedTestCaseUpdate.Partial:
         for validator in RecordedTestCaseUpdate.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_recording_response_notification.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_recording_response_notification.py
@@ -319,7 +319,7 @@ class RecordingResponseNotification(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_recording_response_notification_validate(
+    def _pre_validate_recording_response_notification(
         cls, values: RecordingResponseNotification.Partial
     ) -> RecordingResponseNotification.Partial:
         for validator in RecordingResponseNotification.Validators._pre_validators:
@@ -327,7 +327,7 @@ class RecordingResponseNotification(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_recording_response_notification_validate(
+    def _post_validate_recording_response_notification(
         cls, values: RecordingResponseNotification.Partial
     ) -> RecordingResponseNotification.Partial:
         for validator in RecordingResponseNotification.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_recording_response_notification.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_recording_response_notification.py
@@ -319,7 +319,7 @@ class RecordingResponseNotification(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prerecording_response_notification_validate(
+    def _pre_recording_response_notification_validate(
         cls, values: RecordingResponseNotification.Partial
     ) -> RecordingResponseNotification.Partial:
         for validator in RecordingResponseNotification.Validators._pre_validators:
@@ -327,7 +327,7 @@ class RecordingResponseNotification(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postrecording_response_notification_validate(
+    def _post_recording_response_notification_validate(
         cls, values: RecordingResponseNotification.Partial
     ) -> RecordingResponseNotification.Partial:
         for validator in RecordingResponseNotification.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_recording_response_notification.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_recording_response_notification.py
@@ -319,13 +319,17 @@ class RecordingResponseNotification(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: RecordingResponseNotification.Partial) -> RecordingResponseNotification.Partial:
+    def _prerecording_response_notification_validate(
+        cls, values: RecordingResponseNotification.Partial
+    ) -> RecordingResponseNotification.Partial:
         for validator in RecordingResponseNotification.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: RecordingResponseNotification.Partial) -> RecordingResponseNotification.Partial:
+    def _postrecording_response_notification_validate(
+        cls, values: RecordingResponseNotification.Partial
+    ) -> RecordingResponseNotification.Partial:
         for validator in RecordingResponseNotification.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_running_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_running_response.py
@@ -157,13 +157,13 @@ class RunningResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prerunning_response_validate(cls, values: RunningResponse.Partial) -> RunningResponse.Partial:
+    def _pre_running_response_validate(cls, values: RunningResponse.Partial) -> RunningResponse.Partial:
         for validator in RunningResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postrunning_response_validate(cls, values: RunningResponse.Partial) -> RunningResponse.Partial:
+    def _post_running_response_validate(cls, values: RunningResponse.Partial) -> RunningResponse.Partial:
         for validator in RunningResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_running_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_running_response.py
@@ -157,13 +157,13 @@ class RunningResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: RunningResponse.Partial) -> RunningResponse.Partial:
+    def _prerunning_response_validate(cls, values: RunningResponse.Partial) -> RunningResponse.Partial:
         for validator in RunningResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: RunningResponse.Partial) -> RunningResponse.Partial:
+    def _postrunning_response_validate(cls, values: RunningResponse.Partial) -> RunningResponse.Partial:
         for validator in RunningResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_running_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_running_response.py
@@ -157,13 +157,13 @@ class RunningResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_running_response_validate(cls, values: RunningResponse.Partial) -> RunningResponse.Partial:
+    def _pre_validate_running_response(cls, values: RunningResponse.Partial) -> RunningResponse.Partial:
         for validator in RunningResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_running_response_validate(cls, values: RunningResponse.Partial) -> RunningResponse.Partial:
+    def _post_validate_running_response(cls, values: RunningResponse.Partial) -> RunningResponse.Partial:
         for validator in RunningResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_runtime_error.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_runtime_error.py
@@ -105,13 +105,13 @@ class RuntimeError(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_runtime_error_validate(cls, values: RuntimeError.Partial) -> RuntimeError.Partial:
+    def _pre_validate_runtime_error(cls, values: RuntimeError.Partial) -> RuntimeError.Partial:
         for validator in RuntimeError.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_runtime_error_validate(cls, values: RuntimeError.Partial) -> RuntimeError.Partial:
+    def _post_validate_runtime_error(cls, values: RuntimeError.Partial) -> RuntimeError.Partial:
         for validator in RuntimeError.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_runtime_error.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_runtime_error.py
@@ -105,13 +105,13 @@ class RuntimeError(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: RuntimeError.Partial) -> RuntimeError.Partial:
+    def _preruntime_error_validate(cls, values: RuntimeError.Partial) -> RuntimeError.Partial:
         for validator in RuntimeError.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: RuntimeError.Partial) -> RuntimeError.Partial:
+    def _postruntime_error_validate(cls, values: RuntimeError.Partial) -> RuntimeError.Partial:
         for validator in RuntimeError.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_runtime_error.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_runtime_error.py
@@ -105,13 +105,13 @@ class RuntimeError(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preruntime_error_validate(cls, values: RuntimeError.Partial) -> RuntimeError.Partial:
+    def _pre_runtime_error_validate(cls, values: RuntimeError.Partial) -> RuntimeError.Partial:
         for validator in RuntimeError.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postruntime_error_validate(cls, values: RuntimeError.Partial) -> RuntimeError.Partial:
+    def _post_runtime_error_validate(cls, values: RuntimeError.Partial) -> RuntimeError.Partial:
         for validator in RuntimeError.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_scope.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_scope.py
@@ -106,13 +106,13 @@ class Scope(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prescope_validate(cls, values: Scope.Partial) -> Scope.Partial:
+    def _pre_scope_validate(cls, values: Scope.Partial) -> Scope.Partial:
         for validator in Scope.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postscope_validate(cls, values: Scope.Partial) -> Scope.Partial:
+    def _post_scope_validate(cls, values: Scope.Partial) -> Scope.Partial:
         for validator in Scope.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_scope.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_scope.py
@@ -106,13 +106,13 @@ class Scope(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: Scope.Partial) -> Scope.Partial:
+    def _prescope_validate(cls, values: Scope.Partial) -> Scope.Partial:
         for validator in Scope.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: Scope.Partial) -> Scope.Partial:
+    def _postscope_validate(cls, values: Scope.Partial) -> Scope.Partial:
         for validator in Scope.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_scope.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_scope.py
@@ -106,13 +106,13 @@ class Scope(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_scope_validate(cls, values: Scope.Partial) -> Scope.Partial:
+    def _pre_validate_scope(cls, values: Scope.Partial) -> Scope.Partial:
         for validator in Scope.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_scope_validate(cls, values: Scope.Partial) -> Scope.Partial:
+    def _post_validate_scope(cls, values: Scope.Partial) -> Scope.Partial:
         for validator in Scope.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_stack_frame.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_stack_frame.py
@@ -178,13 +178,13 @@ class StackFrame(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prestack_frame_validate(cls, values: StackFrame.Partial) -> StackFrame.Partial:
+    def _pre_stack_frame_validate(cls, values: StackFrame.Partial) -> StackFrame.Partial:
         for validator in StackFrame.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _poststack_frame_validate(cls, values: StackFrame.Partial) -> StackFrame.Partial:
+    def _post_stack_frame_validate(cls, values: StackFrame.Partial) -> StackFrame.Partial:
         for validator in StackFrame.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_stack_frame.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_stack_frame.py
@@ -178,13 +178,13 @@ class StackFrame(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_stack_frame_validate(cls, values: StackFrame.Partial) -> StackFrame.Partial:
+    def _pre_validate_stack_frame(cls, values: StackFrame.Partial) -> StackFrame.Partial:
         for validator in StackFrame.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_stack_frame_validate(cls, values: StackFrame.Partial) -> StackFrame.Partial:
+    def _post_validate_stack_frame(cls, values: StackFrame.Partial) -> StackFrame.Partial:
         for validator in StackFrame.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_stack_frame.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_stack_frame.py
@@ -178,13 +178,13 @@ class StackFrame(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: StackFrame.Partial) -> StackFrame.Partial:
+    def _prestack_frame_validate(cls, values: StackFrame.Partial) -> StackFrame.Partial:
         for validator in StackFrame.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: StackFrame.Partial) -> StackFrame.Partial:
+    def _poststack_frame_validate(cls, values: StackFrame.Partial) -> StackFrame.Partial:
         for validator in StackFrame.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_stack_information.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_stack_information.py
@@ -167,13 +167,13 @@ class StackInformation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prestack_information_validate(cls, values: StackInformation.Partial) -> StackInformation.Partial:
+    def _pre_stack_information_validate(cls, values: StackInformation.Partial) -> StackInformation.Partial:
         for validator in StackInformation.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _poststack_information_validate(cls, values: StackInformation.Partial) -> StackInformation.Partial:
+    def _post_stack_information_validate(cls, values: StackInformation.Partial) -> StackInformation.Partial:
         for validator in StackInformation.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_stack_information.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_stack_information.py
@@ -167,13 +167,13 @@ class StackInformation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: StackInformation.Partial) -> StackInformation.Partial:
+    def _prestack_information_validate(cls, values: StackInformation.Partial) -> StackInformation.Partial:
         for validator in StackInformation.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: StackInformation.Partial) -> StackInformation.Partial:
+    def _poststack_information_validate(cls, values: StackInformation.Partial) -> StackInformation.Partial:
         for validator in StackInformation.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_stack_information.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_stack_information.py
@@ -167,13 +167,13 @@ class StackInformation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_stack_information_validate(cls, values: StackInformation.Partial) -> StackInformation.Partial:
+    def _pre_validate_stack_information(cls, values: StackInformation.Partial) -> StackInformation.Partial:
         for validator in StackInformation.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_stack_information_validate(cls, values: StackInformation.Partial) -> StackInformation.Partial:
+    def _post_validate_stack_information(cls, values: StackInformation.Partial) -> StackInformation.Partial:
         for validator in StackInformation.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_stderr_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_stderr_response.py
@@ -154,13 +154,13 @@ class StderrResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: StderrResponse.Partial) -> StderrResponse.Partial:
+    def _prestderr_response_validate(cls, values: StderrResponse.Partial) -> StderrResponse.Partial:
         for validator in StderrResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: StderrResponse.Partial) -> StderrResponse.Partial:
+    def _poststderr_response_validate(cls, values: StderrResponse.Partial) -> StderrResponse.Partial:
         for validator in StderrResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_stderr_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_stderr_response.py
@@ -154,13 +154,13 @@ class StderrResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prestderr_response_validate(cls, values: StderrResponse.Partial) -> StderrResponse.Partial:
+    def _pre_stderr_response_validate(cls, values: StderrResponse.Partial) -> StderrResponse.Partial:
         for validator in StderrResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _poststderr_response_validate(cls, values: StderrResponse.Partial) -> StderrResponse.Partial:
+    def _post_stderr_response_validate(cls, values: StderrResponse.Partial) -> StderrResponse.Partial:
         for validator in StderrResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_stderr_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_stderr_response.py
@@ -154,13 +154,13 @@ class StderrResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_stderr_response_validate(cls, values: StderrResponse.Partial) -> StderrResponse.Partial:
+    def _pre_validate_stderr_response(cls, values: StderrResponse.Partial) -> StderrResponse.Partial:
         for validator in StderrResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_stderr_response_validate(cls, values: StderrResponse.Partial) -> StderrResponse.Partial:
+    def _post_validate_stderr_response(cls, values: StderrResponse.Partial) -> StderrResponse.Partial:
         for validator in StderrResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_stdout_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_stdout_response.py
@@ -154,13 +154,13 @@ class StdoutResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: StdoutResponse.Partial) -> StdoutResponse.Partial:
+    def _prestdout_response_validate(cls, values: StdoutResponse.Partial) -> StdoutResponse.Partial:
         for validator in StdoutResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: StdoutResponse.Partial) -> StdoutResponse.Partial:
+    def _poststdout_response_validate(cls, values: StdoutResponse.Partial) -> StdoutResponse.Partial:
         for validator in StdoutResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_stdout_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_stdout_response.py
@@ -154,13 +154,13 @@ class StdoutResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prestdout_response_validate(cls, values: StdoutResponse.Partial) -> StdoutResponse.Partial:
+    def _pre_stdout_response_validate(cls, values: StdoutResponse.Partial) -> StdoutResponse.Partial:
         for validator in StdoutResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _poststdout_response_validate(cls, values: StdoutResponse.Partial) -> StdoutResponse.Partial:
+    def _post_stdout_response_validate(cls, values: StdoutResponse.Partial) -> StdoutResponse.Partial:
         for validator in StdoutResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_stdout_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_stdout_response.py
@@ -154,13 +154,13 @@ class StdoutResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_stdout_response_validate(cls, values: StdoutResponse.Partial) -> StdoutResponse.Partial:
+    def _pre_validate_stdout_response(cls, values: StdoutResponse.Partial) -> StdoutResponse.Partial:
         for validator in StdoutResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_stdout_response_validate(cls, values: StdoutResponse.Partial) -> StdoutResponse.Partial:
+    def _post_validate_stdout_response(cls, values: StdoutResponse.Partial) -> StdoutResponse.Partial:
         for validator in StdoutResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_stop_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_stop_request.py
@@ -113,13 +113,13 @@ class StopRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: StopRequest.Partial) -> StopRequest.Partial:
+    def _prestop_request_validate(cls, values: StopRequest.Partial) -> StopRequest.Partial:
         for validator in StopRequest.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: StopRequest.Partial) -> StopRequest.Partial:
+    def _poststop_request_validate(cls, values: StopRequest.Partial) -> StopRequest.Partial:
         for validator in StopRequest.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_stop_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_stop_request.py
@@ -113,13 +113,13 @@ class StopRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_stop_request_validate(cls, values: StopRequest.Partial) -> StopRequest.Partial:
+    def _pre_validate_stop_request(cls, values: StopRequest.Partial) -> StopRequest.Partial:
         for validator in StopRequest.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_stop_request_validate(cls, values: StopRequest.Partial) -> StopRequest.Partial:
+    def _post_validate_stop_request(cls, values: StopRequest.Partial) -> StopRequest.Partial:
         for validator in StopRequest.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_stop_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_stop_request.py
@@ -113,13 +113,13 @@ class StopRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prestop_request_validate(cls, values: StopRequest.Partial) -> StopRequest.Partial:
+    def _pre_stop_request_validate(cls, values: StopRequest.Partial) -> StopRequest.Partial:
         for validator in StopRequest.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _poststop_request_validate(cls, values: StopRequest.Partial) -> StopRequest.Partial:
+    def _post_stop_request_validate(cls, values: StopRequest.Partial) -> StopRequest.Partial:
         for validator in StopRequest.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_stopped_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_stopped_response.py
@@ -117,13 +117,13 @@ class StoppedResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prestopped_response_validate(cls, values: StoppedResponse.Partial) -> StoppedResponse.Partial:
+    def _pre_stopped_response_validate(cls, values: StoppedResponse.Partial) -> StoppedResponse.Partial:
         for validator in StoppedResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _poststopped_response_validate(cls, values: StoppedResponse.Partial) -> StoppedResponse.Partial:
+    def _post_stopped_response_validate(cls, values: StoppedResponse.Partial) -> StoppedResponse.Partial:
         for validator in StoppedResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_stopped_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_stopped_response.py
@@ -117,13 +117,13 @@ class StoppedResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: StoppedResponse.Partial) -> StoppedResponse.Partial:
+    def _prestopped_response_validate(cls, values: StoppedResponse.Partial) -> StoppedResponse.Partial:
         for validator in StoppedResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: StoppedResponse.Partial) -> StoppedResponse.Partial:
+    def _poststopped_response_validate(cls, values: StoppedResponse.Partial) -> StoppedResponse.Partial:
         for validator in StoppedResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_stopped_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_stopped_response.py
@@ -117,13 +117,13 @@ class StoppedResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_stopped_response_validate(cls, values: StoppedResponse.Partial) -> StoppedResponse.Partial:
+    def _pre_validate_stopped_response(cls, values: StoppedResponse.Partial) -> StoppedResponse.Partial:
         for validator in StoppedResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_stopped_response_validate(cls, values: StoppedResponse.Partial) -> StoppedResponse.Partial:
+    def _post_validate_stopped_response(cls, values: StoppedResponse.Partial) -> StoppedResponse.Partial:
         for validator in StoppedResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_submission_file_info.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_submission_file_info.py
@@ -191,13 +191,13 @@ class SubmissionFileInfo(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_submission_file_info_validate(cls, values: SubmissionFileInfo.Partial) -> SubmissionFileInfo.Partial:
+    def _pre_validate_submission_file_info(cls, values: SubmissionFileInfo.Partial) -> SubmissionFileInfo.Partial:
         for validator in SubmissionFileInfo.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_submission_file_info_validate(cls, values: SubmissionFileInfo.Partial) -> SubmissionFileInfo.Partial:
+    def _post_validate_submission_file_info(cls, values: SubmissionFileInfo.Partial) -> SubmissionFileInfo.Partial:
         for validator in SubmissionFileInfo.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_submission_file_info.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_submission_file_info.py
@@ -191,13 +191,13 @@ class SubmissionFileInfo(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _presubmission_file_info_validate(cls, values: SubmissionFileInfo.Partial) -> SubmissionFileInfo.Partial:
+    def _pre_submission_file_info_validate(cls, values: SubmissionFileInfo.Partial) -> SubmissionFileInfo.Partial:
         for validator in SubmissionFileInfo.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postsubmission_file_info_validate(cls, values: SubmissionFileInfo.Partial) -> SubmissionFileInfo.Partial:
+    def _post_submission_file_info_validate(cls, values: SubmissionFileInfo.Partial) -> SubmissionFileInfo.Partial:
         for validator in SubmissionFileInfo.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_submission_file_info.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_submission_file_info.py
@@ -191,13 +191,13 @@ class SubmissionFileInfo(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: SubmissionFileInfo.Partial) -> SubmissionFileInfo.Partial:
+    def _presubmission_file_info_validate(cls, values: SubmissionFileInfo.Partial) -> SubmissionFileInfo.Partial:
         for validator in SubmissionFileInfo.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: SubmissionFileInfo.Partial) -> SubmissionFileInfo.Partial:
+    def _postsubmission_file_info_validate(cls, values: SubmissionFileInfo.Partial) -> SubmissionFileInfo.Partial:
         for validator in SubmissionFileInfo.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_submission_id_not_found.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_submission_id_not_found.py
@@ -121,13 +121,15 @@ class SubmissionIdNotFound(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: SubmissionIdNotFound.Partial) -> SubmissionIdNotFound.Partial:
+    def _presubmission_id_not_found_validate(cls, values: SubmissionIdNotFound.Partial) -> SubmissionIdNotFound.Partial:
         for validator in SubmissionIdNotFound.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: SubmissionIdNotFound.Partial) -> SubmissionIdNotFound.Partial:
+    def _postsubmission_id_not_found_validate(
+        cls, values: SubmissionIdNotFound.Partial
+    ) -> SubmissionIdNotFound.Partial:
         for validator in SubmissionIdNotFound.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_submission_id_not_found.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_submission_id_not_found.py
@@ -121,7 +121,7 @@ class SubmissionIdNotFound(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_submission_id_not_found_validate(
+    def _pre_validate_submission_id_not_found(
         cls, values: SubmissionIdNotFound.Partial
     ) -> SubmissionIdNotFound.Partial:
         for validator in SubmissionIdNotFound.Validators._pre_validators:
@@ -129,7 +129,7 @@ class SubmissionIdNotFound(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_submission_id_not_found_validate(
+    def _post_validate_submission_id_not_found(
         cls, values: SubmissionIdNotFound.Partial
     ) -> SubmissionIdNotFound.Partial:
         for validator in SubmissionIdNotFound.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_submission_id_not_found.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_submission_id_not_found.py
@@ -121,13 +121,15 @@ class SubmissionIdNotFound(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _presubmission_id_not_found_validate(cls, values: SubmissionIdNotFound.Partial) -> SubmissionIdNotFound.Partial:
+    def _pre_submission_id_not_found_validate(
+        cls, values: SubmissionIdNotFound.Partial
+    ) -> SubmissionIdNotFound.Partial:
         for validator in SubmissionIdNotFound.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postsubmission_id_not_found_validate(
+    def _post_submission_id_not_found_validate(
         cls, values: SubmissionIdNotFound.Partial
     ) -> SubmissionIdNotFound.Partial:
         for validator in SubmissionIdNotFound.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_submit_request_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_submit_request_v_2.py
@@ -331,13 +331,13 @@ class SubmitRequestV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: SubmitRequestV2.Partial) -> SubmitRequestV2.Partial:
+    def _presubmit_request_v_2_validate(cls, values: SubmitRequestV2.Partial) -> SubmitRequestV2.Partial:
         for validator in SubmitRequestV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: SubmitRequestV2.Partial) -> SubmitRequestV2.Partial:
+    def _postsubmit_request_v_2_validate(cls, values: SubmitRequestV2.Partial) -> SubmitRequestV2.Partial:
         for validator in SubmitRequestV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_submit_request_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_submit_request_v_2.py
@@ -331,13 +331,13 @@ class SubmitRequestV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _presubmit_request_v_2_validate(cls, values: SubmitRequestV2.Partial) -> SubmitRequestV2.Partial:
+    def _pre_submit_request_v_2_validate(cls, values: SubmitRequestV2.Partial) -> SubmitRequestV2.Partial:
         for validator in SubmitRequestV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postsubmit_request_v_2_validate(cls, values: SubmitRequestV2.Partial) -> SubmitRequestV2.Partial:
+    def _post_submit_request_v_2_validate(cls, values: SubmitRequestV2.Partial) -> SubmitRequestV2.Partial:
         for validator in SubmitRequestV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_submit_request_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_submit_request_v_2.py
@@ -331,13 +331,13 @@ class SubmitRequestV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_submit_request_v_2_validate(cls, values: SubmitRequestV2.Partial) -> SubmitRequestV2.Partial:
+    def _pre_validate_submit_request_v_2(cls, values: SubmitRequestV2.Partial) -> SubmitRequestV2.Partial:
         for validator in SubmitRequestV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_submit_request_v_2_validate(cls, values: SubmitRequestV2.Partial) -> SubmitRequestV2.Partial:
+    def _post_validate_submit_request_v_2(cls, values: SubmitRequestV2.Partial) -> SubmitRequestV2.Partial:
         for validator in SubmitRequestV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_terminated_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_terminated_response.py
@@ -65,13 +65,13 @@ class TerminatedResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_terminated_response_validate(cls, values: TerminatedResponse.Partial) -> TerminatedResponse.Partial:
+    def _pre_validate_terminated_response(cls, values: TerminatedResponse.Partial) -> TerminatedResponse.Partial:
         for validator in TerminatedResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_terminated_response_validate(cls, values: TerminatedResponse.Partial) -> TerminatedResponse.Partial:
+    def _post_validate_terminated_response(cls, values: TerminatedResponse.Partial) -> TerminatedResponse.Partial:
         for validator in TerminatedResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_terminated_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_terminated_response.py
@@ -65,13 +65,13 @@ class TerminatedResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TerminatedResponse.Partial) -> TerminatedResponse.Partial:
+    def _preterminated_response_validate(cls, values: TerminatedResponse.Partial) -> TerminatedResponse.Partial:
         for validator in TerminatedResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TerminatedResponse.Partial) -> TerminatedResponse.Partial:
+    def _postterminated_response_validate(cls, values: TerminatedResponse.Partial) -> TerminatedResponse.Partial:
         for validator in TerminatedResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_terminated_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_terminated_response.py
@@ -65,13 +65,13 @@ class TerminatedResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preterminated_response_validate(cls, values: TerminatedResponse.Partial) -> TerminatedResponse.Partial:
+    def _pre_terminated_response_validate(cls, values: TerminatedResponse.Partial) -> TerminatedResponse.Partial:
         for validator in TerminatedResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postterminated_response_validate(cls, values: TerminatedResponse.Partial) -> TerminatedResponse.Partial:
+    def _post_terminated_response_validate(cls, values: TerminatedResponse.Partial) -> TerminatedResponse.Partial:
         for validator in TerminatedResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_case_hidden_grade.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_case_hidden_grade.py
@@ -111,13 +111,13 @@ class TestCaseHiddenGrade(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TestCaseHiddenGrade.Partial) -> TestCaseHiddenGrade.Partial:
+    def _pretest_case_hidden_grade_validate(cls, values: TestCaseHiddenGrade.Partial) -> TestCaseHiddenGrade.Partial:
         for validator in TestCaseHiddenGrade.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TestCaseHiddenGrade.Partial) -> TestCaseHiddenGrade.Partial:
+    def _posttest_case_hidden_grade_validate(cls, values: TestCaseHiddenGrade.Partial) -> TestCaseHiddenGrade.Partial:
         for validator in TestCaseHiddenGrade.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_case_hidden_grade.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_case_hidden_grade.py
@@ -111,13 +111,13 @@ class TestCaseHiddenGrade(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_test_case_hidden_grade_validate(cls, values: TestCaseHiddenGrade.Partial) -> TestCaseHiddenGrade.Partial:
+    def _pre_validate_test_case_hidden_grade(cls, values: TestCaseHiddenGrade.Partial) -> TestCaseHiddenGrade.Partial:
         for validator in TestCaseHiddenGrade.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_test_case_hidden_grade_validate(cls, values: TestCaseHiddenGrade.Partial) -> TestCaseHiddenGrade.Partial:
+    def _post_validate_test_case_hidden_grade(cls, values: TestCaseHiddenGrade.Partial) -> TestCaseHiddenGrade.Partial:
         for validator in TestCaseHiddenGrade.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_case_hidden_grade.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_case_hidden_grade.py
@@ -111,13 +111,13 @@ class TestCaseHiddenGrade(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pretest_case_hidden_grade_validate(cls, values: TestCaseHiddenGrade.Partial) -> TestCaseHiddenGrade.Partial:
+    def _pre_test_case_hidden_grade_validate(cls, values: TestCaseHiddenGrade.Partial) -> TestCaseHiddenGrade.Partial:
         for validator in TestCaseHiddenGrade.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _posttest_case_hidden_grade_validate(cls, values: TestCaseHiddenGrade.Partial) -> TestCaseHiddenGrade.Partial:
+    def _post_test_case_hidden_grade_validate(cls, values: TestCaseHiddenGrade.Partial) -> TestCaseHiddenGrade.Partial:
         for validator in TestCaseHiddenGrade.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_case_non_hidden_grade.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_case_non_hidden_grade.py
@@ -248,13 +248,17 @@ class TestCaseNonHiddenGrade(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TestCaseNonHiddenGrade.Partial) -> TestCaseNonHiddenGrade.Partial:
+    def _pretest_case_non_hidden_grade_validate(
+        cls, values: TestCaseNonHiddenGrade.Partial
+    ) -> TestCaseNonHiddenGrade.Partial:
         for validator in TestCaseNonHiddenGrade.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TestCaseNonHiddenGrade.Partial) -> TestCaseNonHiddenGrade.Partial:
+    def _posttest_case_non_hidden_grade_validate(
+        cls, values: TestCaseNonHiddenGrade.Partial
+    ) -> TestCaseNonHiddenGrade.Partial:
         for validator in TestCaseNonHiddenGrade.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_case_non_hidden_grade.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_case_non_hidden_grade.py
@@ -248,7 +248,7 @@ class TestCaseNonHiddenGrade(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_test_case_non_hidden_grade_validate(
+    def _pre_validate_test_case_non_hidden_grade(
         cls, values: TestCaseNonHiddenGrade.Partial
     ) -> TestCaseNonHiddenGrade.Partial:
         for validator in TestCaseNonHiddenGrade.Validators._pre_validators:
@@ -256,7 +256,7 @@ class TestCaseNonHiddenGrade(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_test_case_non_hidden_grade_validate(
+    def _post_validate_test_case_non_hidden_grade(
         cls, values: TestCaseNonHiddenGrade.Partial
     ) -> TestCaseNonHiddenGrade.Partial:
         for validator in TestCaseNonHiddenGrade.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_case_non_hidden_grade.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_case_non_hidden_grade.py
@@ -248,7 +248,7 @@ class TestCaseNonHiddenGrade(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pretest_case_non_hidden_grade_validate(
+    def _pre_test_case_non_hidden_grade_validate(
         cls, values: TestCaseNonHiddenGrade.Partial
     ) -> TestCaseNonHiddenGrade.Partial:
         for validator in TestCaseNonHiddenGrade.Validators._pre_validators:
@@ -256,7 +256,7 @@ class TestCaseNonHiddenGrade(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _posttest_case_non_hidden_grade_validate(
+    def _post_test_case_non_hidden_grade_validate(
         cls, values: TestCaseNonHiddenGrade.Partial
     ) -> TestCaseNonHiddenGrade.Partial:
         for validator in TestCaseNonHiddenGrade.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_case_result.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_case_result.py
@@ -201,13 +201,13 @@ class TestCaseResult(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_test_case_result_validate(cls, values: TestCaseResult.Partial) -> TestCaseResult.Partial:
+    def _pre_validate_test_case_result(cls, values: TestCaseResult.Partial) -> TestCaseResult.Partial:
         for validator in TestCaseResult.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_test_case_result_validate(cls, values: TestCaseResult.Partial) -> TestCaseResult.Partial:
+    def _post_validate_test_case_result(cls, values: TestCaseResult.Partial) -> TestCaseResult.Partial:
         for validator in TestCaseResult.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_case_result.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_case_result.py
@@ -201,13 +201,13 @@ class TestCaseResult(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TestCaseResult.Partial) -> TestCaseResult.Partial:
+    def _pretest_case_result_validate(cls, values: TestCaseResult.Partial) -> TestCaseResult.Partial:
         for validator in TestCaseResult.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TestCaseResult.Partial) -> TestCaseResult.Partial:
+    def _posttest_case_result_validate(cls, values: TestCaseResult.Partial) -> TestCaseResult.Partial:
         for validator in TestCaseResult.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_case_result.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_case_result.py
@@ -201,13 +201,13 @@ class TestCaseResult(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pretest_case_result_validate(cls, values: TestCaseResult.Partial) -> TestCaseResult.Partial:
+    def _pre_test_case_result_validate(cls, values: TestCaseResult.Partial) -> TestCaseResult.Partial:
         for validator in TestCaseResult.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _posttest_case_result_validate(cls, values: TestCaseResult.Partial) -> TestCaseResult.Partial:
+    def _post_test_case_result_validate(cls, values: TestCaseResult.Partial) -> TestCaseResult.Partial:
         for validator in TestCaseResult.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_case_result_with_stdout.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_case_result_with_stdout.py
@@ -158,7 +158,7 @@ class TestCaseResultWithStdout(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_test_case_result_with_stdout_validate(
+    def _pre_validate_test_case_result_with_stdout(
         cls, values: TestCaseResultWithStdout.Partial
     ) -> TestCaseResultWithStdout.Partial:
         for validator in TestCaseResultWithStdout.Validators._pre_validators:
@@ -166,7 +166,7 @@ class TestCaseResultWithStdout(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_test_case_result_with_stdout_validate(
+    def _post_validate_test_case_result_with_stdout(
         cls, values: TestCaseResultWithStdout.Partial
     ) -> TestCaseResultWithStdout.Partial:
         for validator in TestCaseResultWithStdout.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_case_result_with_stdout.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_case_result_with_stdout.py
@@ -158,13 +158,17 @@ class TestCaseResultWithStdout(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TestCaseResultWithStdout.Partial) -> TestCaseResultWithStdout.Partial:
+    def _pretest_case_result_with_stdout_validate(
+        cls, values: TestCaseResultWithStdout.Partial
+    ) -> TestCaseResultWithStdout.Partial:
         for validator in TestCaseResultWithStdout.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TestCaseResultWithStdout.Partial) -> TestCaseResultWithStdout.Partial:
+    def _posttest_case_result_with_stdout_validate(
+        cls, values: TestCaseResultWithStdout.Partial
+    ) -> TestCaseResultWithStdout.Partial:
         for validator in TestCaseResultWithStdout.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_case_result_with_stdout.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_case_result_with_stdout.py
@@ -158,7 +158,7 @@ class TestCaseResultWithStdout(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pretest_case_result_with_stdout_validate(
+    def _pre_test_case_result_with_stdout_validate(
         cls, values: TestCaseResultWithStdout.Partial
     ) -> TestCaseResultWithStdout.Partial:
         for validator in TestCaseResultWithStdout.Validators._pre_validators:
@@ -166,7 +166,7 @@ class TestCaseResultWithStdout(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _posttest_case_result_with_stdout_validate(
+    def _post_test_case_result_with_stdout_validate(
         cls, values: TestCaseResultWithStdout.Partial
     ) -> TestCaseResultWithStdout.Partial:
         for validator in TestCaseResultWithStdout.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_submission_state.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_submission_state.py
@@ -259,13 +259,13 @@ class TestSubmissionState(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_test_submission_state_validate(cls, values: TestSubmissionState.Partial) -> TestSubmissionState.Partial:
+    def _pre_validate_test_submission_state(cls, values: TestSubmissionState.Partial) -> TestSubmissionState.Partial:
         for validator in TestSubmissionState.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_test_submission_state_validate(cls, values: TestSubmissionState.Partial) -> TestSubmissionState.Partial:
+    def _post_validate_test_submission_state(cls, values: TestSubmissionState.Partial) -> TestSubmissionState.Partial:
         for validator in TestSubmissionState.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_submission_state.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_submission_state.py
@@ -259,13 +259,13 @@ class TestSubmissionState(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pretest_submission_state_validate(cls, values: TestSubmissionState.Partial) -> TestSubmissionState.Partial:
+    def _pre_test_submission_state_validate(cls, values: TestSubmissionState.Partial) -> TestSubmissionState.Partial:
         for validator in TestSubmissionState.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _posttest_submission_state_validate(cls, values: TestSubmissionState.Partial) -> TestSubmissionState.Partial:
+    def _post_test_submission_state_validate(cls, values: TestSubmissionState.Partial) -> TestSubmissionState.Partial:
         for validator in TestSubmissionState.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_submission_state.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_submission_state.py
@@ -259,13 +259,13 @@ class TestSubmissionState(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TestSubmissionState.Partial) -> TestSubmissionState.Partial:
+    def _pretest_submission_state_validate(cls, values: TestSubmissionState.Partial) -> TestSubmissionState.Partial:
         for validator in TestSubmissionState.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TestSubmissionState.Partial) -> TestSubmissionState.Partial:
+    def _posttest_submission_state_validate(cls, values: TestSubmissionState.Partial) -> TestSubmissionState.Partial:
         for validator in TestSubmissionState.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_submission_status_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_submission_status_v_2.py
@@ -256,7 +256,7 @@ class TestSubmissionStatusV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_test_submission_status_v_2_validate(
+    def _pre_validate_test_submission_status_v_2(
         cls, values: TestSubmissionStatusV2.Partial
     ) -> TestSubmissionStatusV2.Partial:
         for validator in TestSubmissionStatusV2.Validators._pre_validators:
@@ -264,7 +264,7 @@ class TestSubmissionStatusV2(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_test_submission_status_v_2_validate(
+    def _post_validate_test_submission_status_v_2(
         cls, values: TestSubmissionStatusV2.Partial
     ) -> TestSubmissionStatusV2.Partial:
         for validator in TestSubmissionStatusV2.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_submission_status_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_submission_status_v_2.py
@@ -256,13 +256,17 @@ class TestSubmissionStatusV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TestSubmissionStatusV2.Partial) -> TestSubmissionStatusV2.Partial:
+    def _pretest_submission_status_v_2_validate(
+        cls, values: TestSubmissionStatusV2.Partial
+    ) -> TestSubmissionStatusV2.Partial:
         for validator in TestSubmissionStatusV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TestSubmissionStatusV2.Partial) -> TestSubmissionStatusV2.Partial:
+    def _posttest_submission_status_v_2_validate(
+        cls, values: TestSubmissionStatusV2.Partial
+    ) -> TestSubmissionStatusV2.Partial:
         for validator in TestSubmissionStatusV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_submission_status_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_submission_status_v_2.py
@@ -256,7 +256,7 @@ class TestSubmissionStatusV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pretest_submission_status_v_2_validate(
+    def _pre_test_submission_status_v_2_validate(
         cls, values: TestSubmissionStatusV2.Partial
     ) -> TestSubmissionStatusV2.Partial:
         for validator in TestSubmissionStatusV2.Validators._pre_validators:
@@ -264,7 +264,7 @@ class TestSubmissionStatusV2(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _posttest_submission_status_v_2_validate(
+    def _post_test_submission_status_v_2_validate(
         cls, values: TestSubmissionStatusV2.Partial
     ) -> TestSubmissionStatusV2.Partial:
         for validator in TestSubmissionStatusV2.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_submission_update.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_submission_update.py
@@ -163,13 +163,13 @@ class TestSubmissionUpdate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_test_submission_update_validate(cls, values: TestSubmissionUpdate.Partial) -> TestSubmissionUpdate.Partial:
+    def _pre_validate_test_submission_update(cls, values: TestSubmissionUpdate.Partial) -> TestSubmissionUpdate.Partial:
         for validator in TestSubmissionUpdate.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_test_submission_update_validate(
+    def _post_validate_test_submission_update(
         cls, values: TestSubmissionUpdate.Partial
     ) -> TestSubmissionUpdate.Partial:
         for validator in TestSubmissionUpdate.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_submission_update.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_submission_update.py
@@ -163,13 +163,15 @@ class TestSubmissionUpdate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pretest_submission_update_validate(cls, values: TestSubmissionUpdate.Partial) -> TestSubmissionUpdate.Partial:
+    def _pre_test_submission_update_validate(cls, values: TestSubmissionUpdate.Partial) -> TestSubmissionUpdate.Partial:
         for validator in TestSubmissionUpdate.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _posttest_submission_update_validate(cls, values: TestSubmissionUpdate.Partial) -> TestSubmissionUpdate.Partial:
+    def _post_test_submission_update_validate(
+        cls, values: TestSubmissionUpdate.Partial
+    ) -> TestSubmissionUpdate.Partial:
         for validator in TestSubmissionUpdate.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_submission_update.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_test_submission_update.py
@@ -163,13 +163,13 @@ class TestSubmissionUpdate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TestSubmissionUpdate.Partial) -> TestSubmissionUpdate.Partial:
+    def _pretest_submission_update_validate(cls, values: TestSubmissionUpdate.Partial) -> TestSubmissionUpdate.Partial:
         for validator in TestSubmissionUpdate.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TestSubmissionUpdate.Partial) -> TestSubmissionUpdate.Partial:
+    def _posttest_submission_update_validate(cls, values: TestSubmissionUpdate.Partial) -> TestSubmissionUpdate.Partial:
         for validator in TestSubmissionUpdate.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_trace_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_trace_response.py
@@ -321,13 +321,13 @@ class TraceResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pretrace_response_validate(cls, values: TraceResponse.Partial) -> TraceResponse.Partial:
+    def _pre_trace_response_validate(cls, values: TraceResponse.Partial) -> TraceResponse.Partial:
         for validator in TraceResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _posttrace_response_validate(cls, values: TraceResponse.Partial) -> TraceResponse.Partial:
+    def _post_trace_response_validate(cls, values: TraceResponse.Partial) -> TraceResponse.Partial:
         for validator in TraceResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_trace_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_trace_response.py
@@ -321,13 +321,13 @@ class TraceResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_trace_response_validate(cls, values: TraceResponse.Partial) -> TraceResponse.Partial:
+    def _pre_validate_trace_response(cls, values: TraceResponse.Partial) -> TraceResponse.Partial:
         for validator in TraceResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_trace_response_validate(cls, values: TraceResponse.Partial) -> TraceResponse.Partial:
+    def _post_validate_trace_response(cls, values: TraceResponse.Partial) -> TraceResponse.Partial:
         for validator in TraceResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_trace_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_trace_response.py
@@ -321,13 +321,13 @@ class TraceResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TraceResponse.Partial) -> TraceResponse.Partial:
+    def _pretrace_response_validate(cls, values: TraceResponse.Partial) -> TraceResponse.Partial:
         for validator in TraceResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TraceResponse.Partial) -> TraceResponse.Partial:
+    def _posttrace_response_validate(cls, values: TraceResponse.Partial) -> TraceResponse.Partial:
         for validator in TraceResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_trace_response_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_trace_response_v_2.py
@@ -368,13 +368,13 @@ class TraceResponseV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pretrace_response_v_2_validate(cls, values: TraceResponseV2.Partial) -> TraceResponseV2.Partial:
+    def _pre_trace_response_v_2_validate(cls, values: TraceResponseV2.Partial) -> TraceResponseV2.Partial:
         for validator in TraceResponseV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _posttrace_response_v_2_validate(cls, values: TraceResponseV2.Partial) -> TraceResponseV2.Partial:
+    def _post_trace_response_v_2_validate(cls, values: TraceResponseV2.Partial) -> TraceResponseV2.Partial:
         for validator in TraceResponseV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_trace_response_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_trace_response_v_2.py
@@ -368,13 +368,13 @@ class TraceResponseV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_trace_response_v_2_validate(cls, values: TraceResponseV2.Partial) -> TraceResponseV2.Partial:
+    def _pre_validate_trace_response_v_2(cls, values: TraceResponseV2.Partial) -> TraceResponseV2.Partial:
         for validator in TraceResponseV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_trace_response_v_2_validate(cls, values: TraceResponseV2.Partial) -> TraceResponseV2.Partial:
+    def _post_validate_trace_response_v_2(cls, values: TraceResponseV2.Partial) -> TraceResponseV2.Partial:
         for validator in TraceResponseV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_trace_response_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_trace_response_v_2.py
@@ -368,13 +368,13 @@ class TraceResponseV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TraceResponseV2.Partial) -> TraceResponseV2.Partial:
+    def _pretrace_response_v_2_validate(cls, values: TraceResponseV2.Partial) -> TraceResponseV2.Partial:
         for validator in TraceResponseV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TraceResponseV2.Partial) -> TraceResponseV2.Partial:
+    def _posttrace_response_v_2_validate(cls, values: TraceResponseV2.Partial) -> TraceResponseV2.Partial:
         for validator in TraceResponseV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_trace_responses_page.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_trace_responses_page.py
@@ -167,13 +167,13 @@ class TraceResponsesPage(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pretrace_responses_page_validate(cls, values: TraceResponsesPage.Partial) -> TraceResponsesPage.Partial:
+    def _pre_trace_responses_page_validate(cls, values: TraceResponsesPage.Partial) -> TraceResponsesPage.Partial:
         for validator in TraceResponsesPage.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _posttrace_responses_page_validate(cls, values: TraceResponsesPage.Partial) -> TraceResponsesPage.Partial:
+    def _post_trace_responses_page_validate(cls, values: TraceResponsesPage.Partial) -> TraceResponsesPage.Partial:
         for validator in TraceResponsesPage.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_trace_responses_page.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_trace_responses_page.py
@@ -167,13 +167,13 @@ class TraceResponsesPage(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_trace_responses_page_validate(cls, values: TraceResponsesPage.Partial) -> TraceResponsesPage.Partial:
+    def _pre_validate_trace_responses_page(cls, values: TraceResponsesPage.Partial) -> TraceResponsesPage.Partial:
         for validator in TraceResponsesPage.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_trace_responses_page_validate(cls, values: TraceResponsesPage.Partial) -> TraceResponsesPage.Partial:
+    def _post_validate_trace_responses_page(cls, values: TraceResponsesPage.Partial) -> TraceResponsesPage.Partial:
         for validator in TraceResponsesPage.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_trace_responses_page.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_trace_responses_page.py
@@ -167,13 +167,13 @@ class TraceResponsesPage(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TraceResponsesPage.Partial) -> TraceResponsesPage.Partial:
+    def _pretrace_responses_page_validate(cls, values: TraceResponsesPage.Partial) -> TraceResponsesPage.Partial:
         for validator in TraceResponsesPage.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TraceResponsesPage.Partial) -> TraceResponsesPage.Partial:
+    def _posttrace_responses_page_validate(cls, values: TraceResponsesPage.Partial) -> TraceResponsesPage.Partial:
         for validator in TraceResponsesPage.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_trace_responses_page_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_trace_responses_page_v_2.py
@@ -169,7 +169,7 @@ class TraceResponsesPageV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pretrace_responses_page_v_2_validate(
+    def _pre_trace_responses_page_v_2_validate(
         cls, values: TraceResponsesPageV2.Partial
     ) -> TraceResponsesPageV2.Partial:
         for validator in TraceResponsesPageV2.Validators._pre_validators:
@@ -177,7 +177,7 @@ class TraceResponsesPageV2(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _posttrace_responses_page_v_2_validate(
+    def _post_trace_responses_page_v_2_validate(
         cls, values: TraceResponsesPageV2.Partial
     ) -> TraceResponsesPageV2.Partial:
         for validator in TraceResponsesPageV2.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_trace_responses_page_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_trace_responses_page_v_2.py
@@ -169,7 +169,7 @@ class TraceResponsesPageV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_trace_responses_page_v_2_validate(
+    def _pre_validate_trace_responses_page_v_2(
         cls, values: TraceResponsesPageV2.Partial
     ) -> TraceResponsesPageV2.Partial:
         for validator in TraceResponsesPageV2.Validators._pre_validators:
@@ -177,7 +177,7 @@ class TraceResponsesPageV2(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_trace_responses_page_v_2_validate(
+    def _post_validate_trace_responses_page_v_2(
         cls, values: TraceResponsesPageV2.Partial
     ) -> TraceResponsesPageV2.Partial:
         for validator in TraceResponsesPageV2.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_trace_responses_page_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_trace_responses_page_v_2.py
@@ -169,13 +169,17 @@ class TraceResponsesPageV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TraceResponsesPageV2.Partial) -> TraceResponsesPageV2.Partial:
+    def _pretrace_responses_page_v_2_validate(
+        cls, values: TraceResponsesPageV2.Partial
+    ) -> TraceResponsesPageV2.Partial:
         for validator in TraceResponsesPageV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TraceResponsesPageV2.Partial) -> TraceResponsesPageV2.Partial:
+    def _posttrace_responses_page_v_2_validate(
+        cls, values: TraceResponsesPageV2.Partial
+    ) -> TraceResponsesPageV2.Partial:
         for validator in TraceResponsesPageV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_traced_file.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_traced_file.py
@@ -140,13 +140,13 @@ class TracedFile(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TracedFile.Partial) -> TracedFile.Partial:
+    def _pretraced_file_validate(cls, values: TracedFile.Partial) -> TracedFile.Partial:
         for validator in TracedFile.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TracedFile.Partial) -> TracedFile.Partial:
+    def _posttraced_file_validate(cls, values: TracedFile.Partial) -> TracedFile.Partial:
         for validator in TracedFile.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_traced_file.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_traced_file.py
@@ -140,13 +140,13 @@ class TracedFile(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_traced_file_validate(cls, values: TracedFile.Partial) -> TracedFile.Partial:
+    def _pre_validate_traced_file(cls, values: TracedFile.Partial) -> TracedFile.Partial:
         for validator in TracedFile.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_traced_file_validate(cls, values: TracedFile.Partial) -> TracedFile.Partial:
+    def _post_validate_traced_file(cls, values: TracedFile.Partial) -> TracedFile.Partial:
         for validator in TracedFile.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_traced_file.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_traced_file.py
@@ -140,13 +140,13 @@ class TracedFile(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pretraced_file_validate(cls, values: TracedFile.Partial) -> TracedFile.Partial:
+    def _pre_traced_file_validate(cls, values: TracedFile.Partial) -> TracedFile.Partial:
         for validator in TracedFile.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _posttraced_file_validate(cls, values: TracedFile.Partial) -> TracedFile.Partial:
+    def _post_traced_file_validate(cls, values: TracedFile.Partial) -> TracedFile.Partial:
         for validator in TracedFile.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_traced_test_case.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_traced_test_case.py
@@ -158,13 +158,13 @@ class TracedTestCase(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pretraced_test_case_validate(cls, values: TracedTestCase.Partial) -> TracedTestCase.Partial:
+    def _pre_traced_test_case_validate(cls, values: TracedTestCase.Partial) -> TracedTestCase.Partial:
         for validator in TracedTestCase.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _posttraced_test_case_validate(cls, values: TracedTestCase.Partial) -> TracedTestCase.Partial:
+    def _post_traced_test_case_validate(cls, values: TracedTestCase.Partial) -> TracedTestCase.Partial:
         for validator in TracedTestCase.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_traced_test_case.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_traced_test_case.py
@@ -158,13 +158,13 @@ class TracedTestCase(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TracedTestCase.Partial) -> TracedTestCase.Partial:
+    def _pretraced_test_case_validate(cls, values: TracedTestCase.Partial) -> TracedTestCase.Partial:
         for validator in TracedTestCase.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TracedTestCase.Partial) -> TracedTestCase.Partial:
+    def _posttraced_test_case_validate(cls, values: TracedTestCase.Partial) -> TracedTestCase.Partial:
         for validator in TracedTestCase.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_traced_test_case.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_traced_test_case.py
@@ -158,13 +158,13 @@ class TracedTestCase(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_traced_test_case_validate(cls, values: TracedTestCase.Partial) -> TracedTestCase.Partial:
+    def _pre_validate_traced_test_case(cls, values: TracedTestCase.Partial) -> TracedTestCase.Partial:
         for validator in TracedTestCase.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_traced_test_case_validate(cls, values: TracedTestCase.Partial) -> TracedTestCase.Partial:
+    def _post_validate_traced_test_case(cls, values: TracedTestCase.Partial) -> TracedTestCase.Partial:
         for validator in TracedTestCase.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_unexpected_language_error.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_unexpected_language_error.py
@@ -169,7 +169,7 @@ class UnexpectedLanguageError(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preunexpected_language_error_validate(
+    def _pre_unexpected_language_error_validate(
         cls, values: UnexpectedLanguageError.Partial
     ) -> UnexpectedLanguageError.Partial:
         for validator in UnexpectedLanguageError.Validators._pre_validators:
@@ -177,7 +177,7 @@ class UnexpectedLanguageError(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postunexpected_language_error_validate(
+    def _post_unexpected_language_error_validate(
         cls, values: UnexpectedLanguageError.Partial
     ) -> UnexpectedLanguageError.Partial:
         for validator in UnexpectedLanguageError.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_unexpected_language_error.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_unexpected_language_error.py
@@ -169,7 +169,7 @@ class UnexpectedLanguageError(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_unexpected_language_error_validate(
+    def _pre_validate_unexpected_language_error(
         cls, values: UnexpectedLanguageError.Partial
     ) -> UnexpectedLanguageError.Partial:
         for validator in UnexpectedLanguageError.Validators._pre_validators:
@@ -177,7 +177,7 @@ class UnexpectedLanguageError(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_unexpected_language_error_validate(
+    def _post_validate_unexpected_language_error(
         cls, values: UnexpectedLanguageError.Partial
     ) -> UnexpectedLanguageError.Partial:
         for validator in UnexpectedLanguageError.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_unexpected_language_error.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_unexpected_language_error.py
@@ -169,13 +169,17 @@ class UnexpectedLanguageError(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: UnexpectedLanguageError.Partial) -> UnexpectedLanguageError.Partial:
+    def _preunexpected_language_error_validate(
+        cls, values: UnexpectedLanguageError.Partial
+    ) -> UnexpectedLanguageError.Partial:
         for validator in UnexpectedLanguageError.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: UnexpectedLanguageError.Partial) -> UnexpectedLanguageError.Partial:
+    def _postunexpected_language_error_validate(
+        cls, values: UnexpectedLanguageError.Partial
+    ) -> UnexpectedLanguageError.Partial:
         for validator in UnexpectedLanguageError.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_files.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_files.py
@@ -156,13 +156,13 @@ class WorkspaceFiles(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_workspace_files_validate(cls, values: WorkspaceFiles.Partial) -> WorkspaceFiles.Partial:
+    def _pre_validate_workspace_files(cls, values: WorkspaceFiles.Partial) -> WorkspaceFiles.Partial:
         for validator in WorkspaceFiles.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_workspace_files_validate(cls, values: WorkspaceFiles.Partial) -> WorkspaceFiles.Partial:
+    def _post_validate_workspace_files(cls, values: WorkspaceFiles.Partial) -> WorkspaceFiles.Partial:
         for validator in WorkspaceFiles.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_files.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_files.py
@@ -156,13 +156,13 @@ class WorkspaceFiles(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preworkspace_files_validate(cls, values: WorkspaceFiles.Partial) -> WorkspaceFiles.Partial:
+    def _pre_workspace_files_validate(cls, values: WorkspaceFiles.Partial) -> WorkspaceFiles.Partial:
         for validator in WorkspaceFiles.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postworkspace_files_validate(cls, values: WorkspaceFiles.Partial) -> WorkspaceFiles.Partial:
+    def _post_workspace_files_validate(cls, values: WorkspaceFiles.Partial) -> WorkspaceFiles.Partial:
         for validator in WorkspaceFiles.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_files.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_files.py
@@ -156,13 +156,13 @@ class WorkspaceFiles(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: WorkspaceFiles.Partial) -> WorkspaceFiles.Partial:
+    def _preworkspace_files_validate(cls, values: WorkspaceFiles.Partial) -> WorkspaceFiles.Partial:
         for validator in WorkspaceFiles.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: WorkspaceFiles.Partial) -> WorkspaceFiles.Partial:
+    def _postworkspace_files_validate(cls, values: WorkspaceFiles.Partial) -> WorkspaceFiles.Partial:
         for validator in WorkspaceFiles.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_ran_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_ran_response.py
@@ -166,13 +166,13 @@ class WorkspaceRanResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: WorkspaceRanResponse.Partial) -> WorkspaceRanResponse.Partial:
+    def _preworkspace_ran_response_validate(cls, values: WorkspaceRanResponse.Partial) -> WorkspaceRanResponse.Partial:
         for validator in WorkspaceRanResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: WorkspaceRanResponse.Partial) -> WorkspaceRanResponse.Partial:
+    def _postworkspace_ran_response_validate(cls, values: WorkspaceRanResponse.Partial) -> WorkspaceRanResponse.Partial:
         for validator in WorkspaceRanResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_ran_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_ran_response.py
@@ -166,13 +166,13 @@ class WorkspaceRanResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_workspace_ran_response_validate(cls, values: WorkspaceRanResponse.Partial) -> WorkspaceRanResponse.Partial:
+    def _pre_validate_workspace_ran_response(cls, values: WorkspaceRanResponse.Partial) -> WorkspaceRanResponse.Partial:
         for validator in WorkspaceRanResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_workspace_ran_response_validate(
+    def _post_validate_workspace_ran_response(
         cls, values: WorkspaceRanResponse.Partial
     ) -> WorkspaceRanResponse.Partial:
         for validator in WorkspaceRanResponse.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_ran_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_ran_response.py
@@ -166,13 +166,15 @@ class WorkspaceRanResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preworkspace_ran_response_validate(cls, values: WorkspaceRanResponse.Partial) -> WorkspaceRanResponse.Partial:
+    def _pre_workspace_ran_response_validate(cls, values: WorkspaceRanResponse.Partial) -> WorkspaceRanResponse.Partial:
         for validator in WorkspaceRanResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postworkspace_ran_response_validate(cls, values: WorkspaceRanResponse.Partial) -> WorkspaceRanResponse.Partial:
+    def _post_workspace_ran_response_validate(
+        cls, values: WorkspaceRanResponse.Partial
+    ) -> WorkspaceRanResponse.Partial:
         for validator in WorkspaceRanResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_run_details.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_run_details.py
@@ -205,13 +205,13 @@ class WorkspaceRunDetails(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preworkspace_run_details_validate(cls, values: WorkspaceRunDetails.Partial) -> WorkspaceRunDetails.Partial:
+    def _pre_workspace_run_details_validate(cls, values: WorkspaceRunDetails.Partial) -> WorkspaceRunDetails.Partial:
         for validator in WorkspaceRunDetails.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postworkspace_run_details_validate(cls, values: WorkspaceRunDetails.Partial) -> WorkspaceRunDetails.Partial:
+    def _post_workspace_run_details_validate(cls, values: WorkspaceRunDetails.Partial) -> WorkspaceRunDetails.Partial:
         for validator in WorkspaceRunDetails.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_run_details.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_run_details.py
@@ -205,13 +205,13 @@ class WorkspaceRunDetails(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_workspace_run_details_validate(cls, values: WorkspaceRunDetails.Partial) -> WorkspaceRunDetails.Partial:
+    def _pre_validate_workspace_run_details(cls, values: WorkspaceRunDetails.Partial) -> WorkspaceRunDetails.Partial:
         for validator in WorkspaceRunDetails.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_workspace_run_details_validate(cls, values: WorkspaceRunDetails.Partial) -> WorkspaceRunDetails.Partial:
+    def _post_validate_workspace_run_details(cls, values: WorkspaceRunDetails.Partial) -> WorkspaceRunDetails.Partial:
         for validator in WorkspaceRunDetails.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_run_details.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_run_details.py
@@ -205,13 +205,13 @@ class WorkspaceRunDetails(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: WorkspaceRunDetails.Partial) -> WorkspaceRunDetails.Partial:
+    def _preworkspace_run_details_validate(cls, values: WorkspaceRunDetails.Partial) -> WorkspaceRunDetails.Partial:
         for validator in WorkspaceRunDetails.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: WorkspaceRunDetails.Partial) -> WorkspaceRunDetails.Partial:
+    def _postworkspace_run_details_validate(cls, values: WorkspaceRunDetails.Partial) -> WorkspaceRunDetails.Partial:
         for validator in WorkspaceRunDetails.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_starter_files_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_starter_files_response.py
@@ -125,7 +125,7 @@ class WorkspaceStarterFilesResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_workspace_starter_files_response_validate(
+    def _pre_validate_workspace_starter_files_response(
         cls, values: WorkspaceStarterFilesResponse.Partial
     ) -> WorkspaceStarterFilesResponse.Partial:
         for validator in WorkspaceStarterFilesResponse.Validators._pre_validators:
@@ -133,7 +133,7 @@ class WorkspaceStarterFilesResponse(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_workspace_starter_files_response_validate(
+    def _post_validate_workspace_starter_files_response(
         cls, values: WorkspaceStarterFilesResponse.Partial
     ) -> WorkspaceStarterFilesResponse.Partial:
         for validator in WorkspaceStarterFilesResponse.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_starter_files_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_starter_files_response.py
@@ -125,13 +125,17 @@ class WorkspaceStarterFilesResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: WorkspaceStarterFilesResponse.Partial) -> WorkspaceStarterFilesResponse.Partial:
+    def _preworkspace_starter_files_response_validate(
+        cls, values: WorkspaceStarterFilesResponse.Partial
+    ) -> WorkspaceStarterFilesResponse.Partial:
         for validator in WorkspaceStarterFilesResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: WorkspaceStarterFilesResponse.Partial) -> WorkspaceStarterFilesResponse.Partial:
+    def _postworkspace_starter_files_response_validate(
+        cls, values: WorkspaceStarterFilesResponse.Partial
+    ) -> WorkspaceStarterFilesResponse.Partial:
         for validator in WorkspaceStarterFilesResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_starter_files_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_starter_files_response.py
@@ -125,7 +125,7 @@ class WorkspaceStarterFilesResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preworkspace_starter_files_response_validate(
+    def _pre_workspace_starter_files_response_validate(
         cls, values: WorkspaceStarterFilesResponse.Partial
     ) -> WorkspaceStarterFilesResponse.Partial:
         for validator in WorkspaceStarterFilesResponse.Validators._pre_validators:
@@ -133,7 +133,7 @@ class WorkspaceStarterFilesResponse(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postworkspace_starter_files_response_validate(
+    def _post_workspace_starter_files_response_validate(
         cls, values: WorkspaceStarterFilesResponse.Partial
     ) -> WorkspaceStarterFilesResponse.Partial:
         for validator in WorkspaceStarterFilesResponse.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_starter_files_response_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_starter_files_response_v_2.py
@@ -128,7 +128,7 @@ class WorkspaceStarterFilesResponseV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_workspace_starter_files_response_v_2_validate(
+    def _pre_validate_workspace_starter_files_response_v_2(
         cls, values: WorkspaceStarterFilesResponseV2.Partial
     ) -> WorkspaceStarterFilesResponseV2.Partial:
         for validator in WorkspaceStarterFilesResponseV2.Validators._pre_validators:
@@ -136,7 +136,7 @@ class WorkspaceStarterFilesResponseV2(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_workspace_starter_files_response_v_2_validate(
+    def _post_validate_workspace_starter_files_response_v_2(
         cls, values: WorkspaceStarterFilesResponseV2.Partial
     ) -> WorkspaceStarterFilesResponseV2.Partial:
         for validator in WorkspaceStarterFilesResponseV2.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_starter_files_response_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_starter_files_response_v_2.py
@@ -128,13 +128,17 @@ class WorkspaceStarterFilesResponseV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: WorkspaceStarterFilesResponseV2.Partial) -> WorkspaceStarterFilesResponseV2.Partial:
+    def _preworkspace_starter_files_response_v_2_validate(
+        cls, values: WorkspaceStarterFilesResponseV2.Partial
+    ) -> WorkspaceStarterFilesResponseV2.Partial:
         for validator in WorkspaceStarterFilesResponseV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: WorkspaceStarterFilesResponseV2.Partial) -> WorkspaceStarterFilesResponseV2.Partial:
+    def _postworkspace_starter_files_response_v_2_validate(
+        cls, values: WorkspaceStarterFilesResponseV2.Partial
+    ) -> WorkspaceStarterFilesResponseV2.Partial:
         for validator in WorkspaceStarterFilesResponseV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_starter_files_response_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_starter_files_response_v_2.py
@@ -128,7 +128,7 @@ class WorkspaceStarterFilesResponseV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preworkspace_starter_files_response_v_2_validate(
+    def _pre_workspace_starter_files_response_v_2_validate(
         cls, values: WorkspaceStarterFilesResponseV2.Partial
     ) -> WorkspaceStarterFilesResponseV2.Partial:
         for validator in WorkspaceStarterFilesResponseV2.Validators._pre_validators:
@@ -136,7 +136,7 @@ class WorkspaceStarterFilesResponseV2(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postworkspace_starter_files_response_v_2_validate(
+    def _post_workspace_starter_files_response_v_2_validate(
         cls, values: WorkspaceStarterFilesResponseV2.Partial
     ) -> WorkspaceStarterFilesResponseV2.Partial:
         for validator in WorkspaceStarterFilesResponseV2.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_submission_state.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_submission_state.py
@@ -118,13 +118,17 @@ class WorkspaceSubmissionState(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: WorkspaceSubmissionState.Partial) -> WorkspaceSubmissionState.Partial:
+    def _preworkspace_submission_state_validate(
+        cls, values: WorkspaceSubmissionState.Partial
+    ) -> WorkspaceSubmissionState.Partial:
         for validator in WorkspaceSubmissionState.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: WorkspaceSubmissionState.Partial) -> WorkspaceSubmissionState.Partial:
+    def _postworkspace_submission_state_validate(
+        cls, values: WorkspaceSubmissionState.Partial
+    ) -> WorkspaceSubmissionState.Partial:
         for validator in WorkspaceSubmissionState.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_submission_state.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_submission_state.py
@@ -118,7 +118,7 @@ class WorkspaceSubmissionState(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_workspace_submission_state_validate(
+    def _pre_validate_workspace_submission_state(
         cls, values: WorkspaceSubmissionState.Partial
     ) -> WorkspaceSubmissionState.Partial:
         for validator in WorkspaceSubmissionState.Validators._pre_validators:
@@ -126,7 +126,7 @@ class WorkspaceSubmissionState(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_workspace_submission_state_validate(
+    def _post_validate_workspace_submission_state(
         cls, values: WorkspaceSubmissionState.Partial
     ) -> WorkspaceSubmissionState.Partial:
         for validator in WorkspaceSubmissionState.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_submission_state.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_submission_state.py
@@ -118,7 +118,7 @@ class WorkspaceSubmissionState(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preworkspace_submission_state_validate(
+    def _pre_workspace_submission_state_validate(
         cls, values: WorkspaceSubmissionState.Partial
     ) -> WorkspaceSubmissionState.Partial:
         for validator in WorkspaceSubmissionState.Validators._pre_validators:
@@ -126,7 +126,7 @@ class WorkspaceSubmissionState(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postworkspace_submission_state_validate(
+    def _post_workspace_submission_state_validate(
         cls, values: WorkspaceSubmissionState.Partial
     ) -> WorkspaceSubmissionState.Partial:
         for validator in WorkspaceSubmissionState.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_submission_status_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_submission_status_v_2.py
@@ -122,13 +122,17 @@ class WorkspaceSubmissionStatusV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: WorkspaceSubmissionStatusV2.Partial) -> WorkspaceSubmissionStatusV2.Partial:
+    def _preworkspace_submission_status_v_2_validate(
+        cls, values: WorkspaceSubmissionStatusV2.Partial
+    ) -> WorkspaceSubmissionStatusV2.Partial:
         for validator in WorkspaceSubmissionStatusV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: WorkspaceSubmissionStatusV2.Partial) -> WorkspaceSubmissionStatusV2.Partial:
+    def _postworkspace_submission_status_v_2_validate(
+        cls, values: WorkspaceSubmissionStatusV2.Partial
+    ) -> WorkspaceSubmissionStatusV2.Partial:
         for validator in WorkspaceSubmissionStatusV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_submission_status_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_submission_status_v_2.py
@@ -122,7 +122,7 @@ class WorkspaceSubmissionStatusV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preworkspace_submission_status_v_2_validate(
+    def _pre_workspace_submission_status_v_2_validate(
         cls, values: WorkspaceSubmissionStatusV2.Partial
     ) -> WorkspaceSubmissionStatusV2.Partial:
         for validator in WorkspaceSubmissionStatusV2.Validators._pre_validators:
@@ -130,7 +130,7 @@ class WorkspaceSubmissionStatusV2(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postworkspace_submission_status_v_2_validate(
+    def _post_workspace_submission_status_v_2_validate(
         cls, values: WorkspaceSubmissionStatusV2.Partial
     ) -> WorkspaceSubmissionStatusV2.Partial:
         for validator in WorkspaceSubmissionStatusV2.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_submission_status_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_submission_status_v_2.py
@@ -122,7 +122,7 @@ class WorkspaceSubmissionStatusV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_workspace_submission_status_v_2_validate(
+    def _pre_validate_workspace_submission_status_v_2(
         cls, values: WorkspaceSubmissionStatusV2.Partial
     ) -> WorkspaceSubmissionStatusV2.Partial:
         for validator in WorkspaceSubmissionStatusV2.Validators._pre_validators:
@@ -130,7 +130,7 @@ class WorkspaceSubmissionStatusV2(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_workspace_submission_status_v_2_validate(
+    def _post_validate_workspace_submission_status_v_2(
         cls, values: WorkspaceSubmissionStatusV2.Partial
     ) -> WorkspaceSubmissionStatusV2.Partial:
         for validator in WorkspaceSubmissionStatusV2.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_submission_update.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_submission_update.py
@@ -166,13 +166,17 @@ class WorkspaceSubmissionUpdate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: WorkspaceSubmissionUpdate.Partial) -> WorkspaceSubmissionUpdate.Partial:
+    def _preworkspace_submission_update_validate(
+        cls, values: WorkspaceSubmissionUpdate.Partial
+    ) -> WorkspaceSubmissionUpdate.Partial:
         for validator in WorkspaceSubmissionUpdate.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: WorkspaceSubmissionUpdate.Partial) -> WorkspaceSubmissionUpdate.Partial:
+    def _postworkspace_submission_update_validate(
+        cls, values: WorkspaceSubmissionUpdate.Partial
+    ) -> WorkspaceSubmissionUpdate.Partial:
         for validator in WorkspaceSubmissionUpdate.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_submission_update.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_submission_update.py
@@ -166,7 +166,7 @@ class WorkspaceSubmissionUpdate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preworkspace_submission_update_validate(
+    def _pre_workspace_submission_update_validate(
         cls, values: WorkspaceSubmissionUpdate.Partial
     ) -> WorkspaceSubmissionUpdate.Partial:
         for validator in WorkspaceSubmissionUpdate.Validators._pre_validators:
@@ -174,7 +174,7 @@ class WorkspaceSubmissionUpdate(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postworkspace_submission_update_validate(
+    def _post_workspace_submission_update_validate(
         cls, values: WorkspaceSubmissionUpdate.Partial
     ) -> WorkspaceSubmissionUpdate.Partial:
         for validator in WorkspaceSubmissionUpdate.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_submission_update.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_submission_update.py
@@ -166,7 +166,7 @@ class WorkspaceSubmissionUpdate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_workspace_submission_update_validate(
+    def _pre_validate_workspace_submission_update(
         cls, values: WorkspaceSubmissionUpdate.Partial
     ) -> WorkspaceSubmissionUpdate.Partial:
         for validator in WorkspaceSubmissionUpdate.Validators._pre_validators:
@@ -174,7 +174,7 @@ class WorkspaceSubmissionUpdate(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_workspace_submission_update_validate(
+    def _post_validate_workspace_submission_update(
         cls, values: WorkspaceSubmissionUpdate.Partial
     ) -> WorkspaceSubmissionUpdate.Partial:
         for validator in WorkspaceSubmissionUpdate.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_submit_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_submit_request.py
@@ -258,7 +258,7 @@ class WorkspaceSubmitRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preworkspace_submit_request_validate(
+    def _pre_workspace_submit_request_validate(
         cls, values: WorkspaceSubmitRequest.Partial
     ) -> WorkspaceSubmitRequest.Partial:
         for validator in WorkspaceSubmitRequest.Validators._pre_validators:
@@ -266,7 +266,7 @@ class WorkspaceSubmitRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postworkspace_submit_request_validate(
+    def _post_workspace_submit_request_validate(
         cls, values: WorkspaceSubmitRequest.Partial
     ) -> WorkspaceSubmitRequest.Partial:
         for validator in WorkspaceSubmitRequest.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_submit_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_submit_request.py
@@ -258,13 +258,17 @@ class WorkspaceSubmitRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: WorkspaceSubmitRequest.Partial) -> WorkspaceSubmitRequest.Partial:
+    def _preworkspace_submit_request_validate(
+        cls, values: WorkspaceSubmitRequest.Partial
+    ) -> WorkspaceSubmitRequest.Partial:
         for validator in WorkspaceSubmitRequest.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: WorkspaceSubmitRequest.Partial) -> WorkspaceSubmitRequest.Partial:
+    def _postworkspace_submit_request_validate(
+        cls, values: WorkspaceSubmitRequest.Partial
+    ) -> WorkspaceSubmitRequest.Partial:
         for validator in WorkspaceSubmitRequest.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_submit_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_submit_request.py
@@ -258,7 +258,7 @@ class WorkspaceSubmitRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_workspace_submit_request_validate(
+    def _pre_validate_workspace_submit_request(
         cls, values: WorkspaceSubmitRequest.Partial
     ) -> WorkspaceSubmitRequest.Partial:
         for validator in WorkspaceSubmitRequest.Validators._pre_validators:
@@ -266,7 +266,7 @@ class WorkspaceSubmitRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_workspace_submit_request_validate(
+    def _post_validate_workspace_submit_request(
         cls, values: WorkspaceSubmitRequest.Partial
     ) -> WorkspaceSubmitRequest.Partial:
         for validator in WorkspaceSubmitRequest.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_traced_update.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_traced_update.py
@@ -120,13 +120,17 @@ class WorkspaceTracedUpdate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: WorkspaceTracedUpdate.Partial) -> WorkspaceTracedUpdate.Partial:
+    def _preworkspace_traced_update_validate(
+        cls, values: WorkspaceTracedUpdate.Partial
+    ) -> WorkspaceTracedUpdate.Partial:
         for validator in WorkspaceTracedUpdate.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: WorkspaceTracedUpdate.Partial) -> WorkspaceTracedUpdate.Partial:
+    def _postworkspace_traced_update_validate(
+        cls, values: WorkspaceTracedUpdate.Partial
+    ) -> WorkspaceTracedUpdate.Partial:
         for validator in WorkspaceTracedUpdate.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_traced_update.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_traced_update.py
@@ -120,7 +120,7 @@ class WorkspaceTracedUpdate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preworkspace_traced_update_validate(
+    def _pre_workspace_traced_update_validate(
         cls, values: WorkspaceTracedUpdate.Partial
     ) -> WorkspaceTracedUpdate.Partial:
         for validator in WorkspaceTracedUpdate.Validators._pre_validators:
@@ -128,7 +128,7 @@ class WorkspaceTracedUpdate(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postworkspace_traced_update_validate(
+    def _post_workspace_traced_update_validate(
         cls, values: WorkspaceTracedUpdate.Partial
     ) -> WorkspaceTracedUpdate.Partial:
         for validator in WorkspaceTracedUpdate.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_traced_update.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_submission_types_workspace_traced_update.py
@@ -120,7 +120,7 @@ class WorkspaceTracedUpdate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_workspace_traced_update_validate(
+    def _pre_validate_workspace_traced_update(
         cls, values: WorkspaceTracedUpdate.Partial
     ) -> WorkspaceTracedUpdate.Partial:
         for validator in WorkspaceTracedUpdate.Validators._pre_validators:
@@ -128,7 +128,7 @@ class WorkspaceTracedUpdate(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_workspace_traced_update_validate(
+    def _post_validate_workspace_traced_update(
         cls, values: WorkspaceTracedUpdate.Partial
     ) -> WorkspaceTracedUpdate.Partial:
         for validator in WorkspaceTracedUpdate.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_basic_custom_files.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_basic_custom_files.py
@@ -256,13 +256,13 @@ class BasicCustomFiles(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
+    def _prev_2_basic_custom_files_validate(cls, values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
         for validator in BasicCustomFiles.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
+    def _postv_2_basic_custom_files_validate(cls, values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
         for validator in BasicCustomFiles.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_basic_custom_files.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_basic_custom_files.py
@@ -256,13 +256,13 @@ class BasicCustomFiles(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_basic_custom_files_validate(cls, values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
+    def _pre_validate_v_2_basic_custom_files(cls, values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
         for validator in BasicCustomFiles.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_basic_custom_files_validate(cls, values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
+    def _post_validate_v_2_basic_custom_files(cls, values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
         for validator in BasicCustomFiles.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_basic_custom_files.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_basic_custom_files.py
@@ -256,13 +256,13 @@ class BasicCustomFiles(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_basic_custom_files_validate(cls, values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
+    def _pre_v_2_basic_custom_files_validate(cls, values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
         for validator in BasicCustomFiles.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_basic_custom_files_validate(cls, values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
+    def _post_v_2_basic_custom_files_validate(cls, values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
         for validator in BasicCustomFiles.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_basic_test_case_template.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_basic_test_case_template.py
@@ -256,7 +256,7 @@ class BasicTestCaseTemplate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_basic_test_case_template_validate(
+    def _pre_v_2_basic_test_case_template_validate(
         cls, values: BasicTestCaseTemplate.Partial
     ) -> BasicTestCaseTemplate.Partial:
         for validator in BasicTestCaseTemplate.Validators._pre_validators:
@@ -264,7 +264,7 @@ class BasicTestCaseTemplate(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_basic_test_case_template_validate(
+    def _post_v_2_basic_test_case_template_validate(
         cls, values: BasicTestCaseTemplate.Partial
     ) -> BasicTestCaseTemplate.Partial:
         for validator in BasicTestCaseTemplate.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_basic_test_case_template.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_basic_test_case_template.py
@@ -256,13 +256,17 @@ class BasicTestCaseTemplate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: BasicTestCaseTemplate.Partial) -> BasicTestCaseTemplate.Partial:
+    def _prev_2_basic_test_case_template_validate(
+        cls, values: BasicTestCaseTemplate.Partial
+    ) -> BasicTestCaseTemplate.Partial:
         for validator in BasicTestCaseTemplate.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: BasicTestCaseTemplate.Partial) -> BasicTestCaseTemplate.Partial:
+    def _postv_2_basic_test_case_template_validate(
+        cls, values: BasicTestCaseTemplate.Partial
+    ) -> BasicTestCaseTemplate.Partial:
         for validator in BasicTestCaseTemplate.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_basic_test_case_template.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_basic_test_case_template.py
@@ -256,7 +256,7 @@ class BasicTestCaseTemplate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_basic_test_case_template_validate(
+    def _pre_validate_v_2_basic_test_case_template(
         cls, values: BasicTestCaseTemplate.Partial
     ) -> BasicTestCaseTemplate.Partial:
         for validator in BasicTestCaseTemplate.Validators._pre_validators:
@@ -264,7 +264,7 @@ class BasicTestCaseTemplate(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_basic_test_case_template_validate(
+    def _post_validate_v_2_basic_test_case_template(
         cls, values: BasicTestCaseTemplate.Partial
     ) -> BasicTestCaseTemplate.Partial:
         for validator in BasicTestCaseTemplate.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_create_problem_request_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_create_problem_request_v_2.py
@@ -408,7 +408,7 @@ class CreateProblemRequestV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_create_problem_request_v_2_validate(
+    def _pre_validate_v_2_create_problem_request_v_2(
         cls, values: CreateProblemRequestV2.Partial
     ) -> CreateProblemRequestV2.Partial:
         for validator in CreateProblemRequestV2.Validators._pre_validators:
@@ -416,7 +416,7 @@ class CreateProblemRequestV2(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_create_problem_request_v_2_validate(
+    def _post_validate_v_2_create_problem_request_v_2(
         cls, values: CreateProblemRequestV2.Partial
     ) -> CreateProblemRequestV2.Partial:
         for validator in CreateProblemRequestV2.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_create_problem_request_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_create_problem_request_v_2.py
@@ -408,7 +408,7 @@ class CreateProblemRequestV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_create_problem_request_v_2_validate(
+    def _pre_v_2_create_problem_request_v_2_validate(
         cls, values: CreateProblemRequestV2.Partial
     ) -> CreateProblemRequestV2.Partial:
         for validator in CreateProblemRequestV2.Validators._pre_validators:
@@ -416,7 +416,7 @@ class CreateProblemRequestV2(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_create_problem_request_v_2_validate(
+    def _post_v_2_create_problem_request_v_2_validate(
         cls, values: CreateProblemRequestV2.Partial
     ) -> CreateProblemRequestV2.Partial:
         for validator in CreateProblemRequestV2.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_create_problem_request_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_create_problem_request_v_2.py
@@ -408,13 +408,17 @@ class CreateProblemRequestV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: CreateProblemRequestV2.Partial) -> CreateProblemRequestV2.Partial:
+    def _prev_2_create_problem_request_v_2_validate(
+        cls, values: CreateProblemRequestV2.Partial
+    ) -> CreateProblemRequestV2.Partial:
         for validator in CreateProblemRequestV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: CreateProblemRequestV2.Partial) -> CreateProblemRequestV2.Partial:
+    def _postv_2_create_problem_request_v_2_validate(
+        cls, values: CreateProblemRequestV2.Partial
+    ) -> CreateProblemRequestV2.Partial:
         for validator in CreateProblemRequestV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_deep_equality_correctness_check.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_deep_equality_correctness_check.py
@@ -126,13 +126,17 @@ class DeepEqualityCorrectnessCheck(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: DeepEqualityCorrectnessCheck.Partial) -> DeepEqualityCorrectnessCheck.Partial:
+    def _prev_2_deep_equality_correctness_check_validate(
+        cls, values: DeepEqualityCorrectnessCheck.Partial
+    ) -> DeepEqualityCorrectnessCheck.Partial:
         for validator in DeepEqualityCorrectnessCheck.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: DeepEqualityCorrectnessCheck.Partial) -> DeepEqualityCorrectnessCheck.Partial:
+    def _postv_2_deep_equality_correctness_check_validate(
+        cls, values: DeepEqualityCorrectnessCheck.Partial
+    ) -> DeepEqualityCorrectnessCheck.Partial:
         for validator in DeepEqualityCorrectnessCheck.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_deep_equality_correctness_check.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_deep_equality_correctness_check.py
@@ -126,7 +126,7 @@ class DeepEqualityCorrectnessCheck(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_deep_equality_correctness_check_validate(
+    def _pre_validate_v_2_deep_equality_correctness_check(
         cls, values: DeepEqualityCorrectnessCheck.Partial
     ) -> DeepEqualityCorrectnessCheck.Partial:
         for validator in DeepEqualityCorrectnessCheck.Validators._pre_validators:
@@ -134,7 +134,7 @@ class DeepEqualityCorrectnessCheck(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_deep_equality_correctness_check_validate(
+    def _post_validate_v_2_deep_equality_correctness_check(
         cls, values: DeepEqualityCorrectnessCheck.Partial
     ) -> DeepEqualityCorrectnessCheck.Partial:
         for validator in DeepEqualityCorrectnessCheck.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_deep_equality_correctness_check.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_deep_equality_correctness_check.py
@@ -126,7 +126,7 @@ class DeepEqualityCorrectnessCheck(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_deep_equality_correctness_check_validate(
+    def _pre_v_2_deep_equality_correctness_check_validate(
         cls, values: DeepEqualityCorrectnessCheck.Partial
     ) -> DeepEqualityCorrectnessCheck.Partial:
         for validator in DeepEqualityCorrectnessCheck.Validators._pre_validators:
@@ -134,7 +134,7 @@ class DeepEqualityCorrectnessCheck(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_deep_equality_correctness_check_validate(
+    def _post_v_2_deep_equality_correctness_check_validate(
         cls, values: DeepEqualityCorrectnessCheck.Partial
     ) -> DeepEqualityCorrectnessCheck.Partial:
         for validator in DeepEqualityCorrectnessCheck.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_default_provided_file.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_default_provided_file.py
@@ -162,7 +162,7 @@ class DefaultProvidedFile(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_default_provided_file_validate(
+    def _pre_validate_v_2_default_provided_file(
         cls, values: DefaultProvidedFile.Partial
     ) -> DefaultProvidedFile.Partial:
         for validator in DefaultProvidedFile.Validators._pre_validators:
@@ -170,7 +170,7 @@ class DefaultProvidedFile(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_default_provided_file_validate(
+    def _post_validate_v_2_default_provided_file(
         cls, values: DefaultProvidedFile.Partial
     ) -> DefaultProvidedFile.Partial:
         for validator in DefaultProvidedFile.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_default_provided_file.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_default_provided_file.py
@@ -162,13 +162,15 @@ class DefaultProvidedFile(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: DefaultProvidedFile.Partial) -> DefaultProvidedFile.Partial:
+    def _prev_2_default_provided_file_validate(cls, values: DefaultProvidedFile.Partial) -> DefaultProvidedFile.Partial:
         for validator in DefaultProvidedFile.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: DefaultProvidedFile.Partial) -> DefaultProvidedFile.Partial:
+    def _postv_2_default_provided_file_validate(
+        cls, values: DefaultProvidedFile.Partial
+    ) -> DefaultProvidedFile.Partial:
         for validator in DefaultProvidedFile.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_default_provided_file.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_default_provided_file.py
@@ -162,13 +162,15 @@ class DefaultProvidedFile(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_default_provided_file_validate(cls, values: DefaultProvidedFile.Partial) -> DefaultProvidedFile.Partial:
+    def _pre_v_2_default_provided_file_validate(
+        cls, values: DefaultProvidedFile.Partial
+    ) -> DefaultProvidedFile.Partial:
         for validator in DefaultProvidedFile.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_default_provided_file_validate(
+    def _post_v_2_default_provided_file_validate(
         cls, values: DefaultProvidedFile.Partial
     ) -> DefaultProvidedFile.Partial:
         for validator in DefaultProvidedFile.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_file_info_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_file_info_v_2.py
@@ -210,13 +210,13 @@ class FileInfoV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_file_info_v_2_validate(cls, values: FileInfoV2.Partial) -> FileInfoV2.Partial:
+    def _pre_validate_v_2_file_info_v_2(cls, values: FileInfoV2.Partial) -> FileInfoV2.Partial:
         for validator in FileInfoV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_file_info_v_2_validate(cls, values: FileInfoV2.Partial) -> FileInfoV2.Partial:
+    def _post_validate_v_2_file_info_v_2(cls, values: FileInfoV2.Partial) -> FileInfoV2.Partial:
         for validator in FileInfoV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_file_info_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_file_info_v_2.py
@@ -210,13 +210,13 @@ class FileInfoV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_file_info_v_2_validate(cls, values: FileInfoV2.Partial) -> FileInfoV2.Partial:
+    def _pre_v_2_file_info_v_2_validate(cls, values: FileInfoV2.Partial) -> FileInfoV2.Partial:
         for validator in FileInfoV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_file_info_v_2_validate(cls, values: FileInfoV2.Partial) -> FileInfoV2.Partial:
+    def _post_v_2_file_info_v_2_validate(cls, values: FileInfoV2.Partial) -> FileInfoV2.Partial:
         for validator in FileInfoV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_file_info_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_file_info_v_2.py
@@ -210,13 +210,13 @@ class FileInfoV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: FileInfoV2.Partial) -> FileInfoV2.Partial:
+    def _prev_2_file_info_v_2_validate(cls, values: FileInfoV2.Partial) -> FileInfoV2.Partial:
         for validator in FileInfoV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: FileInfoV2.Partial) -> FileInfoV2.Partial:
+    def _postv_2_file_info_v_2_validate(cls, values: FileInfoV2.Partial) -> FileInfoV2.Partial:
         for validator in FileInfoV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_files.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_files.py
@@ -104,13 +104,13 @@ class Files(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_files_validate(cls, values: Files.Partial) -> Files.Partial:
+    def _pre_v_2_files_validate(cls, values: Files.Partial) -> Files.Partial:
         for validator in Files.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_files_validate(cls, values: Files.Partial) -> Files.Partial:
+    def _post_v_2_files_validate(cls, values: Files.Partial) -> Files.Partial:
         for validator in Files.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_files.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_files.py
@@ -104,13 +104,13 @@ class Files(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_files_validate(cls, values: Files.Partial) -> Files.Partial:
+    def _pre_validate_v_2_files(cls, values: Files.Partial) -> Files.Partial:
         for validator in Files.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_files_validate(cls, values: Files.Partial) -> Files.Partial:
+    def _post_validate_v_2_files(cls, values: Files.Partial) -> Files.Partial:
         for validator in Files.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_files.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_files.py
@@ -104,13 +104,13 @@ class Files(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: Files.Partial) -> Files.Partial:
+    def _prev_2_files_validate(cls, values: Files.Partial) -> Files.Partial:
         for validator in Files.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: Files.Partial) -> Files.Partial:
+    def _postv_2_files_validate(cls, values: Files.Partial) -> Files.Partial:
         for validator in Files.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_function_implementation.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_function_implementation.py
@@ -155,13 +155,17 @@ class FunctionImplementation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: FunctionImplementation.Partial) -> FunctionImplementation.Partial:
+    def _prev_2_function_implementation_validate(
+        cls, values: FunctionImplementation.Partial
+    ) -> FunctionImplementation.Partial:
         for validator in FunctionImplementation.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: FunctionImplementation.Partial) -> FunctionImplementation.Partial:
+    def _postv_2_function_implementation_validate(
+        cls, values: FunctionImplementation.Partial
+    ) -> FunctionImplementation.Partial:
         for validator in FunctionImplementation.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_function_implementation.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_function_implementation.py
@@ -155,7 +155,7 @@ class FunctionImplementation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_function_implementation_validate(
+    def _pre_validate_v_2_function_implementation(
         cls, values: FunctionImplementation.Partial
     ) -> FunctionImplementation.Partial:
         for validator in FunctionImplementation.Validators._pre_validators:
@@ -163,7 +163,7 @@ class FunctionImplementation(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_function_implementation_validate(
+    def _post_validate_v_2_function_implementation(
         cls, values: FunctionImplementation.Partial
     ) -> FunctionImplementation.Partial:
         for validator in FunctionImplementation.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_function_implementation.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_function_implementation.py
@@ -155,7 +155,7 @@ class FunctionImplementation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_function_implementation_validate(
+    def _pre_v_2_function_implementation_validate(
         cls, values: FunctionImplementation.Partial
     ) -> FunctionImplementation.Partial:
         for validator in FunctionImplementation.Validators._pre_validators:
@@ -163,7 +163,7 @@ class FunctionImplementation(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_function_implementation_validate(
+    def _post_v_2_function_implementation_validate(
         cls, values: FunctionImplementation.Partial
     ) -> FunctionImplementation.Partial:
         for validator in FunctionImplementation.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_function_implementation_for_multiple_languages.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_function_implementation_for_multiple_languages.py
@@ -136,7 +136,7 @@ class FunctionImplementationForMultipleLanguages(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_function_implementation_for_multiple_languages_validate(
+    def _pre_validate_v_2_function_implementation_for_multiple_languages(
         cls, values: FunctionImplementationForMultipleLanguages.Partial
     ) -> FunctionImplementationForMultipleLanguages.Partial:
         for validator in FunctionImplementationForMultipleLanguages.Validators._pre_validators:
@@ -144,7 +144,7 @@ class FunctionImplementationForMultipleLanguages(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_function_implementation_for_multiple_languages_validate(
+    def _post_validate_v_2_function_implementation_for_multiple_languages(
         cls, values: FunctionImplementationForMultipleLanguages.Partial
     ) -> FunctionImplementationForMultipleLanguages.Partial:
         for validator in FunctionImplementationForMultipleLanguages.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_function_implementation_for_multiple_languages.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_function_implementation_for_multiple_languages.py
@@ -136,7 +136,7 @@ class FunctionImplementationForMultipleLanguages(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(
+    def _prev_2_function_implementation_for_multiple_languages_validate(
         cls, values: FunctionImplementationForMultipleLanguages.Partial
     ) -> FunctionImplementationForMultipleLanguages.Partial:
         for validator in FunctionImplementationForMultipleLanguages.Validators._pre_validators:
@@ -144,7 +144,7 @@ class FunctionImplementationForMultipleLanguages(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(
+    def _postv_2_function_implementation_for_multiple_languages_validate(
         cls, values: FunctionImplementationForMultipleLanguages.Partial
     ) -> FunctionImplementationForMultipleLanguages.Partial:
         for validator in FunctionImplementationForMultipleLanguages.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_function_implementation_for_multiple_languages.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_function_implementation_for_multiple_languages.py
@@ -136,7 +136,7 @@ class FunctionImplementationForMultipleLanguages(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_function_implementation_for_multiple_languages_validate(
+    def _pre_v_2_function_implementation_for_multiple_languages_validate(
         cls, values: FunctionImplementationForMultipleLanguages.Partial
     ) -> FunctionImplementationForMultipleLanguages.Partial:
         for validator in FunctionImplementationForMultipleLanguages.Validators._pre_validators:
@@ -144,7 +144,7 @@ class FunctionImplementationForMultipleLanguages(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_function_implementation_for_multiple_languages_validate(
+    def _post_v_2_function_implementation_for_multiple_languages_validate(
         cls, values: FunctionImplementationForMultipleLanguages.Partial
     ) -> FunctionImplementationForMultipleLanguages.Partial:
         for validator in FunctionImplementationForMultipleLanguages.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_generated_files.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_generated_files.py
@@ -217,13 +217,13 @@ class GeneratedFiles(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_generated_files_validate(cls, values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
+    def _pre_validate_v_2_generated_files(cls, values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
         for validator in GeneratedFiles.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_generated_files_validate(cls, values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
+    def _post_validate_v_2_generated_files(cls, values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
         for validator in GeneratedFiles.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_generated_files.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_generated_files.py
@@ -217,13 +217,13 @@ class GeneratedFiles(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_generated_files_validate(cls, values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
+    def _pre_v_2_generated_files_validate(cls, values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
         for validator in GeneratedFiles.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_generated_files_validate(cls, values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
+    def _post_v_2_generated_files_validate(cls, values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
         for validator in GeneratedFiles.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_generated_files.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_generated_files.py
@@ -217,13 +217,13 @@ class GeneratedFiles(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
+    def _prev_2_generated_files_validate(cls, values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
         for validator in GeneratedFiles.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
+    def _postv_2_generated_files_validate(cls, values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
         for validator in GeneratedFiles.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_get_basic_solution_file_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_get_basic_solution_file_request.py
@@ -167,7 +167,7 @@ class GetBasicSolutionFileRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_get_basic_solution_file_request_validate(
+    def _pre_validate_v_2_get_basic_solution_file_request(
         cls, values: GetBasicSolutionFileRequest.Partial
     ) -> GetBasicSolutionFileRequest.Partial:
         for validator in GetBasicSolutionFileRequest.Validators._pre_validators:
@@ -175,7 +175,7 @@ class GetBasicSolutionFileRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_get_basic_solution_file_request_validate(
+    def _post_validate_v_2_get_basic_solution_file_request(
         cls, values: GetBasicSolutionFileRequest.Partial
     ) -> GetBasicSolutionFileRequest.Partial:
         for validator in GetBasicSolutionFileRequest.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_get_basic_solution_file_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_get_basic_solution_file_request.py
@@ -167,13 +167,17 @@ class GetBasicSolutionFileRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: GetBasicSolutionFileRequest.Partial) -> GetBasicSolutionFileRequest.Partial:
+    def _prev_2_get_basic_solution_file_request_validate(
+        cls, values: GetBasicSolutionFileRequest.Partial
+    ) -> GetBasicSolutionFileRequest.Partial:
         for validator in GetBasicSolutionFileRequest.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: GetBasicSolutionFileRequest.Partial) -> GetBasicSolutionFileRequest.Partial:
+    def _postv_2_get_basic_solution_file_request_validate(
+        cls, values: GetBasicSolutionFileRequest.Partial
+    ) -> GetBasicSolutionFileRequest.Partial:
         for validator in GetBasicSolutionFileRequest.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_get_basic_solution_file_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_get_basic_solution_file_request.py
@@ -167,7 +167,7 @@ class GetBasicSolutionFileRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_get_basic_solution_file_request_validate(
+    def _pre_v_2_get_basic_solution_file_request_validate(
         cls, values: GetBasicSolutionFileRequest.Partial
     ) -> GetBasicSolutionFileRequest.Partial:
         for validator in GetBasicSolutionFileRequest.Validators._pre_validators:
@@ -175,7 +175,7 @@ class GetBasicSolutionFileRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_get_basic_solution_file_request_validate(
+    def _post_v_2_get_basic_solution_file_request_validate(
         cls, values: GetBasicSolutionFileRequest.Partial
     ) -> GetBasicSolutionFileRequest.Partial:
         for validator in GetBasicSolutionFileRequest.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_get_basic_solution_file_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_get_basic_solution_file_response.py
@@ -129,13 +129,17 @@ class GetBasicSolutionFileResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: GetBasicSolutionFileResponse.Partial) -> GetBasicSolutionFileResponse.Partial:
+    def _prev_2_get_basic_solution_file_response_validate(
+        cls, values: GetBasicSolutionFileResponse.Partial
+    ) -> GetBasicSolutionFileResponse.Partial:
         for validator in GetBasicSolutionFileResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: GetBasicSolutionFileResponse.Partial) -> GetBasicSolutionFileResponse.Partial:
+    def _postv_2_get_basic_solution_file_response_validate(
+        cls, values: GetBasicSolutionFileResponse.Partial
+    ) -> GetBasicSolutionFileResponse.Partial:
         for validator in GetBasicSolutionFileResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_get_basic_solution_file_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_get_basic_solution_file_response.py
@@ -129,7 +129,7 @@ class GetBasicSolutionFileResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_get_basic_solution_file_response_validate(
+    def _pre_v_2_get_basic_solution_file_response_validate(
         cls, values: GetBasicSolutionFileResponse.Partial
     ) -> GetBasicSolutionFileResponse.Partial:
         for validator in GetBasicSolutionFileResponse.Validators._pre_validators:
@@ -137,7 +137,7 @@ class GetBasicSolutionFileResponse(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_get_basic_solution_file_response_validate(
+    def _post_v_2_get_basic_solution_file_response_validate(
         cls, values: GetBasicSolutionFileResponse.Partial
     ) -> GetBasicSolutionFileResponse.Partial:
         for validator in GetBasicSolutionFileResponse.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_get_basic_solution_file_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_get_basic_solution_file_response.py
@@ -129,7 +129,7 @@ class GetBasicSolutionFileResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_get_basic_solution_file_response_validate(
+    def _pre_validate_v_2_get_basic_solution_file_response(
         cls, values: GetBasicSolutionFileResponse.Partial
     ) -> GetBasicSolutionFileResponse.Partial:
         for validator in GetBasicSolutionFileResponse.Validators._pre_validators:
@@ -137,7 +137,7 @@ class GetBasicSolutionFileResponse(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_get_basic_solution_file_response_validate(
+    def _post_validate_v_2_get_basic_solution_file_response(
         cls, values: GetBasicSolutionFileResponse.Partial
     ) -> GetBasicSolutionFileResponse.Partial:
         for validator in GetBasicSolutionFileResponse.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_get_function_signature_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_get_function_signature_request.py
@@ -125,7 +125,7 @@ class GetFunctionSignatureRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_get_function_signature_request_validate(
+    def _pre_validate_v_2_get_function_signature_request(
         cls, values: GetFunctionSignatureRequest.Partial
     ) -> GetFunctionSignatureRequest.Partial:
         for validator in GetFunctionSignatureRequest.Validators._pre_validators:
@@ -133,7 +133,7 @@ class GetFunctionSignatureRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_get_function_signature_request_validate(
+    def _post_validate_v_2_get_function_signature_request(
         cls, values: GetFunctionSignatureRequest.Partial
     ) -> GetFunctionSignatureRequest.Partial:
         for validator in GetFunctionSignatureRequest.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_get_function_signature_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_get_function_signature_request.py
@@ -125,13 +125,17 @@ class GetFunctionSignatureRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: GetFunctionSignatureRequest.Partial) -> GetFunctionSignatureRequest.Partial:
+    def _prev_2_get_function_signature_request_validate(
+        cls, values: GetFunctionSignatureRequest.Partial
+    ) -> GetFunctionSignatureRequest.Partial:
         for validator in GetFunctionSignatureRequest.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: GetFunctionSignatureRequest.Partial) -> GetFunctionSignatureRequest.Partial:
+    def _postv_2_get_function_signature_request_validate(
+        cls, values: GetFunctionSignatureRequest.Partial
+    ) -> GetFunctionSignatureRequest.Partial:
         for validator in GetFunctionSignatureRequest.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_get_function_signature_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_get_function_signature_request.py
@@ -125,7 +125,7 @@ class GetFunctionSignatureRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_get_function_signature_request_validate(
+    def _pre_v_2_get_function_signature_request_validate(
         cls, values: GetFunctionSignatureRequest.Partial
     ) -> GetFunctionSignatureRequest.Partial:
         for validator in GetFunctionSignatureRequest.Validators._pre_validators:
@@ -133,7 +133,7 @@ class GetFunctionSignatureRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_get_function_signature_request_validate(
+    def _post_v_2_get_function_signature_request_validate(
         cls, values: GetFunctionSignatureRequest.Partial
     ) -> GetFunctionSignatureRequest.Partial:
         for validator in GetFunctionSignatureRequest.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_get_function_signature_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_get_function_signature_response.py
@@ -125,7 +125,7 @@ class GetFunctionSignatureResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_get_function_signature_response_validate(
+    def _pre_v_2_get_function_signature_response_validate(
         cls, values: GetFunctionSignatureResponse.Partial
     ) -> GetFunctionSignatureResponse.Partial:
         for validator in GetFunctionSignatureResponse.Validators._pre_validators:
@@ -133,7 +133,7 @@ class GetFunctionSignatureResponse(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_get_function_signature_response_validate(
+    def _post_v_2_get_function_signature_response_validate(
         cls, values: GetFunctionSignatureResponse.Partial
     ) -> GetFunctionSignatureResponse.Partial:
         for validator in GetFunctionSignatureResponse.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_get_function_signature_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_get_function_signature_response.py
@@ -125,7 +125,7 @@ class GetFunctionSignatureResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_get_function_signature_response_validate(
+    def _pre_validate_v_2_get_function_signature_response(
         cls, values: GetFunctionSignatureResponse.Partial
     ) -> GetFunctionSignatureResponse.Partial:
         for validator in GetFunctionSignatureResponse.Validators._pre_validators:
@@ -133,7 +133,7 @@ class GetFunctionSignatureResponse(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_get_function_signature_response_validate(
+    def _post_validate_v_2_get_function_signature_response(
         cls, values: GetFunctionSignatureResponse.Partial
     ) -> GetFunctionSignatureResponse.Partial:
         for validator in GetFunctionSignatureResponse.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_get_function_signature_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_get_function_signature_response.py
@@ -125,13 +125,17 @@ class GetFunctionSignatureResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: GetFunctionSignatureResponse.Partial) -> GetFunctionSignatureResponse.Partial:
+    def _prev_2_get_function_signature_response_validate(
+        cls, values: GetFunctionSignatureResponse.Partial
+    ) -> GetFunctionSignatureResponse.Partial:
         for validator in GetFunctionSignatureResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: GetFunctionSignatureResponse.Partial) -> GetFunctionSignatureResponse.Partial:
+    def _postv_2_get_function_signature_response_validate(
+        cls, values: GetFunctionSignatureResponse.Partial
+    ) -> GetFunctionSignatureResponse.Partial:
         for validator in GetFunctionSignatureResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_get_generated_test_case_file_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_get_generated_test_case_file_request.py
@@ -170,13 +170,17 @@ class GetGeneratedTestCaseFileRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: GetGeneratedTestCaseFileRequest.Partial) -> GetGeneratedTestCaseFileRequest.Partial:
+    def _prev_2_get_generated_test_case_file_request_validate(
+        cls, values: GetGeneratedTestCaseFileRequest.Partial
+    ) -> GetGeneratedTestCaseFileRequest.Partial:
         for validator in GetGeneratedTestCaseFileRequest.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: GetGeneratedTestCaseFileRequest.Partial) -> GetGeneratedTestCaseFileRequest.Partial:
+    def _postv_2_get_generated_test_case_file_request_validate(
+        cls, values: GetGeneratedTestCaseFileRequest.Partial
+    ) -> GetGeneratedTestCaseFileRequest.Partial:
         for validator in GetGeneratedTestCaseFileRequest.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_get_generated_test_case_file_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_get_generated_test_case_file_request.py
@@ -170,7 +170,7 @@ class GetGeneratedTestCaseFileRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_get_generated_test_case_file_request_validate(
+    def _pre_v_2_get_generated_test_case_file_request_validate(
         cls, values: GetGeneratedTestCaseFileRequest.Partial
     ) -> GetGeneratedTestCaseFileRequest.Partial:
         for validator in GetGeneratedTestCaseFileRequest.Validators._pre_validators:
@@ -178,7 +178,7 @@ class GetGeneratedTestCaseFileRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_get_generated_test_case_file_request_validate(
+    def _post_v_2_get_generated_test_case_file_request_validate(
         cls, values: GetGeneratedTestCaseFileRequest.Partial
     ) -> GetGeneratedTestCaseFileRequest.Partial:
         for validator in GetGeneratedTestCaseFileRequest.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_get_generated_test_case_file_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_get_generated_test_case_file_request.py
@@ -170,7 +170,7 @@ class GetGeneratedTestCaseFileRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_get_generated_test_case_file_request_validate(
+    def _pre_validate_v_2_get_generated_test_case_file_request(
         cls, values: GetGeneratedTestCaseFileRequest.Partial
     ) -> GetGeneratedTestCaseFileRequest.Partial:
         for validator in GetGeneratedTestCaseFileRequest.Validators._pre_validators:
@@ -178,7 +178,7 @@ class GetGeneratedTestCaseFileRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_get_generated_test_case_file_request_validate(
+    def _post_validate_v_2_get_generated_test_case_file_request(
         cls, values: GetGeneratedTestCaseFileRequest.Partial
     ) -> GetGeneratedTestCaseFileRequest.Partial:
         for validator in GetGeneratedTestCaseFileRequest.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_get_generated_test_case_template_file_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_get_generated_test_case_template_file_request.py
@@ -130,7 +130,7 @@ class GetGeneratedTestCaseTemplateFileRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(
+    def _prev_2_get_generated_test_case_template_file_request_validate(
         cls, values: GetGeneratedTestCaseTemplateFileRequest.Partial
     ) -> GetGeneratedTestCaseTemplateFileRequest.Partial:
         for validator in GetGeneratedTestCaseTemplateFileRequest.Validators._pre_validators:
@@ -138,7 +138,7 @@ class GetGeneratedTestCaseTemplateFileRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(
+    def _postv_2_get_generated_test_case_template_file_request_validate(
         cls, values: GetGeneratedTestCaseTemplateFileRequest.Partial
     ) -> GetGeneratedTestCaseTemplateFileRequest.Partial:
         for validator in GetGeneratedTestCaseTemplateFileRequest.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_get_generated_test_case_template_file_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_get_generated_test_case_template_file_request.py
@@ -130,7 +130,7 @@ class GetGeneratedTestCaseTemplateFileRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_get_generated_test_case_template_file_request_validate(
+    def _pre_v_2_get_generated_test_case_template_file_request_validate(
         cls, values: GetGeneratedTestCaseTemplateFileRequest.Partial
     ) -> GetGeneratedTestCaseTemplateFileRequest.Partial:
         for validator in GetGeneratedTestCaseTemplateFileRequest.Validators._pre_validators:
@@ -138,7 +138,7 @@ class GetGeneratedTestCaseTemplateFileRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_get_generated_test_case_template_file_request_validate(
+    def _post_v_2_get_generated_test_case_template_file_request_validate(
         cls, values: GetGeneratedTestCaseTemplateFileRequest.Partial
     ) -> GetGeneratedTestCaseTemplateFileRequest.Partial:
         for validator in GetGeneratedTestCaseTemplateFileRequest.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_get_generated_test_case_template_file_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_get_generated_test_case_template_file_request.py
@@ -130,7 +130,7 @@ class GetGeneratedTestCaseTemplateFileRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_get_generated_test_case_template_file_request_validate(
+    def _pre_validate_v_2_get_generated_test_case_template_file_request(
         cls, values: GetGeneratedTestCaseTemplateFileRequest.Partial
     ) -> GetGeneratedTestCaseTemplateFileRequest.Partial:
         for validator in GetGeneratedTestCaseTemplateFileRequest.Validators._pre_validators:
@@ -138,7 +138,7 @@ class GetGeneratedTestCaseTemplateFileRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_get_generated_test_case_template_file_request_validate(
+    def _post_validate_v_2_get_generated_test_case_template_file_request(
         cls, values: GetGeneratedTestCaseTemplateFileRequest.Partial
     ) -> GetGeneratedTestCaseTemplateFileRequest.Partial:
         for validator in GetGeneratedTestCaseTemplateFileRequest.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_lightweight_problem_info_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_lightweight_problem_info_v_2.py
@@ -263,13 +263,17 @@ class LightweightProblemInfoV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: LightweightProblemInfoV2.Partial) -> LightweightProblemInfoV2.Partial:
+    def _prev_2_lightweight_problem_info_v_2_validate(
+        cls, values: LightweightProblemInfoV2.Partial
+    ) -> LightweightProblemInfoV2.Partial:
         for validator in LightweightProblemInfoV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: LightweightProblemInfoV2.Partial) -> LightweightProblemInfoV2.Partial:
+    def _postv_2_lightweight_problem_info_v_2_validate(
+        cls, values: LightweightProblemInfoV2.Partial
+    ) -> LightweightProblemInfoV2.Partial:
         for validator in LightweightProblemInfoV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_lightweight_problem_info_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_lightweight_problem_info_v_2.py
@@ -263,7 +263,7 @@ class LightweightProblemInfoV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_lightweight_problem_info_v_2_validate(
+    def _pre_v_2_lightweight_problem_info_v_2_validate(
         cls, values: LightweightProblemInfoV2.Partial
     ) -> LightweightProblemInfoV2.Partial:
         for validator in LightweightProblemInfoV2.Validators._pre_validators:
@@ -271,7 +271,7 @@ class LightweightProblemInfoV2(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_lightweight_problem_info_v_2_validate(
+    def _post_v_2_lightweight_problem_info_v_2_validate(
         cls, values: LightweightProblemInfoV2.Partial
     ) -> LightweightProblemInfoV2.Partial:
         for validator in LightweightProblemInfoV2.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_lightweight_problem_info_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_lightweight_problem_info_v_2.py
@@ -263,7 +263,7 @@ class LightweightProblemInfoV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_lightweight_problem_info_v_2_validate(
+    def _pre_validate_v_2_lightweight_problem_info_v_2(
         cls, values: LightweightProblemInfoV2.Partial
     ) -> LightweightProblemInfoV2.Partial:
         for validator in LightweightProblemInfoV2.Validators._pre_validators:
@@ -271,7 +271,7 @@ class LightweightProblemInfoV2(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_lightweight_problem_info_v_2_validate(
+    def _post_validate_v_2_lightweight_problem_info_v_2(
         cls, values: LightweightProblemInfoV2.Partial
     ) -> LightweightProblemInfoV2.Partial:
         for validator in LightweightProblemInfoV2.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_non_void_function_definition.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_non_void_function_definition.py
@@ -164,13 +164,17 @@ class NonVoidFunctionDefinition(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: NonVoidFunctionDefinition.Partial) -> NonVoidFunctionDefinition.Partial:
+    def _prev_2_non_void_function_definition_validate(
+        cls, values: NonVoidFunctionDefinition.Partial
+    ) -> NonVoidFunctionDefinition.Partial:
         for validator in NonVoidFunctionDefinition.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: NonVoidFunctionDefinition.Partial) -> NonVoidFunctionDefinition.Partial:
+    def _postv_2_non_void_function_definition_validate(
+        cls, values: NonVoidFunctionDefinition.Partial
+    ) -> NonVoidFunctionDefinition.Partial:
         for validator in NonVoidFunctionDefinition.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_non_void_function_definition.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_non_void_function_definition.py
@@ -164,7 +164,7 @@ class NonVoidFunctionDefinition(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_non_void_function_definition_validate(
+    def _pre_v_2_non_void_function_definition_validate(
         cls, values: NonVoidFunctionDefinition.Partial
     ) -> NonVoidFunctionDefinition.Partial:
         for validator in NonVoidFunctionDefinition.Validators._pre_validators:
@@ -172,7 +172,7 @@ class NonVoidFunctionDefinition(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_non_void_function_definition_validate(
+    def _post_v_2_non_void_function_definition_validate(
         cls, values: NonVoidFunctionDefinition.Partial
     ) -> NonVoidFunctionDefinition.Partial:
         for validator in NonVoidFunctionDefinition.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_non_void_function_definition.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_non_void_function_definition.py
@@ -164,7 +164,7 @@ class NonVoidFunctionDefinition(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_non_void_function_definition_validate(
+    def _pre_validate_v_2_non_void_function_definition(
         cls, values: NonVoidFunctionDefinition.Partial
     ) -> NonVoidFunctionDefinition.Partial:
         for validator in NonVoidFunctionDefinition.Validators._pre_validators:
@@ -172,7 +172,7 @@ class NonVoidFunctionDefinition(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_non_void_function_definition_validate(
+    def _post_validate_v_2_non_void_function_definition(
         cls, values: NonVoidFunctionDefinition.Partial
     ) -> NonVoidFunctionDefinition.Partial:
         for validator in NonVoidFunctionDefinition.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_non_void_function_signature.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_non_void_function_signature.py
@@ -167,7 +167,7 @@ class NonVoidFunctionSignature(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_non_void_function_signature_validate(
+    def _pre_validate_v_2_non_void_function_signature(
         cls, values: NonVoidFunctionSignature.Partial
     ) -> NonVoidFunctionSignature.Partial:
         for validator in NonVoidFunctionSignature.Validators._pre_validators:
@@ -175,7 +175,7 @@ class NonVoidFunctionSignature(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_non_void_function_signature_validate(
+    def _post_validate_v_2_non_void_function_signature(
         cls, values: NonVoidFunctionSignature.Partial
     ) -> NonVoidFunctionSignature.Partial:
         for validator in NonVoidFunctionSignature.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_non_void_function_signature.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_non_void_function_signature.py
@@ -167,7 +167,7 @@ class NonVoidFunctionSignature(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_non_void_function_signature_validate(
+    def _pre_v_2_non_void_function_signature_validate(
         cls, values: NonVoidFunctionSignature.Partial
     ) -> NonVoidFunctionSignature.Partial:
         for validator in NonVoidFunctionSignature.Validators._pre_validators:
@@ -175,7 +175,7 @@ class NonVoidFunctionSignature(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_non_void_function_signature_validate(
+    def _post_v_2_non_void_function_signature_validate(
         cls, values: NonVoidFunctionSignature.Partial
     ) -> NonVoidFunctionSignature.Partial:
         for validator in NonVoidFunctionSignature.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_non_void_function_signature.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_non_void_function_signature.py
@@ -167,13 +167,17 @@ class NonVoidFunctionSignature(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: NonVoidFunctionSignature.Partial) -> NonVoidFunctionSignature.Partial:
+    def _prev_2_non_void_function_signature_validate(
+        cls, values: NonVoidFunctionSignature.Partial
+    ) -> NonVoidFunctionSignature.Partial:
         for validator in NonVoidFunctionSignature.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: NonVoidFunctionSignature.Partial) -> NonVoidFunctionSignature.Partial:
+    def _postv_2_non_void_function_signature_validate(
+        cls, values: NonVoidFunctionSignature.Partial
+    ) -> NonVoidFunctionSignature.Partial:
         for validator in NonVoidFunctionSignature.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_parameter.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_parameter.py
@@ -182,13 +182,13 @@ class Parameter(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_parameter_validate(cls, values: Parameter.Partial) -> Parameter.Partial:
+    def _pre_validate_v_2_parameter(cls, values: Parameter.Partial) -> Parameter.Partial:
         for validator in Parameter.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_parameter_validate(cls, values: Parameter.Partial) -> Parameter.Partial:
+    def _post_validate_v_2_parameter(cls, values: Parameter.Partial) -> Parameter.Partial:
         for validator in Parameter.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_parameter.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_parameter.py
@@ -182,13 +182,13 @@ class Parameter(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: Parameter.Partial) -> Parameter.Partial:
+    def _prev_2_parameter_validate(cls, values: Parameter.Partial) -> Parameter.Partial:
         for validator in Parameter.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: Parameter.Partial) -> Parameter.Partial:
+    def _postv_2_parameter_validate(cls, values: Parameter.Partial) -> Parameter.Partial:
         for validator in Parameter.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_parameter.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_parameter.py
@@ -182,13 +182,13 @@ class Parameter(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_parameter_validate(cls, values: Parameter.Partial) -> Parameter.Partial:
+    def _pre_v_2_parameter_validate(cls, values: Parameter.Partial) -> Parameter.Partial:
         for validator in Parameter.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_parameter_validate(cls, values: Parameter.Partial) -> Parameter.Partial:
+    def _post_v_2_parameter_validate(cls, values: Parameter.Partial) -> Parameter.Partial:
         for validator in Parameter.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_problem_info_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_problem_info_v_2.py
@@ -513,13 +513,13 @@ class ProblemInfoV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_problem_info_v_2_validate(cls, values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
+    def _pre_v_2_problem_info_v_2_validate(cls, values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
         for validator in ProblemInfoV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_problem_info_v_2_validate(cls, values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
+    def _post_v_2_problem_info_v_2_validate(cls, values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
         for validator in ProblemInfoV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_problem_info_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_problem_info_v_2.py
@@ -513,13 +513,13 @@ class ProblemInfoV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_problem_info_v_2_validate(cls, values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
+    def _pre_validate_v_2_problem_info_v_2(cls, values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
         for validator in ProblemInfoV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_problem_info_v_2_validate(cls, values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
+    def _post_validate_v_2_problem_info_v_2(cls, values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
         for validator in ProblemInfoV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_problem_info_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_problem_info_v_2.py
@@ -513,13 +513,13 @@ class ProblemInfoV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
+    def _prev_2_problem_info_v_2_validate(cls, values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
         for validator in ProblemInfoV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
+    def _postv_2_problem_info_v_2_validate(cls, values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
         for validator in ProblemInfoV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_test_case_expects.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_test_case_expects.py
@@ -117,13 +117,13 @@ class TestCaseExpects(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
+    def _prev_2_test_case_expects_validate(cls, values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
         for validator in TestCaseExpects.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
+    def _postv_2_test_case_expects_validate(cls, values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
         for validator in TestCaseExpects.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_test_case_expects.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_test_case_expects.py
@@ -117,13 +117,13 @@ class TestCaseExpects(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_test_case_expects_validate(cls, values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
+    def _pre_v_2_test_case_expects_validate(cls, values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
         for validator in TestCaseExpects.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_test_case_expects_validate(cls, values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
+    def _post_v_2_test_case_expects_validate(cls, values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
         for validator in TestCaseExpects.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_test_case_expects.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_test_case_expects.py
@@ -117,13 +117,13 @@ class TestCaseExpects(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_test_case_expects_validate(cls, values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
+    def _pre_validate_v_2_test_case_expects(cls, values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
         for validator in TestCaseExpects.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_test_case_expects_validate(cls, values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
+    def _post_validate_v_2_test_case_expects(cls, values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
         for validator in TestCaseExpects.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_test_case_implementation.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_test_case_implementation.py
@@ -165,7 +165,7 @@ class TestCaseImplementation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_test_case_implementation_validate(
+    def _pre_v_2_test_case_implementation_validate(
         cls, values: TestCaseImplementation.Partial
     ) -> TestCaseImplementation.Partial:
         for validator in TestCaseImplementation.Validators._pre_validators:
@@ -173,7 +173,7 @@ class TestCaseImplementation(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_test_case_implementation_validate(
+    def _post_v_2_test_case_implementation_validate(
         cls, values: TestCaseImplementation.Partial
     ) -> TestCaseImplementation.Partial:
         for validator in TestCaseImplementation.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_test_case_implementation.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_test_case_implementation.py
@@ -165,13 +165,17 @@ class TestCaseImplementation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TestCaseImplementation.Partial) -> TestCaseImplementation.Partial:
+    def _prev_2_test_case_implementation_validate(
+        cls, values: TestCaseImplementation.Partial
+    ) -> TestCaseImplementation.Partial:
         for validator in TestCaseImplementation.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TestCaseImplementation.Partial) -> TestCaseImplementation.Partial:
+    def _postv_2_test_case_implementation_validate(
+        cls, values: TestCaseImplementation.Partial
+    ) -> TestCaseImplementation.Partial:
         for validator in TestCaseImplementation.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_test_case_implementation.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_test_case_implementation.py
@@ -165,7 +165,7 @@ class TestCaseImplementation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_test_case_implementation_validate(
+    def _pre_validate_v_2_test_case_implementation(
         cls, values: TestCaseImplementation.Partial
     ) -> TestCaseImplementation.Partial:
         for validator in TestCaseImplementation.Validators._pre_validators:
@@ -173,7 +173,7 @@ class TestCaseImplementation(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_test_case_implementation_validate(
+    def _post_validate_v_2_test_case_implementation(
         cls, values: TestCaseImplementation.Partial
     ) -> TestCaseImplementation.Partial:
         for validator in TestCaseImplementation.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_test_case_implementation_description.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_test_case_implementation_description.py
@@ -128,7 +128,7 @@ class TestCaseImplementationDescription(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(
+    def _prev_2_test_case_implementation_description_validate(
         cls, values: TestCaseImplementationDescription.Partial
     ) -> TestCaseImplementationDescription.Partial:
         for validator in TestCaseImplementationDescription.Validators._pre_validators:
@@ -136,7 +136,7 @@ class TestCaseImplementationDescription(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(
+    def _postv_2_test_case_implementation_description_validate(
         cls, values: TestCaseImplementationDescription.Partial
     ) -> TestCaseImplementationDescription.Partial:
         for validator in TestCaseImplementationDescription.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_test_case_implementation_description.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_test_case_implementation_description.py
@@ -128,7 +128,7 @@ class TestCaseImplementationDescription(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_test_case_implementation_description_validate(
+    def _pre_v_2_test_case_implementation_description_validate(
         cls, values: TestCaseImplementationDescription.Partial
     ) -> TestCaseImplementationDescription.Partial:
         for validator in TestCaseImplementationDescription.Validators._pre_validators:
@@ -136,7 +136,7 @@ class TestCaseImplementationDescription(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_test_case_implementation_description_validate(
+    def _post_v_2_test_case_implementation_description_validate(
         cls, values: TestCaseImplementationDescription.Partial
     ) -> TestCaseImplementationDescription.Partial:
         for validator in TestCaseImplementationDescription.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_test_case_implementation_description.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_test_case_implementation_description.py
@@ -128,7 +128,7 @@ class TestCaseImplementationDescription(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_test_case_implementation_description_validate(
+    def _pre_validate_v_2_test_case_implementation_description(
         cls, values: TestCaseImplementationDescription.Partial
     ) -> TestCaseImplementationDescription.Partial:
         for validator in TestCaseImplementationDescription.Validators._pre_validators:
@@ -136,7 +136,7 @@ class TestCaseImplementationDescription(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_test_case_implementation_description_validate(
+    def _post_validate_v_2_test_case_implementation_description(
         cls, values: TestCaseImplementationDescription.Partial
     ) -> TestCaseImplementationDescription.Partial:
         for validator in TestCaseImplementationDescription.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_test_case_metadata.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_test_case_metadata.py
@@ -182,13 +182,13 @@ class TestCaseMetadata(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_test_case_metadata_validate(cls, values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
+    def _pre_validate_v_2_test_case_metadata(cls, values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
         for validator in TestCaseMetadata.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_test_case_metadata_validate(cls, values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
+    def _post_validate_v_2_test_case_metadata(cls, values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
         for validator in TestCaseMetadata.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_test_case_metadata.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_test_case_metadata.py
@@ -182,13 +182,13 @@ class TestCaseMetadata(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_test_case_metadata_validate(cls, values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
+    def _pre_v_2_test_case_metadata_validate(cls, values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
         for validator in TestCaseMetadata.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_test_case_metadata_validate(cls, values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
+    def _post_v_2_test_case_metadata_validate(cls, values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
         for validator in TestCaseMetadata.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_test_case_metadata.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_test_case_metadata.py
@@ -182,13 +182,13 @@ class TestCaseMetadata(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
+    def _prev_2_test_case_metadata_validate(cls, values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
         for validator in TestCaseMetadata.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
+    def _postv_2_test_case_metadata_validate(cls, values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
         for validator in TestCaseMetadata.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_test_case_template.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_test_case_template.py
@@ -199,13 +199,13 @@ class TestCaseTemplate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_test_case_template_validate(cls, values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
+    def _pre_v_2_test_case_template_validate(cls, values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
         for validator in TestCaseTemplate.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_test_case_template_validate(cls, values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
+    def _post_v_2_test_case_template_validate(cls, values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
         for validator in TestCaseTemplate.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_test_case_template.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_test_case_template.py
@@ -199,13 +199,13 @@ class TestCaseTemplate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_test_case_template_validate(cls, values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
+    def _pre_validate_v_2_test_case_template(cls, values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
         for validator in TestCaseTemplate.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_test_case_template_validate(cls, values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
+    def _post_validate_v_2_test_case_template(cls, values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
         for validator in TestCaseTemplate.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_test_case_template.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_test_case_template.py
@@ -199,13 +199,13 @@ class TestCaseTemplate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
+    def _prev_2_test_case_template_validate(cls, values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
         for validator in TestCaseTemplate.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
+    def _postv_2_test_case_template_validate(cls, values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
         for validator in TestCaseTemplate.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_test_case_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_test_case_v_2.py
@@ -232,13 +232,13 @@ class TestCaseV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TestCaseV2.Partial) -> TestCaseV2.Partial:
+    def _prev_2_test_case_v_2_validate(cls, values: TestCaseV2.Partial) -> TestCaseV2.Partial:
         for validator in TestCaseV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TestCaseV2.Partial) -> TestCaseV2.Partial:
+    def _postv_2_test_case_v_2_validate(cls, values: TestCaseV2.Partial) -> TestCaseV2.Partial:
         for validator in TestCaseV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_test_case_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_test_case_v_2.py
@@ -232,13 +232,13 @@ class TestCaseV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_test_case_v_2_validate(cls, values: TestCaseV2.Partial) -> TestCaseV2.Partial:
+    def _pre_v_2_test_case_v_2_validate(cls, values: TestCaseV2.Partial) -> TestCaseV2.Partial:
         for validator in TestCaseV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_test_case_v_2_validate(cls, values: TestCaseV2.Partial) -> TestCaseV2.Partial:
+    def _post_v_2_test_case_v_2_validate(cls, values: TestCaseV2.Partial) -> TestCaseV2.Partial:
         for validator in TestCaseV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_test_case_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_test_case_v_2.py
@@ -232,13 +232,13 @@ class TestCaseV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_test_case_v_2_validate(cls, values: TestCaseV2.Partial) -> TestCaseV2.Partial:
+    def _pre_validate_v_2_test_case_v_2(cls, values: TestCaseV2.Partial) -> TestCaseV2.Partial:
         for validator in TestCaseV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_test_case_v_2_validate(cls, values: TestCaseV2.Partial) -> TestCaseV2.Partial:
+    def _post_validate_v_2_test_case_v_2(cls, values: TestCaseV2.Partial) -> TestCaseV2.Partial:
         for validator in TestCaseV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_test_case_with_actual_result_implementation.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_test_case_with_actual_result_implementation.py
@@ -185,7 +185,7 @@ class TestCaseWithActualResultImplementation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(
+    def _prev_2_test_case_with_actual_result_implementation_validate(
         cls, values: TestCaseWithActualResultImplementation.Partial
     ) -> TestCaseWithActualResultImplementation.Partial:
         for validator in TestCaseWithActualResultImplementation.Validators._pre_validators:
@@ -193,7 +193,7 @@ class TestCaseWithActualResultImplementation(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(
+    def _postv_2_test_case_with_actual_result_implementation_validate(
         cls, values: TestCaseWithActualResultImplementation.Partial
     ) -> TestCaseWithActualResultImplementation.Partial:
         for validator in TestCaseWithActualResultImplementation.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_test_case_with_actual_result_implementation.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_test_case_with_actual_result_implementation.py
@@ -185,7 +185,7 @@ class TestCaseWithActualResultImplementation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_test_case_with_actual_result_implementation_validate(
+    def _pre_v_2_test_case_with_actual_result_implementation_validate(
         cls, values: TestCaseWithActualResultImplementation.Partial
     ) -> TestCaseWithActualResultImplementation.Partial:
         for validator in TestCaseWithActualResultImplementation.Validators._pre_validators:
@@ -193,7 +193,7 @@ class TestCaseWithActualResultImplementation(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_test_case_with_actual_result_implementation_validate(
+    def _post_v_2_test_case_with_actual_result_implementation_validate(
         cls, values: TestCaseWithActualResultImplementation.Partial
     ) -> TestCaseWithActualResultImplementation.Partial:
         for validator in TestCaseWithActualResultImplementation.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_test_case_with_actual_result_implementation.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_test_case_with_actual_result_implementation.py
@@ -185,7 +185,7 @@ class TestCaseWithActualResultImplementation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_test_case_with_actual_result_implementation_validate(
+    def _pre_validate_v_2_test_case_with_actual_result_implementation(
         cls, values: TestCaseWithActualResultImplementation.Partial
     ) -> TestCaseWithActualResultImplementation.Partial:
         for validator in TestCaseWithActualResultImplementation.Validators._pre_validators:
@@ -193,7 +193,7 @@ class TestCaseWithActualResultImplementation(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_test_case_with_actual_result_implementation_validate(
+    def _post_validate_v_2_test_case_with_actual_result_implementation(
         cls, values: TestCaseWithActualResultImplementation.Partial
     ) -> TestCaseWithActualResultImplementation.Partial:
         for validator in TestCaseWithActualResultImplementation.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_void_function_definition.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_void_function_definition.py
@@ -162,7 +162,7 @@ class VoidFunctionDefinition(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_void_function_definition_validate(
+    def _pre_v_2_void_function_definition_validate(
         cls, values: VoidFunctionDefinition.Partial
     ) -> VoidFunctionDefinition.Partial:
         for validator in VoidFunctionDefinition.Validators._pre_validators:
@@ -170,7 +170,7 @@ class VoidFunctionDefinition(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_void_function_definition_validate(
+    def _post_v_2_void_function_definition_validate(
         cls, values: VoidFunctionDefinition.Partial
     ) -> VoidFunctionDefinition.Partial:
         for validator in VoidFunctionDefinition.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_void_function_definition.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_void_function_definition.py
@@ -162,13 +162,17 @@ class VoidFunctionDefinition(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: VoidFunctionDefinition.Partial) -> VoidFunctionDefinition.Partial:
+    def _prev_2_void_function_definition_validate(
+        cls, values: VoidFunctionDefinition.Partial
+    ) -> VoidFunctionDefinition.Partial:
         for validator in VoidFunctionDefinition.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: VoidFunctionDefinition.Partial) -> VoidFunctionDefinition.Partial:
+    def _postv_2_void_function_definition_validate(
+        cls, values: VoidFunctionDefinition.Partial
+    ) -> VoidFunctionDefinition.Partial:
         for validator in VoidFunctionDefinition.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_void_function_definition.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_void_function_definition.py
@@ -162,7 +162,7 @@ class VoidFunctionDefinition(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_void_function_definition_validate(
+    def _pre_validate_v_2_void_function_definition(
         cls, values: VoidFunctionDefinition.Partial
     ) -> VoidFunctionDefinition.Partial:
         for validator in VoidFunctionDefinition.Validators._pre_validators:
@@ -170,7 +170,7 @@ class VoidFunctionDefinition(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_void_function_definition_validate(
+    def _post_validate_v_2_void_function_definition(
         cls, values: VoidFunctionDefinition.Partial
     ) -> VoidFunctionDefinition.Partial:
         for validator in VoidFunctionDefinition.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_void_function_definition_that_takes_actual_result.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_void_function_definition_that_takes_actual_result.py
@@ -189,7 +189,7 @@ class VoidFunctionDefinitionThatTakesActualResult(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_void_function_definition_that_takes_actual_result_validate(
+    def _pre_v_2_void_function_definition_that_takes_actual_result_validate(
         cls, values: VoidFunctionDefinitionThatTakesActualResult.Partial
     ) -> VoidFunctionDefinitionThatTakesActualResult.Partial:
         for validator in VoidFunctionDefinitionThatTakesActualResult.Validators._pre_validators:
@@ -197,7 +197,7 @@ class VoidFunctionDefinitionThatTakesActualResult(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_void_function_definition_that_takes_actual_result_validate(
+    def _post_v_2_void_function_definition_that_takes_actual_result_validate(
         cls, values: VoidFunctionDefinitionThatTakesActualResult.Partial
     ) -> VoidFunctionDefinitionThatTakesActualResult.Partial:
         for validator in VoidFunctionDefinitionThatTakesActualResult.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_void_function_definition_that_takes_actual_result.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_void_function_definition_that_takes_actual_result.py
@@ -189,7 +189,7 @@ class VoidFunctionDefinitionThatTakesActualResult(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(
+    def _prev_2_void_function_definition_that_takes_actual_result_validate(
         cls, values: VoidFunctionDefinitionThatTakesActualResult.Partial
     ) -> VoidFunctionDefinitionThatTakesActualResult.Partial:
         for validator in VoidFunctionDefinitionThatTakesActualResult.Validators._pre_validators:
@@ -197,7 +197,7 @@ class VoidFunctionDefinitionThatTakesActualResult(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(
+    def _postv_2_void_function_definition_that_takes_actual_result_validate(
         cls, values: VoidFunctionDefinitionThatTakesActualResult.Partial
     ) -> VoidFunctionDefinitionThatTakesActualResult.Partial:
         for validator in VoidFunctionDefinitionThatTakesActualResult.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_void_function_definition_that_takes_actual_result.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_void_function_definition_that_takes_actual_result.py
@@ -189,7 +189,7 @@ class VoidFunctionDefinitionThatTakesActualResult(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_void_function_definition_that_takes_actual_result_validate(
+    def _pre_validate_v_2_void_function_definition_that_takes_actual_result(
         cls, values: VoidFunctionDefinitionThatTakesActualResult.Partial
     ) -> VoidFunctionDefinitionThatTakesActualResult.Partial:
         for validator in VoidFunctionDefinitionThatTakesActualResult.Validators._pre_validators:
@@ -197,7 +197,7 @@ class VoidFunctionDefinitionThatTakesActualResult(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_void_function_definition_that_takes_actual_result_validate(
+    def _post_validate_v_2_void_function_definition_that_takes_actual_result(
         cls, values: VoidFunctionDefinitionThatTakesActualResult.Partial
     ) -> VoidFunctionDefinitionThatTakesActualResult.Partial:
         for validator in VoidFunctionDefinitionThatTakesActualResult.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_void_function_signature.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_void_function_signature.py
@@ -119,13 +119,17 @@ class VoidFunctionSignature(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: VoidFunctionSignature.Partial) -> VoidFunctionSignature.Partial:
+    def _prev_2_void_function_signature_validate(
+        cls, values: VoidFunctionSignature.Partial
+    ) -> VoidFunctionSignature.Partial:
         for validator in VoidFunctionSignature.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: VoidFunctionSignature.Partial) -> VoidFunctionSignature.Partial:
+    def _postv_2_void_function_signature_validate(
+        cls, values: VoidFunctionSignature.Partial
+    ) -> VoidFunctionSignature.Partial:
         for validator in VoidFunctionSignature.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_void_function_signature.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_void_function_signature.py
@@ -119,7 +119,7 @@ class VoidFunctionSignature(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_void_function_signature_validate(
+    def _pre_v_2_void_function_signature_validate(
         cls, values: VoidFunctionSignature.Partial
     ) -> VoidFunctionSignature.Partial:
         for validator in VoidFunctionSignature.Validators._pre_validators:
@@ -127,7 +127,7 @@ class VoidFunctionSignature(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_void_function_signature_validate(
+    def _post_v_2_void_function_signature_validate(
         cls, values: VoidFunctionSignature.Partial
     ) -> VoidFunctionSignature.Partial:
         for validator in VoidFunctionSignature.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_void_function_signature.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_void_function_signature.py
@@ -119,7 +119,7 @@ class VoidFunctionSignature(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_void_function_signature_validate(
+    def _pre_validate_v_2_void_function_signature(
         cls, values: VoidFunctionSignature.Partial
     ) -> VoidFunctionSignature.Partial:
         for validator in VoidFunctionSignature.Validators._pre_validators:
@@ -127,7 +127,7 @@ class VoidFunctionSignature(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_void_function_signature_validate(
+    def _post_validate_v_2_void_function_signature(
         cls, values: VoidFunctionSignature.Partial
     ) -> VoidFunctionSignature.Partial:
         for validator in VoidFunctionSignature.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_void_function_signature_that_takes_actual_result.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_void_function_signature_that_takes_actual_result.py
@@ -183,7 +183,7 @@ class VoidFunctionSignatureThatTakesActualResult(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(
+    def _prev_2_void_function_signature_that_takes_actual_result_validate(
         cls, values: VoidFunctionSignatureThatTakesActualResult.Partial
     ) -> VoidFunctionSignatureThatTakesActualResult.Partial:
         for validator in VoidFunctionSignatureThatTakesActualResult.Validators._pre_validators:
@@ -191,7 +191,7 @@ class VoidFunctionSignatureThatTakesActualResult(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(
+    def _postv_2_void_function_signature_that_takes_actual_result_validate(
         cls, values: VoidFunctionSignatureThatTakesActualResult.Partial
     ) -> VoidFunctionSignatureThatTakesActualResult.Partial:
         for validator in VoidFunctionSignatureThatTakesActualResult.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_void_function_signature_that_takes_actual_result.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_void_function_signature_that_takes_actual_result.py
@@ -183,7 +183,7 @@ class VoidFunctionSignatureThatTakesActualResult(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_void_function_signature_that_takes_actual_result_validate(
+    def _pre_v_2_void_function_signature_that_takes_actual_result_validate(
         cls, values: VoidFunctionSignatureThatTakesActualResult.Partial
     ) -> VoidFunctionSignatureThatTakesActualResult.Partial:
         for validator in VoidFunctionSignatureThatTakesActualResult.Validators._pre_validators:
@@ -191,7 +191,7 @@ class VoidFunctionSignatureThatTakesActualResult(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_void_function_signature_that_takes_actual_result_validate(
+    def _post_v_2_void_function_signature_that_takes_actual_result_validate(
         cls, values: VoidFunctionSignatureThatTakesActualResult.Partial
     ) -> VoidFunctionSignatureThatTakesActualResult.Partial:
         for validator in VoidFunctionSignatureThatTakesActualResult.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_void_function_signature_that_takes_actual_result.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_problem_types_void_function_signature_that_takes_actual_result.py
@@ -183,7 +183,7 @@ class VoidFunctionSignatureThatTakesActualResult(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_void_function_signature_that_takes_actual_result_validate(
+    def _pre_validate_v_2_void_function_signature_that_takes_actual_result(
         cls, values: VoidFunctionSignatureThatTakesActualResult.Partial
     ) -> VoidFunctionSignatureThatTakesActualResult.Partial:
         for validator in VoidFunctionSignatureThatTakesActualResult.Validators._pre_validators:
@@ -191,7 +191,7 @@ class VoidFunctionSignatureThatTakesActualResult(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_void_function_signature_that_takes_actual_result_validate(
+    def _post_validate_v_2_void_function_signature_that_takes_actual_result(
         cls, values: VoidFunctionSignatureThatTakesActualResult.Partial
     ) -> VoidFunctionSignatureThatTakesActualResult.Partial:
         for validator in VoidFunctionSignatureThatTakesActualResult.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_basic_custom_files.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_basic_custom_files.py
@@ -256,13 +256,13 @@ class BasicCustomFiles(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
+    def _prev_2_v_3_basic_custom_files_validate(cls, values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
         for validator in BasicCustomFiles.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
+    def _postv_2_v_3_basic_custom_files_validate(cls, values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
         for validator in BasicCustomFiles.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_basic_custom_files.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_basic_custom_files.py
@@ -256,13 +256,13 @@ class BasicCustomFiles(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_basic_custom_files_validate(cls, values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
+    def _pre_v_2_v_3_basic_custom_files_validate(cls, values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
         for validator in BasicCustomFiles.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_basic_custom_files_validate(cls, values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
+    def _post_v_2_v_3_basic_custom_files_validate(cls, values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
         for validator in BasicCustomFiles.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_basic_custom_files.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_basic_custom_files.py
@@ -256,13 +256,13 @@ class BasicCustomFiles(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_basic_custom_files_validate(cls, values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
+    def _pre_validate_v_2_v_3_basic_custom_files(cls, values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
         for validator in BasicCustomFiles.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_basic_custom_files_validate(cls, values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
+    def _post_validate_v_2_v_3_basic_custom_files(cls, values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
         for validator in BasicCustomFiles.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_basic_test_case_template.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_basic_test_case_template.py
@@ -256,13 +256,17 @@ class BasicTestCaseTemplate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: BasicTestCaseTemplate.Partial) -> BasicTestCaseTemplate.Partial:
+    def _prev_2_v_3_basic_test_case_template_validate(
+        cls, values: BasicTestCaseTemplate.Partial
+    ) -> BasicTestCaseTemplate.Partial:
         for validator in BasicTestCaseTemplate.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: BasicTestCaseTemplate.Partial) -> BasicTestCaseTemplate.Partial:
+    def _postv_2_v_3_basic_test_case_template_validate(
+        cls, values: BasicTestCaseTemplate.Partial
+    ) -> BasicTestCaseTemplate.Partial:
         for validator in BasicTestCaseTemplate.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_basic_test_case_template.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_basic_test_case_template.py
@@ -256,7 +256,7 @@ class BasicTestCaseTemplate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_basic_test_case_template_validate(
+    def _pre_v_2_v_3_basic_test_case_template_validate(
         cls, values: BasicTestCaseTemplate.Partial
     ) -> BasicTestCaseTemplate.Partial:
         for validator in BasicTestCaseTemplate.Validators._pre_validators:
@@ -264,7 +264,7 @@ class BasicTestCaseTemplate(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_basic_test_case_template_validate(
+    def _post_v_2_v_3_basic_test_case_template_validate(
         cls, values: BasicTestCaseTemplate.Partial
     ) -> BasicTestCaseTemplate.Partial:
         for validator in BasicTestCaseTemplate.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_basic_test_case_template.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_basic_test_case_template.py
@@ -256,7 +256,7 @@ class BasicTestCaseTemplate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_basic_test_case_template_validate(
+    def _pre_validate_v_2_v_3_basic_test_case_template(
         cls, values: BasicTestCaseTemplate.Partial
     ) -> BasicTestCaseTemplate.Partial:
         for validator in BasicTestCaseTemplate.Validators._pre_validators:
@@ -264,7 +264,7 @@ class BasicTestCaseTemplate(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_basic_test_case_template_validate(
+    def _post_validate_v_2_v_3_basic_test_case_template(
         cls, values: BasicTestCaseTemplate.Partial
     ) -> BasicTestCaseTemplate.Partial:
         for validator in BasicTestCaseTemplate.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_create_problem_request_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_create_problem_request_v_2.py
@@ -408,7 +408,7 @@ class CreateProblemRequestV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_create_problem_request_v_2_validate(
+    def _pre_v_2_v_3_create_problem_request_v_2_validate(
         cls, values: CreateProblemRequestV2.Partial
     ) -> CreateProblemRequestV2.Partial:
         for validator in CreateProblemRequestV2.Validators._pre_validators:
@@ -416,7 +416,7 @@ class CreateProblemRequestV2(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_create_problem_request_v_2_validate(
+    def _post_v_2_v_3_create_problem_request_v_2_validate(
         cls, values: CreateProblemRequestV2.Partial
     ) -> CreateProblemRequestV2.Partial:
         for validator in CreateProblemRequestV2.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_create_problem_request_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_create_problem_request_v_2.py
@@ -408,13 +408,17 @@ class CreateProblemRequestV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: CreateProblemRequestV2.Partial) -> CreateProblemRequestV2.Partial:
+    def _prev_2_v_3_create_problem_request_v_2_validate(
+        cls, values: CreateProblemRequestV2.Partial
+    ) -> CreateProblemRequestV2.Partial:
         for validator in CreateProblemRequestV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: CreateProblemRequestV2.Partial) -> CreateProblemRequestV2.Partial:
+    def _postv_2_v_3_create_problem_request_v_2_validate(
+        cls, values: CreateProblemRequestV2.Partial
+    ) -> CreateProblemRequestV2.Partial:
         for validator in CreateProblemRequestV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_create_problem_request_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_create_problem_request_v_2.py
@@ -408,7 +408,7 @@ class CreateProblemRequestV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_create_problem_request_v_2_validate(
+    def _pre_validate_v_2_v_3_create_problem_request_v_2(
         cls, values: CreateProblemRequestV2.Partial
     ) -> CreateProblemRequestV2.Partial:
         for validator in CreateProblemRequestV2.Validators._pre_validators:
@@ -416,7 +416,7 @@ class CreateProblemRequestV2(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_create_problem_request_v_2_validate(
+    def _post_validate_v_2_v_3_create_problem_request_v_2(
         cls, values: CreateProblemRequestV2.Partial
     ) -> CreateProblemRequestV2.Partial:
         for validator in CreateProblemRequestV2.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_deep_equality_correctness_check.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_deep_equality_correctness_check.py
@@ -126,7 +126,7 @@ class DeepEqualityCorrectnessCheck(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_deep_equality_correctness_check_validate(
+    def _pre_v_2_v_3_deep_equality_correctness_check_validate(
         cls, values: DeepEqualityCorrectnessCheck.Partial
     ) -> DeepEqualityCorrectnessCheck.Partial:
         for validator in DeepEqualityCorrectnessCheck.Validators._pre_validators:
@@ -134,7 +134,7 @@ class DeepEqualityCorrectnessCheck(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_deep_equality_correctness_check_validate(
+    def _post_v_2_v_3_deep_equality_correctness_check_validate(
         cls, values: DeepEqualityCorrectnessCheck.Partial
     ) -> DeepEqualityCorrectnessCheck.Partial:
         for validator in DeepEqualityCorrectnessCheck.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_deep_equality_correctness_check.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_deep_equality_correctness_check.py
@@ -126,7 +126,7 @@ class DeepEqualityCorrectnessCheck(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_deep_equality_correctness_check_validate(
+    def _pre_validate_v_2_v_3_deep_equality_correctness_check(
         cls, values: DeepEqualityCorrectnessCheck.Partial
     ) -> DeepEqualityCorrectnessCheck.Partial:
         for validator in DeepEqualityCorrectnessCheck.Validators._pre_validators:
@@ -134,7 +134,7 @@ class DeepEqualityCorrectnessCheck(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_deep_equality_correctness_check_validate(
+    def _post_validate_v_2_v_3_deep_equality_correctness_check(
         cls, values: DeepEqualityCorrectnessCheck.Partial
     ) -> DeepEqualityCorrectnessCheck.Partial:
         for validator in DeepEqualityCorrectnessCheck.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_deep_equality_correctness_check.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_deep_equality_correctness_check.py
@@ -126,13 +126,17 @@ class DeepEqualityCorrectnessCheck(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: DeepEqualityCorrectnessCheck.Partial) -> DeepEqualityCorrectnessCheck.Partial:
+    def _prev_2_v_3_deep_equality_correctness_check_validate(
+        cls, values: DeepEqualityCorrectnessCheck.Partial
+    ) -> DeepEqualityCorrectnessCheck.Partial:
         for validator in DeepEqualityCorrectnessCheck.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: DeepEqualityCorrectnessCheck.Partial) -> DeepEqualityCorrectnessCheck.Partial:
+    def _postv_2_v_3_deep_equality_correctness_check_validate(
+        cls, values: DeepEqualityCorrectnessCheck.Partial
+    ) -> DeepEqualityCorrectnessCheck.Partial:
         for validator in DeepEqualityCorrectnessCheck.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_default_provided_file.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_default_provided_file.py
@@ -162,7 +162,7 @@ class DefaultProvidedFile(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_default_provided_file_validate(
+    def _pre_validate_v_2_v_3_default_provided_file(
         cls, values: DefaultProvidedFile.Partial
     ) -> DefaultProvidedFile.Partial:
         for validator in DefaultProvidedFile.Validators._pre_validators:
@@ -170,7 +170,7 @@ class DefaultProvidedFile(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_default_provided_file_validate(
+    def _post_validate_v_2_v_3_default_provided_file(
         cls, values: DefaultProvidedFile.Partial
     ) -> DefaultProvidedFile.Partial:
         for validator in DefaultProvidedFile.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_default_provided_file.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_default_provided_file.py
@@ -162,13 +162,17 @@ class DefaultProvidedFile(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: DefaultProvidedFile.Partial) -> DefaultProvidedFile.Partial:
+    def _prev_2_v_3_default_provided_file_validate(
+        cls, values: DefaultProvidedFile.Partial
+    ) -> DefaultProvidedFile.Partial:
         for validator in DefaultProvidedFile.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: DefaultProvidedFile.Partial) -> DefaultProvidedFile.Partial:
+    def _postv_2_v_3_default_provided_file_validate(
+        cls, values: DefaultProvidedFile.Partial
+    ) -> DefaultProvidedFile.Partial:
         for validator in DefaultProvidedFile.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_default_provided_file.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_default_provided_file.py
@@ -162,7 +162,7 @@ class DefaultProvidedFile(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_default_provided_file_validate(
+    def _pre_v_2_v_3_default_provided_file_validate(
         cls, values: DefaultProvidedFile.Partial
     ) -> DefaultProvidedFile.Partial:
         for validator in DefaultProvidedFile.Validators._pre_validators:
@@ -170,7 +170,7 @@ class DefaultProvidedFile(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_default_provided_file_validate(
+    def _post_v_2_v_3_default_provided_file_validate(
         cls, values: DefaultProvidedFile.Partial
     ) -> DefaultProvidedFile.Partial:
         for validator in DefaultProvidedFile.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_file_info_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_file_info_v_2.py
@@ -210,13 +210,13 @@ class FileInfoV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_file_info_v_2_validate(cls, values: FileInfoV2.Partial) -> FileInfoV2.Partial:
+    def _pre_validate_v_2_v_3_file_info_v_2(cls, values: FileInfoV2.Partial) -> FileInfoV2.Partial:
         for validator in FileInfoV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_file_info_v_2_validate(cls, values: FileInfoV2.Partial) -> FileInfoV2.Partial:
+    def _post_validate_v_2_v_3_file_info_v_2(cls, values: FileInfoV2.Partial) -> FileInfoV2.Partial:
         for validator in FileInfoV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_file_info_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_file_info_v_2.py
@@ -210,13 +210,13 @@ class FileInfoV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: FileInfoV2.Partial) -> FileInfoV2.Partial:
+    def _prev_2_v_3_file_info_v_2_validate(cls, values: FileInfoV2.Partial) -> FileInfoV2.Partial:
         for validator in FileInfoV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: FileInfoV2.Partial) -> FileInfoV2.Partial:
+    def _postv_2_v_3_file_info_v_2_validate(cls, values: FileInfoV2.Partial) -> FileInfoV2.Partial:
         for validator in FileInfoV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_file_info_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_file_info_v_2.py
@@ -210,13 +210,13 @@ class FileInfoV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_file_info_v_2_validate(cls, values: FileInfoV2.Partial) -> FileInfoV2.Partial:
+    def _pre_v_2_v_3_file_info_v_2_validate(cls, values: FileInfoV2.Partial) -> FileInfoV2.Partial:
         for validator in FileInfoV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_file_info_v_2_validate(cls, values: FileInfoV2.Partial) -> FileInfoV2.Partial:
+    def _post_v_2_v_3_file_info_v_2_validate(cls, values: FileInfoV2.Partial) -> FileInfoV2.Partial:
         for validator in FileInfoV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_files.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_files.py
@@ -104,13 +104,13 @@ class Files(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: Files.Partial) -> Files.Partial:
+    def _prev_2_v_3_files_validate(cls, values: Files.Partial) -> Files.Partial:
         for validator in Files.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: Files.Partial) -> Files.Partial:
+    def _postv_2_v_3_files_validate(cls, values: Files.Partial) -> Files.Partial:
         for validator in Files.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_files.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_files.py
@@ -104,13 +104,13 @@ class Files(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_files_validate(cls, values: Files.Partial) -> Files.Partial:
+    def _pre_validate_v_2_v_3_files(cls, values: Files.Partial) -> Files.Partial:
         for validator in Files.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_files_validate(cls, values: Files.Partial) -> Files.Partial:
+    def _post_validate_v_2_v_3_files(cls, values: Files.Partial) -> Files.Partial:
         for validator in Files.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_files.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_files.py
@@ -104,13 +104,13 @@ class Files(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_files_validate(cls, values: Files.Partial) -> Files.Partial:
+    def _pre_v_2_v_3_files_validate(cls, values: Files.Partial) -> Files.Partial:
         for validator in Files.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_files_validate(cls, values: Files.Partial) -> Files.Partial:
+    def _post_v_2_v_3_files_validate(cls, values: Files.Partial) -> Files.Partial:
         for validator in Files.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_function_implementation.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_function_implementation.py
@@ -155,7 +155,7 @@ class FunctionImplementation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_function_implementation_validate(
+    def _pre_v_2_v_3_function_implementation_validate(
         cls, values: FunctionImplementation.Partial
     ) -> FunctionImplementation.Partial:
         for validator in FunctionImplementation.Validators._pre_validators:
@@ -163,7 +163,7 @@ class FunctionImplementation(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_function_implementation_validate(
+    def _post_v_2_v_3_function_implementation_validate(
         cls, values: FunctionImplementation.Partial
     ) -> FunctionImplementation.Partial:
         for validator in FunctionImplementation.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_function_implementation.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_function_implementation.py
@@ -155,13 +155,17 @@ class FunctionImplementation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: FunctionImplementation.Partial) -> FunctionImplementation.Partial:
+    def _prev_2_v_3_function_implementation_validate(
+        cls, values: FunctionImplementation.Partial
+    ) -> FunctionImplementation.Partial:
         for validator in FunctionImplementation.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: FunctionImplementation.Partial) -> FunctionImplementation.Partial:
+    def _postv_2_v_3_function_implementation_validate(
+        cls, values: FunctionImplementation.Partial
+    ) -> FunctionImplementation.Partial:
         for validator in FunctionImplementation.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_function_implementation.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_function_implementation.py
@@ -155,7 +155,7 @@ class FunctionImplementation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_function_implementation_validate(
+    def _pre_validate_v_2_v_3_function_implementation(
         cls, values: FunctionImplementation.Partial
     ) -> FunctionImplementation.Partial:
         for validator in FunctionImplementation.Validators._pre_validators:
@@ -163,7 +163,7 @@ class FunctionImplementation(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_function_implementation_validate(
+    def _post_validate_v_2_v_3_function_implementation(
         cls, values: FunctionImplementation.Partial
     ) -> FunctionImplementation.Partial:
         for validator in FunctionImplementation.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_function_implementation_for_multiple_languages.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_function_implementation_for_multiple_languages.py
@@ -136,7 +136,7 @@ class FunctionImplementationForMultipleLanguages(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(
+    def _prev_2_v_3_function_implementation_for_multiple_languages_validate(
         cls, values: FunctionImplementationForMultipleLanguages.Partial
     ) -> FunctionImplementationForMultipleLanguages.Partial:
         for validator in FunctionImplementationForMultipleLanguages.Validators._pre_validators:
@@ -144,7 +144,7 @@ class FunctionImplementationForMultipleLanguages(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(
+    def _postv_2_v_3_function_implementation_for_multiple_languages_validate(
         cls, values: FunctionImplementationForMultipleLanguages.Partial
     ) -> FunctionImplementationForMultipleLanguages.Partial:
         for validator in FunctionImplementationForMultipleLanguages.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_function_implementation_for_multiple_languages.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_function_implementation_for_multiple_languages.py
@@ -136,7 +136,7 @@ class FunctionImplementationForMultipleLanguages(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_function_implementation_for_multiple_languages_validate(
+    def _pre_v_2_v_3_function_implementation_for_multiple_languages_validate(
         cls, values: FunctionImplementationForMultipleLanguages.Partial
     ) -> FunctionImplementationForMultipleLanguages.Partial:
         for validator in FunctionImplementationForMultipleLanguages.Validators._pre_validators:
@@ -144,7 +144,7 @@ class FunctionImplementationForMultipleLanguages(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_function_implementation_for_multiple_languages_validate(
+    def _post_v_2_v_3_function_implementation_for_multiple_languages_validate(
         cls, values: FunctionImplementationForMultipleLanguages.Partial
     ) -> FunctionImplementationForMultipleLanguages.Partial:
         for validator in FunctionImplementationForMultipleLanguages.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_function_implementation_for_multiple_languages.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_function_implementation_for_multiple_languages.py
@@ -136,7 +136,7 @@ class FunctionImplementationForMultipleLanguages(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_function_implementation_for_multiple_languages_validate(
+    def _pre_validate_v_2_v_3_function_implementation_for_multiple_languages(
         cls, values: FunctionImplementationForMultipleLanguages.Partial
     ) -> FunctionImplementationForMultipleLanguages.Partial:
         for validator in FunctionImplementationForMultipleLanguages.Validators._pre_validators:
@@ -144,7 +144,7 @@ class FunctionImplementationForMultipleLanguages(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_function_implementation_for_multiple_languages_validate(
+    def _post_validate_v_2_v_3_function_implementation_for_multiple_languages(
         cls, values: FunctionImplementationForMultipleLanguages.Partial
     ) -> FunctionImplementationForMultipleLanguages.Partial:
         for validator in FunctionImplementationForMultipleLanguages.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_generated_files.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_generated_files.py
@@ -217,13 +217,13 @@ class GeneratedFiles(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
+    def _prev_2_v_3_generated_files_validate(cls, values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
         for validator in GeneratedFiles.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
+    def _postv_2_v_3_generated_files_validate(cls, values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
         for validator in GeneratedFiles.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_generated_files.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_generated_files.py
@@ -217,13 +217,13 @@ class GeneratedFiles(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_generated_files_validate(cls, values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
+    def _pre_v_2_v_3_generated_files_validate(cls, values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
         for validator in GeneratedFiles.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_generated_files_validate(cls, values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
+    def _post_v_2_v_3_generated_files_validate(cls, values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
         for validator in GeneratedFiles.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_generated_files.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_generated_files.py
@@ -217,13 +217,13 @@ class GeneratedFiles(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_generated_files_validate(cls, values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
+    def _pre_validate_v_2_v_3_generated_files(cls, values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
         for validator in GeneratedFiles.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_generated_files_validate(cls, values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
+    def _post_validate_v_2_v_3_generated_files(cls, values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
         for validator in GeneratedFiles.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_get_basic_solution_file_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_get_basic_solution_file_request.py
@@ -167,7 +167,7 @@ class GetBasicSolutionFileRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_get_basic_solution_file_request_validate(
+    def _pre_v_2_v_3_get_basic_solution_file_request_validate(
         cls, values: GetBasicSolutionFileRequest.Partial
     ) -> GetBasicSolutionFileRequest.Partial:
         for validator in GetBasicSolutionFileRequest.Validators._pre_validators:
@@ -175,7 +175,7 @@ class GetBasicSolutionFileRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_get_basic_solution_file_request_validate(
+    def _post_v_2_v_3_get_basic_solution_file_request_validate(
         cls, values: GetBasicSolutionFileRequest.Partial
     ) -> GetBasicSolutionFileRequest.Partial:
         for validator in GetBasicSolutionFileRequest.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_get_basic_solution_file_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_get_basic_solution_file_request.py
@@ -167,13 +167,17 @@ class GetBasicSolutionFileRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: GetBasicSolutionFileRequest.Partial) -> GetBasicSolutionFileRequest.Partial:
+    def _prev_2_v_3_get_basic_solution_file_request_validate(
+        cls, values: GetBasicSolutionFileRequest.Partial
+    ) -> GetBasicSolutionFileRequest.Partial:
         for validator in GetBasicSolutionFileRequest.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: GetBasicSolutionFileRequest.Partial) -> GetBasicSolutionFileRequest.Partial:
+    def _postv_2_v_3_get_basic_solution_file_request_validate(
+        cls, values: GetBasicSolutionFileRequest.Partial
+    ) -> GetBasicSolutionFileRequest.Partial:
         for validator in GetBasicSolutionFileRequest.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_get_basic_solution_file_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_get_basic_solution_file_request.py
@@ -167,7 +167,7 @@ class GetBasicSolutionFileRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_get_basic_solution_file_request_validate(
+    def _pre_validate_v_2_v_3_get_basic_solution_file_request(
         cls, values: GetBasicSolutionFileRequest.Partial
     ) -> GetBasicSolutionFileRequest.Partial:
         for validator in GetBasicSolutionFileRequest.Validators._pre_validators:
@@ -175,7 +175,7 @@ class GetBasicSolutionFileRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_get_basic_solution_file_request_validate(
+    def _post_validate_v_2_v_3_get_basic_solution_file_request(
         cls, values: GetBasicSolutionFileRequest.Partial
     ) -> GetBasicSolutionFileRequest.Partial:
         for validator in GetBasicSolutionFileRequest.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_get_basic_solution_file_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_get_basic_solution_file_response.py
@@ -129,7 +129,7 @@ class GetBasicSolutionFileResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_get_basic_solution_file_response_validate(
+    def _pre_v_2_v_3_get_basic_solution_file_response_validate(
         cls, values: GetBasicSolutionFileResponse.Partial
     ) -> GetBasicSolutionFileResponse.Partial:
         for validator in GetBasicSolutionFileResponse.Validators._pre_validators:
@@ -137,7 +137,7 @@ class GetBasicSolutionFileResponse(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_get_basic_solution_file_response_validate(
+    def _post_v_2_v_3_get_basic_solution_file_response_validate(
         cls, values: GetBasicSolutionFileResponse.Partial
     ) -> GetBasicSolutionFileResponse.Partial:
         for validator in GetBasicSolutionFileResponse.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_get_basic_solution_file_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_get_basic_solution_file_response.py
@@ -129,7 +129,7 @@ class GetBasicSolutionFileResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_get_basic_solution_file_response_validate(
+    def _pre_validate_v_2_v_3_get_basic_solution_file_response(
         cls, values: GetBasicSolutionFileResponse.Partial
     ) -> GetBasicSolutionFileResponse.Partial:
         for validator in GetBasicSolutionFileResponse.Validators._pre_validators:
@@ -137,7 +137,7 @@ class GetBasicSolutionFileResponse(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_get_basic_solution_file_response_validate(
+    def _post_validate_v_2_v_3_get_basic_solution_file_response(
         cls, values: GetBasicSolutionFileResponse.Partial
     ) -> GetBasicSolutionFileResponse.Partial:
         for validator in GetBasicSolutionFileResponse.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_get_basic_solution_file_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_get_basic_solution_file_response.py
@@ -129,13 +129,17 @@ class GetBasicSolutionFileResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: GetBasicSolutionFileResponse.Partial) -> GetBasicSolutionFileResponse.Partial:
+    def _prev_2_v_3_get_basic_solution_file_response_validate(
+        cls, values: GetBasicSolutionFileResponse.Partial
+    ) -> GetBasicSolutionFileResponse.Partial:
         for validator in GetBasicSolutionFileResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: GetBasicSolutionFileResponse.Partial) -> GetBasicSolutionFileResponse.Partial:
+    def _postv_2_v_3_get_basic_solution_file_response_validate(
+        cls, values: GetBasicSolutionFileResponse.Partial
+    ) -> GetBasicSolutionFileResponse.Partial:
         for validator in GetBasicSolutionFileResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_get_function_signature_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_get_function_signature_request.py
@@ -125,13 +125,17 @@ class GetFunctionSignatureRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: GetFunctionSignatureRequest.Partial) -> GetFunctionSignatureRequest.Partial:
+    def _prev_2_v_3_get_function_signature_request_validate(
+        cls, values: GetFunctionSignatureRequest.Partial
+    ) -> GetFunctionSignatureRequest.Partial:
         for validator in GetFunctionSignatureRequest.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: GetFunctionSignatureRequest.Partial) -> GetFunctionSignatureRequest.Partial:
+    def _postv_2_v_3_get_function_signature_request_validate(
+        cls, values: GetFunctionSignatureRequest.Partial
+    ) -> GetFunctionSignatureRequest.Partial:
         for validator in GetFunctionSignatureRequest.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_get_function_signature_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_get_function_signature_request.py
@@ -125,7 +125,7 @@ class GetFunctionSignatureRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_get_function_signature_request_validate(
+    def _pre_v_2_v_3_get_function_signature_request_validate(
         cls, values: GetFunctionSignatureRequest.Partial
     ) -> GetFunctionSignatureRequest.Partial:
         for validator in GetFunctionSignatureRequest.Validators._pre_validators:
@@ -133,7 +133,7 @@ class GetFunctionSignatureRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_get_function_signature_request_validate(
+    def _post_v_2_v_3_get_function_signature_request_validate(
         cls, values: GetFunctionSignatureRequest.Partial
     ) -> GetFunctionSignatureRequest.Partial:
         for validator in GetFunctionSignatureRequest.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_get_function_signature_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_get_function_signature_request.py
@@ -125,7 +125,7 @@ class GetFunctionSignatureRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_get_function_signature_request_validate(
+    def _pre_validate_v_2_v_3_get_function_signature_request(
         cls, values: GetFunctionSignatureRequest.Partial
     ) -> GetFunctionSignatureRequest.Partial:
         for validator in GetFunctionSignatureRequest.Validators._pre_validators:
@@ -133,7 +133,7 @@ class GetFunctionSignatureRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_get_function_signature_request_validate(
+    def _post_validate_v_2_v_3_get_function_signature_request(
         cls, values: GetFunctionSignatureRequest.Partial
     ) -> GetFunctionSignatureRequest.Partial:
         for validator in GetFunctionSignatureRequest.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_get_function_signature_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_get_function_signature_response.py
@@ -125,13 +125,17 @@ class GetFunctionSignatureResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: GetFunctionSignatureResponse.Partial) -> GetFunctionSignatureResponse.Partial:
+    def _prev_2_v_3_get_function_signature_response_validate(
+        cls, values: GetFunctionSignatureResponse.Partial
+    ) -> GetFunctionSignatureResponse.Partial:
         for validator in GetFunctionSignatureResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: GetFunctionSignatureResponse.Partial) -> GetFunctionSignatureResponse.Partial:
+    def _postv_2_v_3_get_function_signature_response_validate(
+        cls, values: GetFunctionSignatureResponse.Partial
+    ) -> GetFunctionSignatureResponse.Partial:
         for validator in GetFunctionSignatureResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_get_function_signature_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_get_function_signature_response.py
@@ -125,7 +125,7 @@ class GetFunctionSignatureResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_get_function_signature_response_validate(
+    def _pre_validate_v_2_v_3_get_function_signature_response(
         cls, values: GetFunctionSignatureResponse.Partial
     ) -> GetFunctionSignatureResponse.Partial:
         for validator in GetFunctionSignatureResponse.Validators._pre_validators:
@@ -133,7 +133,7 @@ class GetFunctionSignatureResponse(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_get_function_signature_response_validate(
+    def _post_validate_v_2_v_3_get_function_signature_response(
         cls, values: GetFunctionSignatureResponse.Partial
     ) -> GetFunctionSignatureResponse.Partial:
         for validator in GetFunctionSignatureResponse.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_get_function_signature_response.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_get_function_signature_response.py
@@ -125,7 +125,7 @@ class GetFunctionSignatureResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_get_function_signature_response_validate(
+    def _pre_v_2_v_3_get_function_signature_response_validate(
         cls, values: GetFunctionSignatureResponse.Partial
     ) -> GetFunctionSignatureResponse.Partial:
         for validator in GetFunctionSignatureResponse.Validators._pre_validators:
@@ -133,7 +133,7 @@ class GetFunctionSignatureResponse(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_get_function_signature_response_validate(
+    def _post_v_2_v_3_get_function_signature_response_validate(
         cls, values: GetFunctionSignatureResponse.Partial
     ) -> GetFunctionSignatureResponse.Partial:
         for validator in GetFunctionSignatureResponse.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_get_generated_test_case_file_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_get_generated_test_case_file_request.py
@@ -170,13 +170,17 @@ class GetGeneratedTestCaseFileRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: GetGeneratedTestCaseFileRequest.Partial) -> GetGeneratedTestCaseFileRequest.Partial:
+    def _prev_2_v_3_get_generated_test_case_file_request_validate(
+        cls, values: GetGeneratedTestCaseFileRequest.Partial
+    ) -> GetGeneratedTestCaseFileRequest.Partial:
         for validator in GetGeneratedTestCaseFileRequest.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: GetGeneratedTestCaseFileRequest.Partial) -> GetGeneratedTestCaseFileRequest.Partial:
+    def _postv_2_v_3_get_generated_test_case_file_request_validate(
+        cls, values: GetGeneratedTestCaseFileRequest.Partial
+    ) -> GetGeneratedTestCaseFileRequest.Partial:
         for validator in GetGeneratedTestCaseFileRequest.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_get_generated_test_case_file_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_get_generated_test_case_file_request.py
@@ -170,7 +170,7 @@ class GetGeneratedTestCaseFileRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_get_generated_test_case_file_request_validate(
+    def _pre_validate_v_2_v_3_get_generated_test_case_file_request(
         cls, values: GetGeneratedTestCaseFileRequest.Partial
     ) -> GetGeneratedTestCaseFileRequest.Partial:
         for validator in GetGeneratedTestCaseFileRequest.Validators._pre_validators:
@@ -178,7 +178,7 @@ class GetGeneratedTestCaseFileRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_get_generated_test_case_file_request_validate(
+    def _post_validate_v_2_v_3_get_generated_test_case_file_request(
         cls, values: GetGeneratedTestCaseFileRequest.Partial
     ) -> GetGeneratedTestCaseFileRequest.Partial:
         for validator in GetGeneratedTestCaseFileRequest.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_get_generated_test_case_file_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_get_generated_test_case_file_request.py
@@ -170,7 +170,7 @@ class GetGeneratedTestCaseFileRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_get_generated_test_case_file_request_validate(
+    def _pre_v_2_v_3_get_generated_test_case_file_request_validate(
         cls, values: GetGeneratedTestCaseFileRequest.Partial
     ) -> GetGeneratedTestCaseFileRequest.Partial:
         for validator in GetGeneratedTestCaseFileRequest.Validators._pre_validators:
@@ -178,7 +178,7 @@ class GetGeneratedTestCaseFileRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_get_generated_test_case_file_request_validate(
+    def _post_v_2_v_3_get_generated_test_case_file_request_validate(
         cls, values: GetGeneratedTestCaseFileRequest.Partial
     ) -> GetGeneratedTestCaseFileRequest.Partial:
         for validator in GetGeneratedTestCaseFileRequest.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_get_generated_test_case_template_file_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_get_generated_test_case_template_file_request.py
@@ -130,7 +130,7 @@ class GetGeneratedTestCaseTemplateFileRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_get_generated_test_case_template_file_request_validate(
+    def _pre_validate_v_2_v_3_get_generated_test_case_template_file_request(
         cls, values: GetGeneratedTestCaseTemplateFileRequest.Partial
     ) -> GetGeneratedTestCaseTemplateFileRequest.Partial:
         for validator in GetGeneratedTestCaseTemplateFileRequest.Validators._pre_validators:
@@ -138,7 +138,7 @@ class GetGeneratedTestCaseTemplateFileRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_get_generated_test_case_template_file_request_validate(
+    def _post_validate_v_2_v_3_get_generated_test_case_template_file_request(
         cls, values: GetGeneratedTestCaseTemplateFileRequest.Partial
     ) -> GetGeneratedTestCaseTemplateFileRequest.Partial:
         for validator in GetGeneratedTestCaseTemplateFileRequest.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_get_generated_test_case_template_file_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_get_generated_test_case_template_file_request.py
@@ -130,7 +130,7 @@ class GetGeneratedTestCaseTemplateFileRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_get_generated_test_case_template_file_request_validate(
+    def _pre_v_2_v_3_get_generated_test_case_template_file_request_validate(
         cls, values: GetGeneratedTestCaseTemplateFileRequest.Partial
     ) -> GetGeneratedTestCaseTemplateFileRequest.Partial:
         for validator in GetGeneratedTestCaseTemplateFileRequest.Validators._pre_validators:
@@ -138,7 +138,7 @@ class GetGeneratedTestCaseTemplateFileRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_get_generated_test_case_template_file_request_validate(
+    def _post_v_2_v_3_get_generated_test_case_template_file_request_validate(
         cls, values: GetGeneratedTestCaseTemplateFileRequest.Partial
     ) -> GetGeneratedTestCaseTemplateFileRequest.Partial:
         for validator in GetGeneratedTestCaseTemplateFileRequest.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_get_generated_test_case_template_file_request.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_get_generated_test_case_template_file_request.py
@@ -130,7 +130,7 @@ class GetGeneratedTestCaseTemplateFileRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(
+    def _prev_2_v_3_get_generated_test_case_template_file_request_validate(
         cls, values: GetGeneratedTestCaseTemplateFileRequest.Partial
     ) -> GetGeneratedTestCaseTemplateFileRequest.Partial:
         for validator in GetGeneratedTestCaseTemplateFileRequest.Validators._pre_validators:
@@ -138,7 +138,7 @@ class GetGeneratedTestCaseTemplateFileRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(
+    def _postv_2_v_3_get_generated_test_case_template_file_request_validate(
         cls, values: GetGeneratedTestCaseTemplateFileRequest.Partial
     ) -> GetGeneratedTestCaseTemplateFileRequest.Partial:
         for validator in GetGeneratedTestCaseTemplateFileRequest.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_lightweight_problem_info_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_lightweight_problem_info_v_2.py
@@ -263,7 +263,7 @@ class LightweightProblemInfoV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_lightweight_problem_info_v_2_validate(
+    def _pre_v_2_v_3_lightweight_problem_info_v_2_validate(
         cls, values: LightweightProblemInfoV2.Partial
     ) -> LightweightProblemInfoV2.Partial:
         for validator in LightweightProblemInfoV2.Validators._pre_validators:
@@ -271,7 +271,7 @@ class LightweightProblemInfoV2(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_lightweight_problem_info_v_2_validate(
+    def _post_v_2_v_3_lightweight_problem_info_v_2_validate(
         cls, values: LightweightProblemInfoV2.Partial
     ) -> LightweightProblemInfoV2.Partial:
         for validator in LightweightProblemInfoV2.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_lightweight_problem_info_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_lightweight_problem_info_v_2.py
@@ -263,7 +263,7 @@ class LightweightProblemInfoV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_lightweight_problem_info_v_2_validate(
+    def _pre_validate_v_2_v_3_lightweight_problem_info_v_2(
         cls, values: LightweightProblemInfoV2.Partial
     ) -> LightweightProblemInfoV2.Partial:
         for validator in LightweightProblemInfoV2.Validators._pre_validators:
@@ -271,7 +271,7 @@ class LightweightProblemInfoV2(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_lightweight_problem_info_v_2_validate(
+    def _post_validate_v_2_v_3_lightweight_problem_info_v_2(
         cls, values: LightweightProblemInfoV2.Partial
     ) -> LightweightProblemInfoV2.Partial:
         for validator in LightweightProblemInfoV2.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_lightweight_problem_info_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_lightweight_problem_info_v_2.py
@@ -263,13 +263,17 @@ class LightweightProblemInfoV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: LightweightProblemInfoV2.Partial) -> LightweightProblemInfoV2.Partial:
+    def _prev_2_v_3_lightweight_problem_info_v_2_validate(
+        cls, values: LightweightProblemInfoV2.Partial
+    ) -> LightweightProblemInfoV2.Partial:
         for validator in LightweightProblemInfoV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: LightweightProblemInfoV2.Partial) -> LightweightProblemInfoV2.Partial:
+    def _postv_2_v_3_lightweight_problem_info_v_2_validate(
+        cls, values: LightweightProblemInfoV2.Partial
+    ) -> LightweightProblemInfoV2.Partial:
         for validator in LightweightProblemInfoV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_non_void_function_definition.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_non_void_function_definition.py
@@ -164,13 +164,17 @@ class NonVoidFunctionDefinition(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: NonVoidFunctionDefinition.Partial) -> NonVoidFunctionDefinition.Partial:
+    def _prev_2_v_3_non_void_function_definition_validate(
+        cls, values: NonVoidFunctionDefinition.Partial
+    ) -> NonVoidFunctionDefinition.Partial:
         for validator in NonVoidFunctionDefinition.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: NonVoidFunctionDefinition.Partial) -> NonVoidFunctionDefinition.Partial:
+    def _postv_2_v_3_non_void_function_definition_validate(
+        cls, values: NonVoidFunctionDefinition.Partial
+    ) -> NonVoidFunctionDefinition.Partial:
         for validator in NonVoidFunctionDefinition.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_non_void_function_definition.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_non_void_function_definition.py
@@ -164,7 +164,7 @@ class NonVoidFunctionDefinition(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_non_void_function_definition_validate(
+    def _pre_validate_v_2_v_3_non_void_function_definition(
         cls, values: NonVoidFunctionDefinition.Partial
     ) -> NonVoidFunctionDefinition.Partial:
         for validator in NonVoidFunctionDefinition.Validators._pre_validators:
@@ -172,7 +172,7 @@ class NonVoidFunctionDefinition(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_non_void_function_definition_validate(
+    def _post_validate_v_2_v_3_non_void_function_definition(
         cls, values: NonVoidFunctionDefinition.Partial
     ) -> NonVoidFunctionDefinition.Partial:
         for validator in NonVoidFunctionDefinition.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_non_void_function_definition.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_non_void_function_definition.py
@@ -164,7 +164,7 @@ class NonVoidFunctionDefinition(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_non_void_function_definition_validate(
+    def _pre_v_2_v_3_non_void_function_definition_validate(
         cls, values: NonVoidFunctionDefinition.Partial
     ) -> NonVoidFunctionDefinition.Partial:
         for validator in NonVoidFunctionDefinition.Validators._pre_validators:
@@ -172,7 +172,7 @@ class NonVoidFunctionDefinition(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_non_void_function_definition_validate(
+    def _post_v_2_v_3_non_void_function_definition_validate(
         cls, values: NonVoidFunctionDefinition.Partial
     ) -> NonVoidFunctionDefinition.Partial:
         for validator in NonVoidFunctionDefinition.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_non_void_function_signature.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_non_void_function_signature.py
@@ -167,13 +167,17 @@ class NonVoidFunctionSignature(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: NonVoidFunctionSignature.Partial) -> NonVoidFunctionSignature.Partial:
+    def _prev_2_v_3_non_void_function_signature_validate(
+        cls, values: NonVoidFunctionSignature.Partial
+    ) -> NonVoidFunctionSignature.Partial:
         for validator in NonVoidFunctionSignature.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: NonVoidFunctionSignature.Partial) -> NonVoidFunctionSignature.Partial:
+    def _postv_2_v_3_non_void_function_signature_validate(
+        cls, values: NonVoidFunctionSignature.Partial
+    ) -> NonVoidFunctionSignature.Partial:
         for validator in NonVoidFunctionSignature.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_non_void_function_signature.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_non_void_function_signature.py
@@ -167,7 +167,7 @@ class NonVoidFunctionSignature(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_non_void_function_signature_validate(
+    def _pre_v_2_v_3_non_void_function_signature_validate(
         cls, values: NonVoidFunctionSignature.Partial
     ) -> NonVoidFunctionSignature.Partial:
         for validator in NonVoidFunctionSignature.Validators._pre_validators:
@@ -175,7 +175,7 @@ class NonVoidFunctionSignature(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_non_void_function_signature_validate(
+    def _post_v_2_v_3_non_void_function_signature_validate(
         cls, values: NonVoidFunctionSignature.Partial
     ) -> NonVoidFunctionSignature.Partial:
         for validator in NonVoidFunctionSignature.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_non_void_function_signature.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_non_void_function_signature.py
@@ -167,7 +167,7 @@ class NonVoidFunctionSignature(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_non_void_function_signature_validate(
+    def _pre_validate_v_2_v_3_non_void_function_signature(
         cls, values: NonVoidFunctionSignature.Partial
     ) -> NonVoidFunctionSignature.Partial:
         for validator in NonVoidFunctionSignature.Validators._pre_validators:
@@ -175,7 +175,7 @@ class NonVoidFunctionSignature(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_non_void_function_signature_validate(
+    def _post_validate_v_2_v_3_non_void_function_signature(
         cls, values: NonVoidFunctionSignature.Partial
     ) -> NonVoidFunctionSignature.Partial:
         for validator in NonVoidFunctionSignature.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_parameter.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_parameter.py
@@ -182,13 +182,13 @@ class Parameter(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_parameter_validate(cls, values: Parameter.Partial) -> Parameter.Partial:
+    def _pre_validate_v_2_v_3_parameter(cls, values: Parameter.Partial) -> Parameter.Partial:
         for validator in Parameter.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_parameter_validate(cls, values: Parameter.Partial) -> Parameter.Partial:
+    def _post_validate_v_2_v_3_parameter(cls, values: Parameter.Partial) -> Parameter.Partial:
         for validator in Parameter.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_parameter.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_parameter.py
@@ -182,13 +182,13 @@ class Parameter(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: Parameter.Partial) -> Parameter.Partial:
+    def _prev_2_v_3_parameter_validate(cls, values: Parameter.Partial) -> Parameter.Partial:
         for validator in Parameter.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: Parameter.Partial) -> Parameter.Partial:
+    def _postv_2_v_3_parameter_validate(cls, values: Parameter.Partial) -> Parameter.Partial:
         for validator in Parameter.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_parameter.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_parameter.py
@@ -182,13 +182,13 @@ class Parameter(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_parameter_validate(cls, values: Parameter.Partial) -> Parameter.Partial:
+    def _pre_v_2_v_3_parameter_validate(cls, values: Parameter.Partial) -> Parameter.Partial:
         for validator in Parameter.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_parameter_validate(cls, values: Parameter.Partial) -> Parameter.Partial:
+    def _post_v_2_v_3_parameter_validate(cls, values: Parameter.Partial) -> Parameter.Partial:
         for validator in Parameter.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_problem_info_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_problem_info_v_2.py
@@ -513,13 +513,13 @@ class ProblemInfoV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
+    def _prev_2_v_3_problem_info_v_2_validate(cls, values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
         for validator in ProblemInfoV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
+    def _postv_2_v_3_problem_info_v_2_validate(cls, values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
         for validator in ProblemInfoV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_problem_info_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_problem_info_v_2.py
@@ -513,13 +513,13 @@ class ProblemInfoV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_problem_info_v_2_validate(cls, values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
+    def _pre_v_2_v_3_problem_info_v_2_validate(cls, values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
         for validator in ProblemInfoV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_problem_info_v_2_validate(cls, values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
+    def _post_v_2_v_3_problem_info_v_2_validate(cls, values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
         for validator in ProblemInfoV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_problem_info_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_problem_info_v_2.py
@@ -513,13 +513,13 @@ class ProblemInfoV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_problem_info_v_2_validate(cls, values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
+    def _pre_validate_v_2_v_3_problem_info_v_2(cls, values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
         for validator in ProblemInfoV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_problem_info_v_2_validate(cls, values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
+    def _post_validate_v_2_v_3_problem_info_v_2(cls, values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
         for validator in ProblemInfoV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_test_case_expects.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_test_case_expects.py
@@ -117,13 +117,13 @@ class TestCaseExpects(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_test_case_expects_validate(cls, values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
+    def _pre_validate_v_2_v_3_test_case_expects(cls, values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
         for validator in TestCaseExpects.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_test_case_expects_validate(cls, values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
+    def _post_validate_v_2_v_3_test_case_expects(cls, values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
         for validator in TestCaseExpects.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_test_case_expects.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_test_case_expects.py
@@ -117,13 +117,13 @@ class TestCaseExpects(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_test_case_expects_validate(cls, values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
+    def _pre_v_2_v_3_test_case_expects_validate(cls, values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
         for validator in TestCaseExpects.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_test_case_expects_validate(cls, values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
+    def _post_v_2_v_3_test_case_expects_validate(cls, values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
         for validator in TestCaseExpects.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_test_case_expects.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_test_case_expects.py
@@ -117,13 +117,13 @@ class TestCaseExpects(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
+    def _prev_2_v_3_test_case_expects_validate(cls, values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
         for validator in TestCaseExpects.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
+    def _postv_2_v_3_test_case_expects_validate(cls, values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
         for validator in TestCaseExpects.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_test_case_implementation.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_test_case_implementation.py
@@ -165,7 +165,7 @@ class TestCaseImplementation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_test_case_implementation_validate(
+    def _pre_v_2_v_3_test_case_implementation_validate(
         cls, values: TestCaseImplementation.Partial
     ) -> TestCaseImplementation.Partial:
         for validator in TestCaseImplementation.Validators._pre_validators:
@@ -173,7 +173,7 @@ class TestCaseImplementation(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_test_case_implementation_validate(
+    def _post_v_2_v_3_test_case_implementation_validate(
         cls, values: TestCaseImplementation.Partial
     ) -> TestCaseImplementation.Partial:
         for validator in TestCaseImplementation.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_test_case_implementation.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_test_case_implementation.py
@@ -165,13 +165,17 @@ class TestCaseImplementation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TestCaseImplementation.Partial) -> TestCaseImplementation.Partial:
+    def _prev_2_v_3_test_case_implementation_validate(
+        cls, values: TestCaseImplementation.Partial
+    ) -> TestCaseImplementation.Partial:
         for validator in TestCaseImplementation.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TestCaseImplementation.Partial) -> TestCaseImplementation.Partial:
+    def _postv_2_v_3_test_case_implementation_validate(
+        cls, values: TestCaseImplementation.Partial
+    ) -> TestCaseImplementation.Partial:
         for validator in TestCaseImplementation.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_test_case_implementation.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_test_case_implementation.py
@@ -165,7 +165,7 @@ class TestCaseImplementation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_test_case_implementation_validate(
+    def _pre_validate_v_2_v_3_test_case_implementation(
         cls, values: TestCaseImplementation.Partial
     ) -> TestCaseImplementation.Partial:
         for validator in TestCaseImplementation.Validators._pre_validators:
@@ -173,7 +173,7 @@ class TestCaseImplementation(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_test_case_implementation_validate(
+    def _post_validate_v_2_v_3_test_case_implementation(
         cls, values: TestCaseImplementation.Partial
     ) -> TestCaseImplementation.Partial:
         for validator in TestCaseImplementation.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_test_case_implementation_description.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_test_case_implementation_description.py
@@ -128,7 +128,7 @@ class TestCaseImplementationDescription(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(
+    def _prev_2_v_3_test_case_implementation_description_validate(
         cls, values: TestCaseImplementationDescription.Partial
     ) -> TestCaseImplementationDescription.Partial:
         for validator in TestCaseImplementationDescription.Validators._pre_validators:
@@ -136,7 +136,7 @@ class TestCaseImplementationDescription(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(
+    def _postv_2_v_3_test_case_implementation_description_validate(
         cls, values: TestCaseImplementationDescription.Partial
     ) -> TestCaseImplementationDescription.Partial:
         for validator in TestCaseImplementationDescription.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_test_case_implementation_description.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_test_case_implementation_description.py
@@ -128,7 +128,7 @@ class TestCaseImplementationDescription(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_test_case_implementation_description_validate(
+    def _pre_v_2_v_3_test_case_implementation_description_validate(
         cls, values: TestCaseImplementationDescription.Partial
     ) -> TestCaseImplementationDescription.Partial:
         for validator in TestCaseImplementationDescription.Validators._pre_validators:
@@ -136,7 +136,7 @@ class TestCaseImplementationDescription(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_test_case_implementation_description_validate(
+    def _post_v_2_v_3_test_case_implementation_description_validate(
         cls, values: TestCaseImplementationDescription.Partial
     ) -> TestCaseImplementationDescription.Partial:
         for validator in TestCaseImplementationDescription.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_test_case_implementation_description.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_test_case_implementation_description.py
@@ -128,7 +128,7 @@ class TestCaseImplementationDescription(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_test_case_implementation_description_validate(
+    def _pre_validate_v_2_v_3_test_case_implementation_description(
         cls, values: TestCaseImplementationDescription.Partial
     ) -> TestCaseImplementationDescription.Partial:
         for validator in TestCaseImplementationDescription.Validators._pre_validators:
@@ -136,7 +136,7 @@ class TestCaseImplementationDescription(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_test_case_implementation_description_validate(
+    def _post_validate_v_2_v_3_test_case_implementation_description(
         cls, values: TestCaseImplementationDescription.Partial
     ) -> TestCaseImplementationDescription.Partial:
         for validator in TestCaseImplementationDescription.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_test_case_metadata.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_test_case_metadata.py
@@ -182,13 +182,13 @@ class TestCaseMetadata(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
+    def _prev_2_v_3_test_case_metadata_validate(cls, values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
         for validator in TestCaseMetadata.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
+    def _postv_2_v_3_test_case_metadata_validate(cls, values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
         for validator in TestCaseMetadata.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_test_case_metadata.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_test_case_metadata.py
@@ -182,13 +182,13 @@ class TestCaseMetadata(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_test_case_metadata_validate(cls, values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
+    def _pre_validate_v_2_v_3_test_case_metadata(cls, values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
         for validator in TestCaseMetadata.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_test_case_metadata_validate(cls, values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
+    def _post_validate_v_2_v_3_test_case_metadata(cls, values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
         for validator in TestCaseMetadata.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_test_case_metadata.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_test_case_metadata.py
@@ -182,13 +182,13 @@ class TestCaseMetadata(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_test_case_metadata_validate(cls, values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
+    def _pre_v_2_v_3_test_case_metadata_validate(cls, values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
         for validator in TestCaseMetadata.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_test_case_metadata_validate(cls, values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
+    def _post_v_2_v_3_test_case_metadata_validate(cls, values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
         for validator in TestCaseMetadata.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_test_case_template.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_test_case_template.py
@@ -199,13 +199,13 @@ class TestCaseTemplate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_test_case_template_validate(cls, values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
+    def _pre_v_2_v_3_test_case_template_validate(cls, values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
         for validator in TestCaseTemplate.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_test_case_template_validate(cls, values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
+    def _post_v_2_v_3_test_case_template_validate(cls, values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
         for validator in TestCaseTemplate.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_test_case_template.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_test_case_template.py
@@ -199,13 +199,13 @@ class TestCaseTemplate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_test_case_template_validate(cls, values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
+    def _pre_validate_v_2_v_3_test_case_template(cls, values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
         for validator in TestCaseTemplate.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_test_case_template_validate(cls, values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
+    def _post_validate_v_2_v_3_test_case_template(cls, values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
         for validator in TestCaseTemplate.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_test_case_template.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_test_case_template.py
@@ -199,13 +199,13 @@ class TestCaseTemplate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
+    def _prev_2_v_3_test_case_template_validate(cls, values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
         for validator in TestCaseTemplate.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
+    def _postv_2_v_3_test_case_template_validate(cls, values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
         for validator in TestCaseTemplate.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_test_case_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_test_case_v_2.py
@@ -232,13 +232,13 @@ class TestCaseV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TestCaseV2.Partial) -> TestCaseV2.Partial:
+    def _prev_2_v_3_test_case_v_2_validate(cls, values: TestCaseV2.Partial) -> TestCaseV2.Partial:
         for validator in TestCaseV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TestCaseV2.Partial) -> TestCaseV2.Partial:
+    def _postv_2_v_3_test_case_v_2_validate(cls, values: TestCaseV2.Partial) -> TestCaseV2.Partial:
         for validator in TestCaseV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_test_case_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_test_case_v_2.py
@@ -232,13 +232,13 @@ class TestCaseV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_test_case_v_2_validate(cls, values: TestCaseV2.Partial) -> TestCaseV2.Partial:
+    def _pre_v_2_v_3_test_case_v_2_validate(cls, values: TestCaseV2.Partial) -> TestCaseV2.Partial:
         for validator in TestCaseV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_test_case_v_2_validate(cls, values: TestCaseV2.Partial) -> TestCaseV2.Partial:
+    def _post_v_2_v_3_test_case_v_2_validate(cls, values: TestCaseV2.Partial) -> TestCaseV2.Partial:
         for validator in TestCaseV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_test_case_v_2.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_test_case_v_2.py
@@ -232,13 +232,13 @@ class TestCaseV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_test_case_v_2_validate(cls, values: TestCaseV2.Partial) -> TestCaseV2.Partial:
+    def _pre_validate_v_2_v_3_test_case_v_2(cls, values: TestCaseV2.Partial) -> TestCaseV2.Partial:
         for validator in TestCaseV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_test_case_v_2_validate(cls, values: TestCaseV2.Partial) -> TestCaseV2.Partial:
+    def _post_validate_v_2_v_3_test_case_v_2(cls, values: TestCaseV2.Partial) -> TestCaseV2.Partial:
         for validator in TestCaseV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_test_case_with_actual_result_implementation.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_test_case_with_actual_result_implementation.py
@@ -185,7 +185,7 @@ class TestCaseWithActualResultImplementation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(
+    def _prev_2_v_3_test_case_with_actual_result_implementation_validate(
         cls, values: TestCaseWithActualResultImplementation.Partial
     ) -> TestCaseWithActualResultImplementation.Partial:
         for validator in TestCaseWithActualResultImplementation.Validators._pre_validators:
@@ -193,7 +193,7 @@ class TestCaseWithActualResultImplementation(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(
+    def _postv_2_v_3_test_case_with_actual_result_implementation_validate(
         cls, values: TestCaseWithActualResultImplementation.Partial
     ) -> TestCaseWithActualResultImplementation.Partial:
         for validator in TestCaseWithActualResultImplementation.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_test_case_with_actual_result_implementation.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_test_case_with_actual_result_implementation.py
@@ -185,7 +185,7 @@ class TestCaseWithActualResultImplementation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_test_case_with_actual_result_implementation_validate(
+    def _pre_validate_v_2_v_3_test_case_with_actual_result_implementation(
         cls, values: TestCaseWithActualResultImplementation.Partial
     ) -> TestCaseWithActualResultImplementation.Partial:
         for validator in TestCaseWithActualResultImplementation.Validators._pre_validators:
@@ -193,7 +193,7 @@ class TestCaseWithActualResultImplementation(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_test_case_with_actual_result_implementation_validate(
+    def _post_validate_v_2_v_3_test_case_with_actual_result_implementation(
         cls, values: TestCaseWithActualResultImplementation.Partial
     ) -> TestCaseWithActualResultImplementation.Partial:
         for validator in TestCaseWithActualResultImplementation.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_test_case_with_actual_result_implementation.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_test_case_with_actual_result_implementation.py
@@ -185,7 +185,7 @@ class TestCaseWithActualResultImplementation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_test_case_with_actual_result_implementation_validate(
+    def _pre_v_2_v_3_test_case_with_actual_result_implementation_validate(
         cls, values: TestCaseWithActualResultImplementation.Partial
     ) -> TestCaseWithActualResultImplementation.Partial:
         for validator in TestCaseWithActualResultImplementation.Validators._pre_validators:
@@ -193,7 +193,7 @@ class TestCaseWithActualResultImplementation(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_test_case_with_actual_result_implementation_validate(
+    def _post_v_2_v_3_test_case_with_actual_result_implementation_validate(
         cls, values: TestCaseWithActualResultImplementation.Partial
     ) -> TestCaseWithActualResultImplementation.Partial:
         for validator in TestCaseWithActualResultImplementation.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_void_function_definition.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_void_function_definition.py
@@ -162,13 +162,17 @@ class VoidFunctionDefinition(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: VoidFunctionDefinition.Partial) -> VoidFunctionDefinition.Partial:
+    def _prev_2_v_3_void_function_definition_validate(
+        cls, values: VoidFunctionDefinition.Partial
+    ) -> VoidFunctionDefinition.Partial:
         for validator in VoidFunctionDefinition.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: VoidFunctionDefinition.Partial) -> VoidFunctionDefinition.Partial:
+    def _postv_2_v_3_void_function_definition_validate(
+        cls, values: VoidFunctionDefinition.Partial
+    ) -> VoidFunctionDefinition.Partial:
         for validator in VoidFunctionDefinition.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_void_function_definition.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_void_function_definition.py
@@ -162,7 +162,7 @@ class VoidFunctionDefinition(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_void_function_definition_validate(
+    def _pre_v_2_v_3_void_function_definition_validate(
         cls, values: VoidFunctionDefinition.Partial
     ) -> VoidFunctionDefinition.Partial:
         for validator in VoidFunctionDefinition.Validators._pre_validators:
@@ -170,7 +170,7 @@ class VoidFunctionDefinition(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_void_function_definition_validate(
+    def _post_v_2_v_3_void_function_definition_validate(
         cls, values: VoidFunctionDefinition.Partial
     ) -> VoidFunctionDefinition.Partial:
         for validator in VoidFunctionDefinition.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_void_function_definition.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_void_function_definition.py
@@ -162,7 +162,7 @@ class VoidFunctionDefinition(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_void_function_definition_validate(
+    def _pre_validate_v_2_v_3_void_function_definition(
         cls, values: VoidFunctionDefinition.Partial
     ) -> VoidFunctionDefinition.Partial:
         for validator in VoidFunctionDefinition.Validators._pre_validators:
@@ -170,7 +170,7 @@ class VoidFunctionDefinition(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_void_function_definition_validate(
+    def _post_validate_v_2_v_3_void_function_definition(
         cls, values: VoidFunctionDefinition.Partial
     ) -> VoidFunctionDefinition.Partial:
         for validator in VoidFunctionDefinition.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_void_function_definition_that_takes_actual_result.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_void_function_definition_that_takes_actual_result.py
@@ -189,7 +189,7 @@ class VoidFunctionDefinitionThatTakesActualResult(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(
+    def _prev_2_v_3_void_function_definition_that_takes_actual_result_validate(
         cls, values: VoidFunctionDefinitionThatTakesActualResult.Partial
     ) -> VoidFunctionDefinitionThatTakesActualResult.Partial:
         for validator in VoidFunctionDefinitionThatTakesActualResult.Validators._pre_validators:
@@ -197,7 +197,7 @@ class VoidFunctionDefinitionThatTakesActualResult(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(
+    def _postv_2_v_3_void_function_definition_that_takes_actual_result_validate(
         cls, values: VoidFunctionDefinitionThatTakesActualResult.Partial
     ) -> VoidFunctionDefinitionThatTakesActualResult.Partial:
         for validator in VoidFunctionDefinitionThatTakesActualResult.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_void_function_definition_that_takes_actual_result.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_void_function_definition_that_takes_actual_result.py
@@ -189,7 +189,7 @@ class VoidFunctionDefinitionThatTakesActualResult(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_void_function_definition_that_takes_actual_result_validate(
+    def _pre_v_2_v_3_void_function_definition_that_takes_actual_result_validate(
         cls, values: VoidFunctionDefinitionThatTakesActualResult.Partial
     ) -> VoidFunctionDefinitionThatTakesActualResult.Partial:
         for validator in VoidFunctionDefinitionThatTakesActualResult.Validators._pre_validators:
@@ -197,7 +197,7 @@ class VoidFunctionDefinitionThatTakesActualResult(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_void_function_definition_that_takes_actual_result_validate(
+    def _post_v_2_v_3_void_function_definition_that_takes_actual_result_validate(
         cls, values: VoidFunctionDefinitionThatTakesActualResult.Partial
     ) -> VoidFunctionDefinitionThatTakesActualResult.Partial:
         for validator in VoidFunctionDefinitionThatTakesActualResult.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_void_function_definition_that_takes_actual_result.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_void_function_definition_that_takes_actual_result.py
@@ -189,7 +189,7 @@ class VoidFunctionDefinitionThatTakesActualResult(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_void_function_definition_that_takes_actual_result_validate(
+    def _pre_validate_v_2_v_3_void_function_definition_that_takes_actual_result(
         cls, values: VoidFunctionDefinitionThatTakesActualResult.Partial
     ) -> VoidFunctionDefinitionThatTakesActualResult.Partial:
         for validator in VoidFunctionDefinitionThatTakesActualResult.Validators._pre_validators:
@@ -197,7 +197,7 @@ class VoidFunctionDefinitionThatTakesActualResult(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_void_function_definition_that_takes_actual_result_validate(
+    def _post_validate_v_2_v_3_void_function_definition_that_takes_actual_result(
         cls, values: VoidFunctionDefinitionThatTakesActualResult.Partial
     ) -> VoidFunctionDefinitionThatTakesActualResult.Partial:
         for validator in VoidFunctionDefinitionThatTakesActualResult.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_void_function_signature.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_void_function_signature.py
@@ -119,7 +119,7 @@ class VoidFunctionSignature(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_void_function_signature_validate(
+    def _pre_v_2_v_3_void_function_signature_validate(
         cls, values: VoidFunctionSignature.Partial
     ) -> VoidFunctionSignature.Partial:
         for validator in VoidFunctionSignature.Validators._pre_validators:
@@ -127,7 +127,7 @@ class VoidFunctionSignature(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_void_function_signature_validate(
+    def _post_v_2_v_3_void_function_signature_validate(
         cls, values: VoidFunctionSignature.Partial
     ) -> VoidFunctionSignature.Partial:
         for validator in VoidFunctionSignature.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_void_function_signature.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_void_function_signature.py
@@ -119,13 +119,17 @@ class VoidFunctionSignature(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: VoidFunctionSignature.Partial) -> VoidFunctionSignature.Partial:
+    def _prev_2_v_3_void_function_signature_validate(
+        cls, values: VoidFunctionSignature.Partial
+    ) -> VoidFunctionSignature.Partial:
         for validator in VoidFunctionSignature.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: VoidFunctionSignature.Partial) -> VoidFunctionSignature.Partial:
+    def _postv_2_v_3_void_function_signature_validate(
+        cls, values: VoidFunctionSignature.Partial
+    ) -> VoidFunctionSignature.Partial:
         for validator in VoidFunctionSignature.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_void_function_signature.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_void_function_signature.py
@@ -119,7 +119,7 @@ class VoidFunctionSignature(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_void_function_signature_validate(
+    def _pre_validate_v_2_v_3_void_function_signature(
         cls, values: VoidFunctionSignature.Partial
     ) -> VoidFunctionSignature.Partial:
         for validator in VoidFunctionSignature.Validators._pre_validators:
@@ -127,7 +127,7 @@ class VoidFunctionSignature(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_void_function_signature_validate(
+    def _post_validate_v_2_v_3_void_function_signature(
         cls, values: VoidFunctionSignature.Partial
     ) -> VoidFunctionSignature.Partial:
         for validator in VoidFunctionSignature.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_void_function_signature_that_takes_actual_result.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_void_function_signature_that_takes_actual_result.py
@@ -183,7 +183,7 @@ class VoidFunctionSignatureThatTakesActualResult(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(
+    def _prev_2_v_3_void_function_signature_that_takes_actual_result_validate(
         cls, values: VoidFunctionSignatureThatTakesActualResult.Partial
     ) -> VoidFunctionSignatureThatTakesActualResult.Partial:
         for validator in VoidFunctionSignatureThatTakesActualResult.Validators._pre_validators:
@@ -191,7 +191,7 @@ class VoidFunctionSignatureThatTakesActualResult(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(
+    def _postv_2_v_3_void_function_signature_that_takes_actual_result_validate(
         cls, values: VoidFunctionSignatureThatTakesActualResult.Partial
     ) -> VoidFunctionSignatureThatTakesActualResult.Partial:
         for validator in VoidFunctionSignatureThatTakesActualResult.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_void_function_signature_that_takes_actual_result.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_void_function_signature_that_takes_actual_result.py
@@ -183,7 +183,7 @@ class VoidFunctionSignatureThatTakesActualResult(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_void_function_signature_that_takes_actual_result_validate(
+    def _pre_validate_v_2_v_3_void_function_signature_that_takes_actual_result(
         cls, values: VoidFunctionSignatureThatTakesActualResult.Partial
     ) -> VoidFunctionSignatureThatTakesActualResult.Partial:
         for validator in VoidFunctionSignatureThatTakesActualResult.Validators._pre_validators:
@@ -191,7 +191,7 @@ class VoidFunctionSignatureThatTakesActualResult(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_void_function_signature_that_takes_actual_result_validate(
+    def _post_validate_v_2_v_3_void_function_signature_that_takes_actual_result(
         cls, values: VoidFunctionSignatureThatTakesActualResult.Partial
     ) -> VoidFunctionSignatureThatTakesActualResult.Partial:
         for validator in VoidFunctionSignatureThatTakesActualResult.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_void_function_signature_that_takes_actual_result.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi resources_v_2_resources_v_3_resources_problem_types_void_function_signature_that_takes_actual_result.py
@@ -183,7 +183,7 @@ class VoidFunctionSignatureThatTakesActualResult(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_void_function_signature_that_takes_actual_result_validate(
+    def _pre_v_2_v_3_void_function_signature_that_takes_actual_result_validate(
         cls, values: VoidFunctionSignatureThatTakesActualResult.Partial
     ) -> VoidFunctionSignatureThatTakesActualResult.Partial:
         for validator in VoidFunctionSignatureThatTakesActualResult.Validators._pre_validators:
@@ -191,7 +191,7 @@ class VoidFunctionSignatureThatTakesActualResult(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_void_function_signature_that_takes_actual_result_validate(
+    def _post_v_2_v_3_void_function_signature_that_takes_actual_result_validate(
         cls, values: VoidFunctionSignatureThatTakesActualResult.Partial
     ) -> VoidFunctionSignatureThatTakesActualResult.Partial:
         for validator in VoidFunctionSignatureThatTakesActualResult.Validators._post_validators:

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi_error_status_code resources_movie_types_movie.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi_error_status_code resources_movie_types_movie.py
@@ -174,13 +174,13 @@ class Movie(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_movie_validate(cls, values: Movie.Partial) -> Movie.Partial:
+    def _pre_validate_movie(cls, values: Movie.Partial) -> Movie.Partial:
         for validator in Movie.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_movie_validate(cls, values: Movie.Partial) -> Movie.Partial:
+    def _post_validate_movie(cls, values: Movie.Partial) -> Movie.Partial:
         for validator in Movie.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi_error_status_code resources_movie_types_movie.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi_error_status_code resources_movie_types_movie.py
@@ -174,13 +174,13 @@ class Movie(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _premovie_validate(cls, values: Movie.Partial) -> Movie.Partial:
+    def _pre_movie_validate(cls, values: Movie.Partial) -> Movie.Partial:
         for validator in Movie.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postmovie_validate(cls, values: Movie.Partial) -> Movie.Partial:
+    def _post_movie_validate(cls, values: Movie.Partial) -> Movie.Partial:
         for validator in Movie.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi_error_status_code resources_movie_types_movie.py
+++ b/tests/fastapi/snapshots/snap_test_fastapi/test_fastapi_error_status_code resources_movie_types_movie.py
@@ -174,13 +174,13 @@ class Movie(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: Movie.Partial) -> Movie.Partial:
+    def _premovie_validate(cls, values: Movie.Partial) -> Movie.Partial:
         for validator in Movie.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: Movie.Partial) -> Movie.Partial:
+    def _postmovie_validate(cls, values: Movie.Partial) -> Movie.Partial:
         for validator in Movie.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_publish_pydantic_model src_fern_api_resources_movie_movie.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_publish_pydantic_model src_fern_api_resources_movie_movie.py
@@ -246,13 +246,13 @@ class Movie(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: Movie.Partial) -> Movie.Partial:
+    def _premovie_validate(cls, values: Movie.Partial) -> Movie.Partial:
         for validator in Movie.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: Movie.Partial) -> Movie.Partial:
+    def _postmovie_validate(cls, values: Movie.Partial) -> Movie.Partial:
         for validator in Movie.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_publish_pydantic_model src_fern_api_resources_movie_movie.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_publish_pydantic_model src_fern_api_resources_movie_movie.py
@@ -246,13 +246,13 @@ class Movie(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _premovie_validate(cls, values: Movie.Partial) -> Movie.Partial:
+    def _pre_movie_validate(cls, values: Movie.Partial) -> Movie.Partial:
         for validator in Movie.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postmovie_validate(cls, values: Movie.Partial) -> Movie.Partial:
+    def _post_movie_validate(cls, values: Movie.Partial) -> Movie.Partial:
         for validator in Movie.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_publish_pydantic_model src_fern_api_resources_movie_movie.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_publish_pydantic_model src_fern_api_resources_movie_movie.py
@@ -246,13 +246,13 @@ class Movie(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_movie_validate(cls, values: Movie.Partial) -> Movie.Partial:
+    def _pre_validate_movie(cls, values: Movie.Partial) -> Movie.Partial:
         for validator in Movie.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_movie_validate(cls, values: Movie.Partial) -> Movie.Partial:
+    def _post_validate_movie(cls, values: Movie.Partial) -> Movie.Partial:
         for validator in Movie.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_binary_tree_node_and_tree_value.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_binary_tree_node_and_tree_value.py
@@ -165,13 +165,17 @@ class BinaryTreeNodeAndTreeValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: BinaryTreeNodeAndTreeValue.Partial) -> BinaryTreeNodeAndTreeValue.Partial:
+    def _prebinary_tree_node_and_tree_value_validate(
+        cls, values: BinaryTreeNodeAndTreeValue.Partial
+    ) -> BinaryTreeNodeAndTreeValue.Partial:
         for validator in BinaryTreeNodeAndTreeValue.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: BinaryTreeNodeAndTreeValue.Partial) -> BinaryTreeNodeAndTreeValue.Partial:
+    def _postbinary_tree_node_and_tree_value_validate(
+        cls, values: BinaryTreeNodeAndTreeValue.Partial
+    ) -> BinaryTreeNodeAndTreeValue.Partial:
         for validator in BinaryTreeNodeAndTreeValue.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_binary_tree_node_and_tree_value.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_binary_tree_node_and_tree_value.py
@@ -165,7 +165,7 @@ class BinaryTreeNodeAndTreeValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prebinary_tree_node_and_tree_value_validate(
+    def _pre_binary_tree_node_and_tree_value_validate(
         cls, values: BinaryTreeNodeAndTreeValue.Partial
     ) -> BinaryTreeNodeAndTreeValue.Partial:
         for validator in BinaryTreeNodeAndTreeValue.Validators._pre_validators:
@@ -173,7 +173,7 @@ class BinaryTreeNodeAndTreeValue(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postbinary_tree_node_and_tree_value_validate(
+    def _post_binary_tree_node_and_tree_value_validate(
         cls, values: BinaryTreeNodeAndTreeValue.Partial
     ) -> BinaryTreeNodeAndTreeValue.Partial:
         for validator in BinaryTreeNodeAndTreeValue.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_binary_tree_node_and_tree_value.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_binary_tree_node_and_tree_value.py
@@ -165,7 +165,7 @@ class BinaryTreeNodeAndTreeValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_binary_tree_node_and_tree_value_validate(
+    def _pre_validate_binary_tree_node_and_tree_value(
         cls, values: BinaryTreeNodeAndTreeValue.Partial
     ) -> BinaryTreeNodeAndTreeValue.Partial:
         for validator in BinaryTreeNodeAndTreeValue.Validators._pre_validators:
@@ -173,7 +173,7 @@ class BinaryTreeNodeAndTreeValue(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_binary_tree_node_and_tree_value_validate(
+    def _post_validate_binary_tree_node_and_tree_value(
         cls, values: BinaryTreeNodeAndTreeValue.Partial
     ) -> BinaryTreeNodeAndTreeValue.Partial:
         for validator in BinaryTreeNodeAndTreeValue.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_binary_tree_node_value.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_binary_tree_node_value.py
@@ -233,13 +233,13 @@ class BinaryTreeNodeValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: BinaryTreeNodeValue.Partial) -> BinaryTreeNodeValue.Partial:
+    def _prebinary_tree_node_value_validate(cls, values: BinaryTreeNodeValue.Partial) -> BinaryTreeNodeValue.Partial:
         for validator in BinaryTreeNodeValue.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: BinaryTreeNodeValue.Partial) -> BinaryTreeNodeValue.Partial:
+    def _postbinary_tree_node_value_validate(cls, values: BinaryTreeNodeValue.Partial) -> BinaryTreeNodeValue.Partial:
         for validator in BinaryTreeNodeValue.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_binary_tree_node_value.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_binary_tree_node_value.py
@@ -233,13 +233,13 @@ class BinaryTreeNodeValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prebinary_tree_node_value_validate(cls, values: BinaryTreeNodeValue.Partial) -> BinaryTreeNodeValue.Partial:
+    def _pre_binary_tree_node_value_validate(cls, values: BinaryTreeNodeValue.Partial) -> BinaryTreeNodeValue.Partial:
         for validator in BinaryTreeNodeValue.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postbinary_tree_node_value_validate(cls, values: BinaryTreeNodeValue.Partial) -> BinaryTreeNodeValue.Partial:
+    def _post_binary_tree_node_value_validate(cls, values: BinaryTreeNodeValue.Partial) -> BinaryTreeNodeValue.Partial:
         for validator in BinaryTreeNodeValue.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_binary_tree_node_value.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_binary_tree_node_value.py
@@ -233,13 +233,13 @@ class BinaryTreeNodeValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_binary_tree_node_value_validate(cls, values: BinaryTreeNodeValue.Partial) -> BinaryTreeNodeValue.Partial:
+    def _pre_validate_binary_tree_node_value(cls, values: BinaryTreeNodeValue.Partial) -> BinaryTreeNodeValue.Partial:
         for validator in BinaryTreeNodeValue.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_binary_tree_node_value_validate(cls, values: BinaryTreeNodeValue.Partial) -> BinaryTreeNodeValue.Partial:
+    def _post_validate_binary_tree_node_value(cls, values: BinaryTreeNodeValue.Partial) -> BinaryTreeNodeValue.Partial:
         for validator in BinaryTreeNodeValue.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_binary_tree_value.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_binary_tree_value.py
@@ -150,13 +150,13 @@ class BinaryTreeValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_binary_tree_value_validate(cls, values: BinaryTreeValue.Partial) -> BinaryTreeValue.Partial:
+    def _pre_validate_binary_tree_value(cls, values: BinaryTreeValue.Partial) -> BinaryTreeValue.Partial:
         for validator in BinaryTreeValue.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_binary_tree_value_validate(cls, values: BinaryTreeValue.Partial) -> BinaryTreeValue.Partial:
+    def _post_validate_binary_tree_value(cls, values: BinaryTreeValue.Partial) -> BinaryTreeValue.Partial:
         for validator in BinaryTreeValue.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_binary_tree_value.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_binary_tree_value.py
@@ -150,13 +150,13 @@ class BinaryTreeValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prebinary_tree_value_validate(cls, values: BinaryTreeValue.Partial) -> BinaryTreeValue.Partial:
+    def _pre_binary_tree_value_validate(cls, values: BinaryTreeValue.Partial) -> BinaryTreeValue.Partial:
         for validator in BinaryTreeValue.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postbinary_tree_value_validate(cls, values: BinaryTreeValue.Partial) -> BinaryTreeValue.Partial:
+    def _post_binary_tree_value_validate(cls, values: BinaryTreeValue.Partial) -> BinaryTreeValue.Partial:
         for validator in BinaryTreeValue.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_binary_tree_value.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_binary_tree_value.py
@@ -150,13 +150,13 @@ class BinaryTreeValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: BinaryTreeValue.Partial) -> BinaryTreeValue.Partial:
+    def _prebinary_tree_value_validate(cls, values: BinaryTreeValue.Partial) -> BinaryTreeValue.Partial:
         for validator in BinaryTreeValue.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: BinaryTreeValue.Partial) -> BinaryTreeValue.Partial:
+    def _postbinary_tree_value_validate(cls, values: BinaryTreeValue.Partial) -> BinaryTreeValue.Partial:
         for validator in BinaryTreeValue.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_debug_key_value_pairs.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_debug_key_value_pairs.py
@@ -148,13 +148,13 @@ class DebugKeyValuePairs(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: DebugKeyValuePairs.Partial) -> DebugKeyValuePairs.Partial:
+    def _predebug_key_value_pairs_validate(cls, values: DebugKeyValuePairs.Partial) -> DebugKeyValuePairs.Partial:
         for validator in DebugKeyValuePairs.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: DebugKeyValuePairs.Partial) -> DebugKeyValuePairs.Partial:
+    def _postdebug_key_value_pairs_validate(cls, values: DebugKeyValuePairs.Partial) -> DebugKeyValuePairs.Partial:
         for validator in DebugKeyValuePairs.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_debug_key_value_pairs.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_debug_key_value_pairs.py
@@ -148,13 +148,13 @@ class DebugKeyValuePairs(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _predebug_key_value_pairs_validate(cls, values: DebugKeyValuePairs.Partial) -> DebugKeyValuePairs.Partial:
+    def _pre_debug_key_value_pairs_validate(cls, values: DebugKeyValuePairs.Partial) -> DebugKeyValuePairs.Partial:
         for validator in DebugKeyValuePairs.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postdebug_key_value_pairs_validate(cls, values: DebugKeyValuePairs.Partial) -> DebugKeyValuePairs.Partial:
+    def _post_debug_key_value_pairs_validate(cls, values: DebugKeyValuePairs.Partial) -> DebugKeyValuePairs.Partial:
         for validator in DebugKeyValuePairs.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_debug_key_value_pairs.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_debug_key_value_pairs.py
@@ -148,13 +148,13 @@ class DebugKeyValuePairs(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_debug_key_value_pairs_validate(cls, values: DebugKeyValuePairs.Partial) -> DebugKeyValuePairs.Partial:
+    def _pre_validate_debug_key_value_pairs(cls, values: DebugKeyValuePairs.Partial) -> DebugKeyValuePairs.Partial:
         for validator in DebugKeyValuePairs.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_debug_key_value_pairs_validate(cls, values: DebugKeyValuePairs.Partial) -> DebugKeyValuePairs.Partial:
+    def _post_validate_debug_key_value_pairs(cls, values: DebugKeyValuePairs.Partial) -> DebugKeyValuePairs.Partial:
         for validator in DebugKeyValuePairs.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_debug_map_value.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_debug_map_value.py
@@ -116,13 +116,13 @@ class DebugMapValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _predebug_map_value_validate(cls, values: DebugMapValue.Partial) -> DebugMapValue.Partial:
+    def _pre_debug_map_value_validate(cls, values: DebugMapValue.Partial) -> DebugMapValue.Partial:
         for validator in DebugMapValue.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postdebug_map_value_validate(cls, values: DebugMapValue.Partial) -> DebugMapValue.Partial:
+    def _post_debug_map_value_validate(cls, values: DebugMapValue.Partial) -> DebugMapValue.Partial:
         for validator in DebugMapValue.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_debug_map_value.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_debug_map_value.py
@@ -116,13 +116,13 @@ class DebugMapValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_debug_map_value_validate(cls, values: DebugMapValue.Partial) -> DebugMapValue.Partial:
+    def _pre_validate_debug_map_value(cls, values: DebugMapValue.Partial) -> DebugMapValue.Partial:
         for validator in DebugMapValue.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_debug_map_value_validate(cls, values: DebugMapValue.Partial) -> DebugMapValue.Partial:
+    def _post_validate_debug_map_value(cls, values: DebugMapValue.Partial) -> DebugMapValue.Partial:
         for validator in DebugMapValue.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_debug_map_value.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_debug_map_value.py
@@ -116,13 +116,13 @@ class DebugMapValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: DebugMapValue.Partial) -> DebugMapValue.Partial:
+    def _predebug_map_value_validate(cls, values: DebugMapValue.Partial) -> DebugMapValue.Partial:
         for validator in DebugMapValue.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: DebugMapValue.Partial) -> DebugMapValue.Partial:
+    def _postdebug_map_value_validate(cls, values: DebugMapValue.Partial) -> DebugMapValue.Partial:
         for validator in DebugMapValue.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_doubly_linked_list_node_and_list_value.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_doubly_linked_list_node_and_list_value.py
@@ -172,7 +172,7 @@ class DoublyLinkedListNodeAndListValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(
+    def _predoubly_linked_list_node_and_list_value_validate(
         cls, values: DoublyLinkedListNodeAndListValue.Partial
     ) -> DoublyLinkedListNodeAndListValue.Partial:
         for validator in DoublyLinkedListNodeAndListValue.Validators._pre_validators:
@@ -180,7 +180,7 @@ class DoublyLinkedListNodeAndListValue(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(
+    def _postdoubly_linked_list_node_and_list_value_validate(
         cls, values: DoublyLinkedListNodeAndListValue.Partial
     ) -> DoublyLinkedListNodeAndListValue.Partial:
         for validator in DoublyLinkedListNodeAndListValue.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_doubly_linked_list_node_and_list_value.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_doubly_linked_list_node_and_list_value.py
@@ -172,7 +172,7 @@ class DoublyLinkedListNodeAndListValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _predoubly_linked_list_node_and_list_value_validate(
+    def _pre_doubly_linked_list_node_and_list_value_validate(
         cls, values: DoublyLinkedListNodeAndListValue.Partial
     ) -> DoublyLinkedListNodeAndListValue.Partial:
         for validator in DoublyLinkedListNodeAndListValue.Validators._pre_validators:
@@ -180,7 +180,7 @@ class DoublyLinkedListNodeAndListValue(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postdoubly_linked_list_node_and_list_value_validate(
+    def _post_doubly_linked_list_node_and_list_value_validate(
         cls, values: DoublyLinkedListNodeAndListValue.Partial
     ) -> DoublyLinkedListNodeAndListValue.Partial:
         for validator in DoublyLinkedListNodeAndListValue.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_doubly_linked_list_node_and_list_value.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_doubly_linked_list_node_and_list_value.py
@@ -172,7 +172,7 @@ class DoublyLinkedListNodeAndListValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_doubly_linked_list_node_and_list_value_validate(
+    def _pre_validate_doubly_linked_list_node_and_list_value(
         cls, values: DoublyLinkedListNodeAndListValue.Partial
     ) -> DoublyLinkedListNodeAndListValue.Partial:
         for validator in DoublyLinkedListNodeAndListValue.Validators._pre_validators:
@@ -180,7 +180,7 @@ class DoublyLinkedListNodeAndListValue(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_doubly_linked_list_node_and_list_value_validate(
+    def _post_validate_doubly_linked_list_node_and_list_value(
         cls, values: DoublyLinkedListNodeAndListValue.Partial
     ) -> DoublyLinkedListNodeAndListValue.Partial:
         for validator in DoublyLinkedListNodeAndListValue.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_doubly_linked_list_node_value.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_doubly_linked_list_node_value.py
@@ -241,7 +241,7 @@ class DoublyLinkedListNodeValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_doubly_linked_list_node_value_validate(
+    def _pre_validate_doubly_linked_list_node_value(
         cls, values: DoublyLinkedListNodeValue.Partial
     ) -> DoublyLinkedListNodeValue.Partial:
         for validator in DoublyLinkedListNodeValue.Validators._pre_validators:
@@ -249,7 +249,7 @@ class DoublyLinkedListNodeValue(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_doubly_linked_list_node_value_validate(
+    def _post_validate_doubly_linked_list_node_value(
         cls, values: DoublyLinkedListNodeValue.Partial
     ) -> DoublyLinkedListNodeValue.Partial:
         for validator in DoublyLinkedListNodeValue.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_doubly_linked_list_node_value.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_doubly_linked_list_node_value.py
@@ -241,13 +241,17 @@ class DoublyLinkedListNodeValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: DoublyLinkedListNodeValue.Partial) -> DoublyLinkedListNodeValue.Partial:
+    def _predoubly_linked_list_node_value_validate(
+        cls, values: DoublyLinkedListNodeValue.Partial
+    ) -> DoublyLinkedListNodeValue.Partial:
         for validator in DoublyLinkedListNodeValue.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: DoublyLinkedListNodeValue.Partial) -> DoublyLinkedListNodeValue.Partial:
+    def _postdoubly_linked_list_node_value_validate(
+        cls, values: DoublyLinkedListNodeValue.Partial
+    ) -> DoublyLinkedListNodeValue.Partial:
         for validator in DoublyLinkedListNodeValue.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_doubly_linked_list_node_value.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_doubly_linked_list_node_value.py
@@ -241,7 +241,7 @@ class DoublyLinkedListNodeValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _predoubly_linked_list_node_value_validate(
+    def _pre_doubly_linked_list_node_value_validate(
         cls, values: DoublyLinkedListNodeValue.Partial
     ) -> DoublyLinkedListNodeValue.Partial:
         for validator in DoublyLinkedListNodeValue.Validators._pre_validators:
@@ -249,7 +249,7 @@ class DoublyLinkedListNodeValue(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postdoubly_linked_list_node_value_validate(
+    def _post_doubly_linked_list_node_value_validate(
         cls, values: DoublyLinkedListNodeValue.Partial
     ) -> DoublyLinkedListNodeValue.Partial:
         for validator in DoublyLinkedListNodeValue.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_doubly_linked_list_value.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_doubly_linked_list_value.py
@@ -156,7 +156,7 @@ class DoublyLinkedListValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_doubly_linked_list_value_validate(
+    def _pre_validate_doubly_linked_list_value(
         cls, values: DoublyLinkedListValue.Partial
     ) -> DoublyLinkedListValue.Partial:
         for validator in DoublyLinkedListValue.Validators._pre_validators:
@@ -164,7 +164,7 @@ class DoublyLinkedListValue(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_doubly_linked_list_value_validate(
+    def _post_validate_doubly_linked_list_value(
         cls, values: DoublyLinkedListValue.Partial
     ) -> DoublyLinkedListValue.Partial:
         for validator in DoublyLinkedListValue.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_doubly_linked_list_value.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_doubly_linked_list_value.py
@@ -156,7 +156,7 @@ class DoublyLinkedListValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _predoubly_linked_list_value_validate(
+    def _pre_doubly_linked_list_value_validate(
         cls, values: DoublyLinkedListValue.Partial
     ) -> DoublyLinkedListValue.Partial:
         for validator in DoublyLinkedListValue.Validators._pre_validators:
@@ -164,7 +164,7 @@ class DoublyLinkedListValue(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postdoubly_linked_list_value_validate(
+    def _post_doubly_linked_list_value_validate(
         cls, values: DoublyLinkedListValue.Partial
     ) -> DoublyLinkedListValue.Partial:
         for validator in DoublyLinkedListValue.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_doubly_linked_list_value.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_doubly_linked_list_value.py
@@ -156,13 +156,17 @@ class DoublyLinkedListValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: DoublyLinkedListValue.Partial) -> DoublyLinkedListValue.Partial:
+    def _predoubly_linked_list_value_validate(
+        cls, values: DoublyLinkedListValue.Partial
+    ) -> DoublyLinkedListValue.Partial:
         for validator in DoublyLinkedListValue.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: DoublyLinkedListValue.Partial) -> DoublyLinkedListValue.Partial:
+    def _postdoubly_linked_list_value_validate(
+        cls, values: DoublyLinkedListValue.Partial
+    ) -> DoublyLinkedListValue.Partial:
         for validator in DoublyLinkedListValue.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_file_info.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_file_info.py
@@ -138,13 +138,13 @@ class FileInfo(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_file_info_validate(cls, values: FileInfo.Partial) -> FileInfo.Partial:
+    def _pre_validate_file_info(cls, values: FileInfo.Partial) -> FileInfo.Partial:
         for validator in FileInfo.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_file_info_validate(cls, values: FileInfo.Partial) -> FileInfo.Partial:
+    def _post_validate_file_info(cls, values: FileInfo.Partial) -> FileInfo.Partial:
         for validator in FileInfo.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_file_info.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_file_info.py
@@ -138,13 +138,13 @@ class FileInfo(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prefile_info_validate(cls, values: FileInfo.Partial) -> FileInfo.Partial:
+    def _pre_file_info_validate(cls, values: FileInfo.Partial) -> FileInfo.Partial:
         for validator in FileInfo.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postfile_info_validate(cls, values: FileInfo.Partial) -> FileInfo.Partial:
+    def _post_file_info_validate(cls, values: FileInfo.Partial) -> FileInfo.Partial:
         for validator in FileInfo.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_file_info.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_file_info.py
@@ -138,13 +138,13 @@ class FileInfo(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: FileInfo.Partial) -> FileInfo.Partial:
+    def _prefile_info_validate(cls, values: FileInfo.Partial) -> FileInfo.Partial:
         for validator in FileInfo.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: FileInfo.Partial) -> FileInfo.Partial:
+    def _postfile_info_validate(cls, values: FileInfo.Partial) -> FileInfo.Partial:
         for validator in FileInfo.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_generic_value.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_generic_value.py
@@ -160,13 +160,13 @@ class GenericValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_generic_value_validate(cls, values: GenericValue.Partial) -> GenericValue.Partial:
+    def _pre_validate_generic_value(cls, values: GenericValue.Partial) -> GenericValue.Partial:
         for validator in GenericValue.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_generic_value_validate(cls, values: GenericValue.Partial) -> GenericValue.Partial:
+    def _post_validate_generic_value(cls, values: GenericValue.Partial) -> GenericValue.Partial:
         for validator in GenericValue.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_generic_value.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_generic_value.py
@@ -160,13 +160,13 @@ class GenericValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: GenericValue.Partial) -> GenericValue.Partial:
+    def _pregeneric_value_validate(cls, values: GenericValue.Partial) -> GenericValue.Partial:
         for validator in GenericValue.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: GenericValue.Partial) -> GenericValue.Partial:
+    def _postgeneric_value_validate(cls, values: GenericValue.Partial) -> GenericValue.Partial:
         for validator in GenericValue.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_generic_value.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_generic_value.py
@@ -160,13 +160,13 @@ class GenericValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pregeneric_value_validate(cls, values: GenericValue.Partial) -> GenericValue.Partial:
+    def _pre_generic_value_validate(cls, values: GenericValue.Partial) -> GenericValue.Partial:
         for validator in GenericValue.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postgeneric_value_validate(cls, values: GenericValue.Partial) -> GenericValue.Partial:
+    def _post_generic_value_validate(cls, values: GenericValue.Partial) -> GenericValue.Partial:
         for validator in GenericValue.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_key_value_pair.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_key_value_pair.py
@@ -138,13 +138,13 @@ class KeyValuePair(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prekey_value_pair_validate(cls, values: KeyValuePair.Partial) -> KeyValuePair.Partial:
+    def _pre_key_value_pair_validate(cls, values: KeyValuePair.Partial) -> KeyValuePair.Partial:
         for validator in KeyValuePair.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postkey_value_pair_validate(cls, values: KeyValuePair.Partial) -> KeyValuePair.Partial:
+    def _post_key_value_pair_validate(cls, values: KeyValuePair.Partial) -> KeyValuePair.Partial:
         for validator in KeyValuePair.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_key_value_pair.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_key_value_pair.py
@@ -138,13 +138,13 @@ class KeyValuePair(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: KeyValuePair.Partial) -> KeyValuePair.Partial:
+    def _prekey_value_pair_validate(cls, values: KeyValuePair.Partial) -> KeyValuePair.Partial:
         for validator in KeyValuePair.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: KeyValuePair.Partial) -> KeyValuePair.Partial:
+    def _postkey_value_pair_validate(cls, values: KeyValuePair.Partial) -> KeyValuePair.Partial:
         for validator in KeyValuePair.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_key_value_pair.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_key_value_pair.py
@@ -138,13 +138,13 @@ class KeyValuePair(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_key_value_pair_validate(cls, values: KeyValuePair.Partial) -> KeyValuePair.Partial:
+    def _pre_validate_key_value_pair(cls, values: KeyValuePair.Partial) -> KeyValuePair.Partial:
         for validator in KeyValuePair.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_key_value_pair_validate(cls, values: KeyValuePair.Partial) -> KeyValuePair.Partial:
+    def _post_validate_key_value_pair(cls, values: KeyValuePair.Partial) -> KeyValuePair.Partial:
         for validator in KeyValuePair.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_list_type.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_list_type.py
@@ -150,13 +150,13 @@ class ListType(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: ListType.Partial) -> ListType.Partial:
+    def _prelist_type_validate(cls, values: ListType.Partial) -> ListType.Partial:
         for validator in ListType.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: ListType.Partial) -> ListType.Partial:
+    def _postlist_type_validate(cls, values: ListType.Partial) -> ListType.Partial:
         for validator in ListType.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_list_type.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_list_type.py
@@ -150,13 +150,13 @@ class ListType(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prelist_type_validate(cls, values: ListType.Partial) -> ListType.Partial:
+    def _pre_list_type_validate(cls, values: ListType.Partial) -> ListType.Partial:
         for validator in ListType.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postlist_type_validate(cls, values: ListType.Partial) -> ListType.Partial:
+    def _post_list_type_validate(cls, values: ListType.Partial) -> ListType.Partial:
         for validator in ListType.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_list_type.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_list_type.py
@@ -150,13 +150,13 @@ class ListType(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_list_type_validate(cls, values: ListType.Partial) -> ListType.Partial:
+    def _pre_validate_list_type(cls, values: ListType.Partial) -> ListType.Partial:
         for validator in ListType.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_list_type_validate(cls, values: ListType.Partial) -> ListType.Partial:
+    def _post_validate_list_type(cls, values: ListType.Partial) -> ListType.Partial:
         for validator in ListType.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_map_type.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_map_type.py
@@ -138,13 +138,13 @@ class MapType(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_map_type_validate(cls, values: MapType.Partial) -> MapType.Partial:
+    def _pre_validate_map_type(cls, values: MapType.Partial) -> MapType.Partial:
         for validator in MapType.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_map_type_validate(cls, values: MapType.Partial) -> MapType.Partial:
+    def _post_validate_map_type(cls, values: MapType.Partial) -> MapType.Partial:
         for validator in MapType.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_map_type.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_map_type.py
@@ -138,13 +138,13 @@ class MapType(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _premap_type_validate(cls, values: MapType.Partial) -> MapType.Partial:
+    def _pre_map_type_validate(cls, values: MapType.Partial) -> MapType.Partial:
         for validator in MapType.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postmap_type_validate(cls, values: MapType.Partial) -> MapType.Partial:
+    def _post_map_type_validate(cls, values: MapType.Partial) -> MapType.Partial:
         for validator in MapType.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_map_type.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_map_type.py
@@ -138,13 +138,13 @@ class MapType(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: MapType.Partial) -> MapType.Partial:
+    def _premap_type_validate(cls, values: MapType.Partial) -> MapType.Partial:
         for validator in MapType.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: MapType.Partial) -> MapType.Partial:
+    def _postmap_type_validate(cls, values: MapType.Partial) -> MapType.Partial:
         for validator in MapType.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_map_value.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_map_value.py
@@ -110,13 +110,13 @@ class MapValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: MapValue.Partial) -> MapValue.Partial:
+    def _premap_value_validate(cls, values: MapValue.Partial) -> MapValue.Partial:
         for validator in MapValue.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: MapValue.Partial) -> MapValue.Partial:
+    def _postmap_value_validate(cls, values: MapValue.Partial) -> MapValue.Partial:
         for validator in MapValue.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_map_value.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_map_value.py
@@ -110,13 +110,13 @@ class MapValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _premap_value_validate(cls, values: MapValue.Partial) -> MapValue.Partial:
+    def _pre_map_value_validate(cls, values: MapValue.Partial) -> MapValue.Partial:
         for validator in MapValue.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postmap_value_validate(cls, values: MapValue.Partial) -> MapValue.Partial:
+    def _post_map_value_validate(cls, values: MapValue.Partial) -> MapValue.Partial:
         for validator in MapValue.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_map_value.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_map_value.py
@@ -110,13 +110,13 @@ class MapValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_map_value_validate(cls, values: MapValue.Partial) -> MapValue.Partial:
+    def _pre_validate_map_value(cls, values: MapValue.Partial) -> MapValue.Partial:
         for validator in MapValue.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_map_value_validate(cls, values: MapValue.Partial) -> MapValue.Partial:
+    def _post_validate_map_value(cls, values: MapValue.Partial) -> MapValue.Partial:
         for validator in MapValue.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_singly_linked_list_node_and_list_value.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_singly_linked_list_node_and_list_value.py
@@ -172,7 +172,7 @@ class SinglyLinkedListNodeAndListValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(
+    def _presingly_linked_list_node_and_list_value_validate(
         cls, values: SinglyLinkedListNodeAndListValue.Partial
     ) -> SinglyLinkedListNodeAndListValue.Partial:
         for validator in SinglyLinkedListNodeAndListValue.Validators._pre_validators:
@@ -180,7 +180,7 @@ class SinglyLinkedListNodeAndListValue(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(
+    def _postsingly_linked_list_node_and_list_value_validate(
         cls, values: SinglyLinkedListNodeAndListValue.Partial
     ) -> SinglyLinkedListNodeAndListValue.Partial:
         for validator in SinglyLinkedListNodeAndListValue.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_singly_linked_list_node_and_list_value.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_singly_linked_list_node_and_list_value.py
@@ -172,7 +172,7 @@ class SinglyLinkedListNodeAndListValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_singly_linked_list_node_and_list_value_validate(
+    def _pre_validate_singly_linked_list_node_and_list_value(
         cls, values: SinglyLinkedListNodeAndListValue.Partial
     ) -> SinglyLinkedListNodeAndListValue.Partial:
         for validator in SinglyLinkedListNodeAndListValue.Validators._pre_validators:
@@ -180,7 +180,7 @@ class SinglyLinkedListNodeAndListValue(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_singly_linked_list_node_and_list_value_validate(
+    def _post_validate_singly_linked_list_node_and_list_value(
         cls, values: SinglyLinkedListNodeAndListValue.Partial
     ) -> SinglyLinkedListNodeAndListValue.Partial:
         for validator in SinglyLinkedListNodeAndListValue.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_singly_linked_list_node_and_list_value.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_singly_linked_list_node_and_list_value.py
@@ -172,7 +172,7 @@ class SinglyLinkedListNodeAndListValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _presingly_linked_list_node_and_list_value_validate(
+    def _pre_singly_linked_list_node_and_list_value_validate(
         cls, values: SinglyLinkedListNodeAndListValue.Partial
     ) -> SinglyLinkedListNodeAndListValue.Partial:
         for validator in SinglyLinkedListNodeAndListValue.Validators._pre_validators:
@@ -180,7 +180,7 @@ class SinglyLinkedListNodeAndListValue(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postsingly_linked_list_node_and_list_value_validate(
+    def _post_singly_linked_list_node_and_list_value_validate(
         cls, values: SinglyLinkedListNodeAndListValue.Partial
     ) -> SinglyLinkedListNodeAndListValue.Partial:
         for validator in SinglyLinkedListNodeAndListValue.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_singly_linked_list_node_value.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_singly_linked_list_node_value.py
@@ -199,13 +199,17 @@ class SinglyLinkedListNodeValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: SinglyLinkedListNodeValue.Partial) -> SinglyLinkedListNodeValue.Partial:
+    def _presingly_linked_list_node_value_validate(
+        cls, values: SinglyLinkedListNodeValue.Partial
+    ) -> SinglyLinkedListNodeValue.Partial:
         for validator in SinglyLinkedListNodeValue.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: SinglyLinkedListNodeValue.Partial) -> SinglyLinkedListNodeValue.Partial:
+    def _postsingly_linked_list_node_value_validate(
+        cls, values: SinglyLinkedListNodeValue.Partial
+    ) -> SinglyLinkedListNodeValue.Partial:
         for validator in SinglyLinkedListNodeValue.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_singly_linked_list_node_value.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_singly_linked_list_node_value.py
@@ -199,7 +199,7 @@ class SinglyLinkedListNodeValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _presingly_linked_list_node_value_validate(
+    def _pre_singly_linked_list_node_value_validate(
         cls, values: SinglyLinkedListNodeValue.Partial
     ) -> SinglyLinkedListNodeValue.Partial:
         for validator in SinglyLinkedListNodeValue.Validators._pre_validators:
@@ -207,7 +207,7 @@ class SinglyLinkedListNodeValue(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postsingly_linked_list_node_value_validate(
+    def _post_singly_linked_list_node_value_validate(
         cls, values: SinglyLinkedListNodeValue.Partial
     ) -> SinglyLinkedListNodeValue.Partial:
         for validator in SinglyLinkedListNodeValue.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_singly_linked_list_node_value.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_singly_linked_list_node_value.py
@@ -199,7 +199,7 @@ class SinglyLinkedListNodeValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_singly_linked_list_node_value_validate(
+    def _pre_validate_singly_linked_list_node_value(
         cls, values: SinglyLinkedListNodeValue.Partial
     ) -> SinglyLinkedListNodeValue.Partial:
         for validator in SinglyLinkedListNodeValue.Validators._pre_validators:
@@ -207,7 +207,7 @@ class SinglyLinkedListNodeValue(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_singly_linked_list_node_value_validate(
+    def _post_validate_singly_linked_list_node_value(
         cls, values: SinglyLinkedListNodeValue.Partial
     ) -> SinglyLinkedListNodeValue.Partial:
         for validator in SinglyLinkedListNodeValue.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_singly_linked_list_value.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_singly_linked_list_value.py
@@ -156,7 +156,7 @@ class SinglyLinkedListValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_singly_linked_list_value_validate(
+    def _pre_validate_singly_linked_list_value(
         cls, values: SinglyLinkedListValue.Partial
     ) -> SinglyLinkedListValue.Partial:
         for validator in SinglyLinkedListValue.Validators._pre_validators:
@@ -164,7 +164,7 @@ class SinglyLinkedListValue(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_singly_linked_list_value_validate(
+    def _post_validate_singly_linked_list_value(
         cls, values: SinglyLinkedListValue.Partial
     ) -> SinglyLinkedListValue.Partial:
         for validator in SinglyLinkedListValue.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_singly_linked_list_value.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_singly_linked_list_value.py
@@ -156,7 +156,7 @@ class SinglyLinkedListValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _presingly_linked_list_value_validate(
+    def _pre_singly_linked_list_value_validate(
         cls, values: SinglyLinkedListValue.Partial
     ) -> SinglyLinkedListValue.Partial:
         for validator in SinglyLinkedListValue.Validators._pre_validators:
@@ -164,7 +164,7 @@ class SinglyLinkedListValue(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postsingly_linked_list_value_validate(
+    def _post_singly_linked_list_value_validate(
         cls, values: SinglyLinkedListValue.Partial
     ) -> SinglyLinkedListValue.Partial:
         for validator in SinglyLinkedListValue.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_singly_linked_list_value.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_singly_linked_list_value.py
@@ -156,13 +156,17 @@ class SinglyLinkedListValue(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: SinglyLinkedListValue.Partial) -> SinglyLinkedListValue.Partial:
+    def _presingly_linked_list_value_validate(
+        cls, values: SinglyLinkedListValue.Partial
+    ) -> SinglyLinkedListValue.Partial:
         for validator in SinglyLinkedListValue.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: SinglyLinkedListValue.Partial) -> SinglyLinkedListValue.Partial:
+    def _postsingly_linked_list_value_validate(
+        cls, values: SinglyLinkedListValue.Partial
+    ) -> SinglyLinkedListValue.Partial:
         for validator in SinglyLinkedListValue.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_test_case.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_test_case.py
@@ -141,13 +141,13 @@ class TestCase(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pretest_case_validate(cls, values: TestCase.Partial) -> TestCase.Partial:
+    def _pre_test_case_validate(cls, values: TestCase.Partial) -> TestCase.Partial:
         for validator in TestCase.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _posttest_case_validate(cls, values: TestCase.Partial) -> TestCase.Partial:
+    def _post_test_case_validate(cls, values: TestCase.Partial) -> TestCase.Partial:
         for validator in TestCase.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_test_case.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_test_case.py
@@ -141,13 +141,13 @@ class TestCase(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_test_case_validate(cls, values: TestCase.Partial) -> TestCase.Partial:
+    def _pre_validate_test_case(cls, values: TestCase.Partial) -> TestCase.Partial:
         for validator in TestCase.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_test_case_validate(cls, values: TestCase.Partial) -> TestCase.Partial:
+    def _post_validate_test_case(cls, values: TestCase.Partial) -> TestCase.Partial:
         for validator in TestCase.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_test_case.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_test_case.py
@@ -141,13 +141,13 @@ class TestCase(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TestCase.Partial) -> TestCase.Partial:
+    def _pretest_case_validate(cls, values: TestCase.Partial) -> TestCase.Partial:
         for validator in TestCase.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TestCase.Partial) -> TestCase.Partial:
+    def _posttest_case_validate(cls, values: TestCase.Partial) -> TestCase.Partial:
         for validator in TestCase.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_test_case_with_expected_result.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_test_case_with_expected_result.py
@@ -168,7 +168,7 @@ class TestCaseWithExpectedResult(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pretest_case_with_expected_result_validate(
+    def _pre_test_case_with_expected_result_validate(
         cls, values: TestCaseWithExpectedResult.Partial
     ) -> TestCaseWithExpectedResult.Partial:
         for validator in TestCaseWithExpectedResult.Validators._pre_validators:
@@ -176,7 +176,7 @@ class TestCaseWithExpectedResult(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _posttest_case_with_expected_result_validate(
+    def _post_test_case_with_expected_result_validate(
         cls, values: TestCaseWithExpectedResult.Partial
     ) -> TestCaseWithExpectedResult.Partial:
         for validator in TestCaseWithExpectedResult.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_test_case_with_expected_result.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_test_case_with_expected_result.py
@@ -168,13 +168,17 @@ class TestCaseWithExpectedResult(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TestCaseWithExpectedResult.Partial) -> TestCaseWithExpectedResult.Partial:
+    def _pretest_case_with_expected_result_validate(
+        cls, values: TestCaseWithExpectedResult.Partial
+    ) -> TestCaseWithExpectedResult.Partial:
         for validator in TestCaseWithExpectedResult.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TestCaseWithExpectedResult.Partial) -> TestCaseWithExpectedResult.Partial:
+    def _posttest_case_with_expected_result_validate(
+        cls, values: TestCaseWithExpectedResult.Partial
+    ) -> TestCaseWithExpectedResult.Partial:
         for validator in TestCaseWithExpectedResult.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_test_case_with_expected_result.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_commons_test_case_with_expected_result.py
@@ -168,7 +168,7 @@ class TestCaseWithExpectedResult(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_test_case_with_expected_result_validate(
+    def _pre_validate_test_case_with_expected_result(
         cls, values: TestCaseWithExpectedResult.Partial
     ) -> TestCaseWithExpectedResult.Partial:
         for validator in TestCaseWithExpectedResult.Validators._pre_validators:
@@ -176,7 +176,7 @@ class TestCaseWithExpectedResult(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_test_case_with_expected_result_validate(
+    def _post_validate_test_case_with_expected_result(
         cls, values: TestCaseWithExpectedResult.Partial
     ) -> TestCaseWithExpectedResult.Partial:
         for validator in TestCaseWithExpectedResult.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_lang_server_lang_server_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_lang_server_lang_server_request.py
@@ -111,13 +111,13 @@ class LangServerRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: LangServerRequest.Partial) -> LangServerRequest.Partial:
+    def _prelang_server_request_validate(cls, values: LangServerRequest.Partial) -> LangServerRequest.Partial:
         for validator in LangServerRequest.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: LangServerRequest.Partial) -> LangServerRequest.Partial:
+    def _postlang_server_request_validate(cls, values: LangServerRequest.Partial) -> LangServerRequest.Partial:
         for validator in LangServerRequest.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_lang_server_lang_server_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_lang_server_lang_server_request.py
@@ -111,13 +111,13 @@ class LangServerRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_lang_server_request_validate(cls, values: LangServerRequest.Partial) -> LangServerRequest.Partial:
+    def _pre_validate_lang_server_request(cls, values: LangServerRequest.Partial) -> LangServerRequest.Partial:
         for validator in LangServerRequest.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_lang_server_request_validate(cls, values: LangServerRequest.Partial) -> LangServerRequest.Partial:
+    def _post_validate_lang_server_request(cls, values: LangServerRequest.Partial) -> LangServerRequest.Partial:
         for validator in LangServerRequest.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_lang_server_lang_server_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_lang_server_lang_server_request.py
@@ -111,13 +111,13 @@ class LangServerRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prelang_server_request_validate(cls, values: LangServerRequest.Partial) -> LangServerRequest.Partial:
+    def _pre_lang_server_request_validate(cls, values: LangServerRequest.Partial) -> LangServerRequest.Partial:
         for validator in LangServerRequest.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postlang_server_request_validate(cls, values: LangServerRequest.Partial) -> LangServerRequest.Partial:
+    def _post_lang_server_request_validate(cls, values: LangServerRequest.Partial) -> LangServerRequest.Partial:
         for validator in LangServerRequest.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_lang_server_lang_server_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_lang_server_lang_server_response.py
@@ -111,13 +111,13 @@ class LangServerResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_lang_server_response_validate(cls, values: LangServerResponse.Partial) -> LangServerResponse.Partial:
+    def _pre_validate_lang_server_response(cls, values: LangServerResponse.Partial) -> LangServerResponse.Partial:
         for validator in LangServerResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_lang_server_response_validate(cls, values: LangServerResponse.Partial) -> LangServerResponse.Partial:
+    def _post_validate_lang_server_response(cls, values: LangServerResponse.Partial) -> LangServerResponse.Partial:
         for validator in LangServerResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_lang_server_lang_server_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_lang_server_lang_server_response.py
@@ -111,13 +111,13 @@ class LangServerResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prelang_server_response_validate(cls, values: LangServerResponse.Partial) -> LangServerResponse.Partial:
+    def _pre_lang_server_response_validate(cls, values: LangServerResponse.Partial) -> LangServerResponse.Partial:
         for validator in LangServerResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postlang_server_response_validate(cls, values: LangServerResponse.Partial) -> LangServerResponse.Partial:
+    def _post_lang_server_response_validate(cls, values: LangServerResponse.Partial) -> LangServerResponse.Partial:
         for validator in LangServerResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_lang_server_lang_server_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_lang_server_lang_server_response.py
@@ -111,13 +111,13 @@ class LangServerResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: LangServerResponse.Partial) -> LangServerResponse.Partial:
+    def _prelang_server_response_validate(cls, values: LangServerResponse.Partial) -> LangServerResponse.Partial:
         for validator in LangServerResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: LangServerResponse.Partial) -> LangServerResponse.Partial:
+    def _postlang_server_response_validate(cls, values: LangServerResponse.Partial) -> LangServerResponse.Partial:
         for validator in LangServerResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_migration_migration.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_migration_migration.py
@@ -139,13 +139,13 @@ class Migration(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _premigration_validate(cls, values: Migration.Partial) -> Migration.Partial:
+    def _pre_migration_validate(cls, values: Migration.Partial) -> Migration.Partial:
         for validator in Migration.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postmigration_validate(cls, values: Migration.Partial) -> Migration.Partial:
+    def _post_migration_validate(cls, values: Migration.Partial) -> Migration.Partial:
         for validator in Migration.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_migration_migration.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_migration_migration.py
@@ -139,13 +139,13 @@ class Migration(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: Migration.Partial) -> Migration.Partial:
+    def _premigration_validate(cls, values: Migration.Partial) -> Migration.Partial:
         for validator in Migration.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: Migration.Partial) -> Migration.Partial:
+    def _postmigration_validate(cls, values: Migration.Partial) -> Migration.Partial:
         for validator in Migration.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_migration_migration.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_migration_migration.py
@@ -139,13 +139,13 @@ class Migration(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_migration_validate(cls, values: Migration.Partial) -> Migration.Partial:
+    def _pre_validate_migration(cls, values: Migration.Partial) -> Migration.Partial:
         for validator in Migration.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_migration_validate(cls, values: Migration.Partial) -> Migration.Partial:
+    def _post_validate_migration(cls, values: Migration.Partial) -> Migration.Partial:
         for validator in Migration.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_playlist_playlist.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_playlist_playlist.py
@@ -243,13 +243,13 @@ class Playlist(PlaylistCreateRequest):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_playlist_validate(cls, values: Playlist.Partial) -> Playlist.Partial:
+    def _pre_validate_playlist(cls, values: Playlist.Partial) -> Playlist.Partial:
         for validator in Playlist.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_playlist_validate(cls, values: Playlist.Partial) -> Playlist.Partial:
+    def _post_validate_playlist(cls, values: Playlist.Partial) -> Playlist.Partial:
         for validator in Playlist.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_playlist_playlist.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_playlist_playlist.py
@@ -243,13 +243,13 @@ class Playlist(PlaylistCreateRequest):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preplaylist_validate(cls, values: Playlist.Partial) -> Playlist.Partial:
+    def _pre_playlist_validate(cls, values: Playlist.Partial) -> Playlist.Partial:
         for validator in Playlist.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postplaylist_validate(cls, values: Playlist.Partial) -> Playlist.Partial:
+    def _post_playlist_validate(cls, values: Playlist.Partial) -> Playlist.Partial:
         for validator in Playlist.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_playlist_playlist.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_playlist_playlist.py
@@ -243,13 +243,13 @@ class Playlist(PlaylistCreateRequest):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: Playlist.Partial) -> Playlist.Partial:
+    def _preplaylist_validate(cls, values: Playlist.Partial) -> Playlist.Partial:
         for validator in Playlist.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: Playlist.Partial) -> Playlist.Partial:
+    def _postplaylist_validate(cls, values: Playlist.Partial) -> Playlist.Partial:
         for validator in Playlist.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_playlist_playlist_create_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_playlist_playlist_create_request.py
@@ -156,7 +156,7 @@ class PlaylistCreateRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preplaylist_create_request_validate(
+    def _pre_playlist_create_request_validate(
         cls, values: PlaylistCreateRequest.Partial
     ) -> PlaylistCreateRequest.Partial:
         for validator in PlaylistCreateRequest.Validators._pre_validators:
@@ -164,7 +164,7 @@ class PlaylistCreateRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postplaylist_create_request_validate(
+    def _post_playlist_create_request_validate(
         cls, values: PlaylistCreateRequest.Partial
     ) -> PlaylistCreateRequest.Partial:
         for validator in PlaylistCreateRequest.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_playlist_playlist_create_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_playlist_playlist_create_request.py
@@ -156,7 +156,7 @@ class PlaylistCreateRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_playlist_create_request_validate(
+    def _pre_validate_playlist_create_request(
         cls, values: PlaylistCreateRequest.Partial
     ) -> PlaylistCreateRequest.Partial:
         for validator in PlaylistCreateRequest.Validators._pre_validators:
@@ -164,7 +164,7 @@ class PlaylistCreateRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_playlist_create_request_validate(
+    def _post_validate_playlist_create_request(
         cls, values: PlaylistCreateRequest.Partial
     ) -> PlaylistCreateRequest.Partial:
         for validator in PlaylistCreateRequest.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_playlist_playlist_create_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_playlist_playlist_create_request.py
@@ -156,13 +156,17 @@ class PlaylistCreateRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: PlaylistCreateRequest.Partial) -> PlaylistCreateRequest.Partial:
+    def _preplaylist_create_request_validate(
+        cls, values: PlaylistCreateRequest.Partial
+    ) -> PlaylistCreateRequest.Partial:
         for validator in PlaylistCreateRequest.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: PlaylistCreateRequest.Partial) -> PlaylistCreateRequest.Partial:
+    def _postplaylist_create_request_validate(
+        cls, values: PlaylistCreateRequest.Partial
+    ) -> PlaylistCreateRequest.Partial:
         for validator in PlaylistCreateRequest.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_playlist_update_playlist_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_playlist_update_playlist_request.py
@@ -156,7 +156,7 @@ class UpdatePlaylistRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preupdate_playlist_request_validate(
+    def _pre_update_playlist_request_validate(
         cls, values: UpdatePlaylistRequest.Partial
     ) -> UpdatePlaylistRequest.Partial:
         for validator in UpdatePlaylistRequest.Validators._pre_validators:
@@ -164,7 +164,7 @@ class UpdatePlaylistRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postupdate_playlist_request_validate(
+    def _post_update_playlist_request_validate(
         cls, values: UpdatePlaylistRequest.Partial
     ) -> UpdatePlaylistRequest.Partial:
         for validator in UpdatePlaylistRequest.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_playlist_update_playlist_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_playlist_update_playlist_request.py
@@ -156,13 +156,17 @@ class UpdatePlaylistRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: UpdatePlaylistRequest.Partial) -> UpdatePlaylistRequest.Partial:
+    def _preupdate_playlist_request_validate(
+        cls, values: UpdatePlaylistRequest.Partial
+    ) -> UpdatePlaylistRequest.Partial:
         for validator in UpdatePlaylistRequest.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: UpdatePlaylistRequest.Partial) -> UpdatePlaylistRequest.Partial:
+    def _postupdate_playlist_request_validate(
+        cls, values: UpdatePlaylistRequest.Partial
+    ) -> UpdatePlaylistRequest.Partial:
         for validator in UpdatePlaylistRequest.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_playlist_update_playlist_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_playlist_update_playlist_request.py
@@ -156,7 +156,7 @@ class UpdatePlaylistRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_update_playlist_request_validate(
+    def _pre_validate_update_playlist_request(
         cls, values: UpdatePlaylistRequest.Partial
     ) -> UpdatePlaylistRequest.Partial:
         for validator in UpdatePlaylistRequest.Validators._pre_validators:
@@ -164,7 +164,7 @@ class UpdatePlaylistRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_update_playlist_request_validate(
+    def _post_validate_update_playlist_request(
         cls, values: UpdatePlaylistRequest.Partial
     ) -> UpdatePlaylistRequest.Partial:
         for validator in UpdatePlaylistRequest.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_problem_create_problem_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_problem_create_problem_request.py
@@ -391,13 +391,13 @@ class CreateProblemRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: CreateProblemRequest.Partial) -> CreateProblemRequest.Partial:
+    def _precreate_problem_request_validate(cls, values: CreateProblemRequest.Partial) -> CreateProblemRequest.Partial:
         for validator in CreateProblemRequest.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: CreateProblemRequest.Partial) -> CreateProblemRequest.Partial:
+    def _postcreate_problem_request_validate(cls, values: CreateProblemRequest.Partial) -> CreateProblemRequest.Partial:
         for validator in CreateProblemRequest.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_problem_create_problem_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_problem_create_problem_request.py
@@ -391,13 +391,15 @@ class CreateProblemRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _precreate_problem_request_validate(cls, values: CreateProblemRequest.Partial) -> CreateProblemRequest.Partial:
+    def _pre_create_problem_request_validate(cls, values: CreateProblemRequest.Partial) -> CreateProblemRequest.Partial:
         for validator in CreateProblemRequest.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postcreate_problem_request_validate(cls, values: CreateProblemRequest.Partial) -> CreateProblemRequest.Partial:
+    def _post_create_problem_request_validate(
+        cls, values: CreateProblemRequest.Partial
+    ) -> CreateProblemRequest.Partial:
         for validator in CreateProblemRequest.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_problem_create_problem_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_problem_create_problem_request.py
@@ -391,13 +391,13 @@ class CreateProblemRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_create_problem_request_validate(cls, values: CreateProblemRequest.Partial) -> CreateProblemRequest.Partial:
+    def _pre_validate_create_problem_request(cls, values: CreateProblemRequest.Partial) -> CreateProblemRequest.Partial:
         for validator in CreateProblemRequest.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_create_problem_request_validate(
+    def _post_validate_create_problem_request(
         cls, values: CreateProblemRequest.Partial
     ) -> CreateProblemRequest.Partial:
         for validator in CreateProblemRequest.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_problem_generic_create_problem_error.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_problem_generic_create_problem_error.py
@@ -203,13 +203,17 @@ class GenericCreateProblemError(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: GenericCreateProblemError.Partial) -> GenericCreateProblemError.Partial:
+    def _pregeneric_create_problem_error_validate(
+        cls, values: GenericCreateProblemError.Partial
+    ) -> GenericCreateProblemError.Partial:
         for validator in GenericCreateProblemError.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: GenericCreateProblemError.Partial) -> GenericCreateProblemError.Partial:
+    def _postgeneric_create_problem_error_validate(
+        cls, values: GenericCreateProblemError.Partial
+    ) -> GenericCreateProblemError.Partial:
         for validator in GenericCreateProblemError.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_problem_generic_create_problem_error.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_problem_generic_create_problem_error.py
@@ -203,7 +203,7 @@ class GenericCreateProblemError(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pregeneric_create_problem_error_validate(
+    def _pre_generic_create_problem_error_validate(
         cls, values: GenericCreateProblemError.Partial
     ) -> GenericCreateProblemError.Partial:
         for validator in GenericCreateProblemError.Validators._pre_validators:
@@ -211,7 +211,7 @@ class GenericCreateProblemError(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postgeneric_create_problem_error_validate(
+    def _post_generic_create_problem_error_validate(
         cls, values: GenericCreateProblemError.Partial
     ) -> GenericCreateProblemError.Partial:
         for validator in GenericCreateProblemError.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_problem_generic_create_problem_error.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_problem_generic_create_problem_error.py
@@ -203,7 +203,7 @@ class GenericCreateProblemError(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_generic_create_problem_error_validate(
+    def _pre_validate_generic_create_problem_error(
         cls, values: GenericCreateProblemError.Partial
     ) -> GenericCreateProblemError.Partial:
         for validator in GenericCreateProblemError.Validators._pre_validators:
@@ -211,7 +211,7 @@ class GenericCreateProblemError(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_generic_create_problem_error_validate(
+    def _post_validate_generic_create_problem_error(
         cls, values: GenericCreateProblemError.Partial
     ) -> GenericCreateProblemError.Partial:
         for validator in GenericCreateProblemError.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_problem_get_default_starter_files_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_problem_get_default_starter_files_response.py
@@ -125,7 +125,7 @@ class GetDefaultStarterFilesResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preget_default_starter_files_response_validate(
+    def _pre_get_default_starter_files_response_validate(
         cls, values: GetDefaultStarterFilesResponse.Partial
     ) -> GetDefaultStarterFilesResponse.Partial:
         for validator in GetDefaultStarterFilesResponse.Validators._pre_validators:
@@ -133,7 +133,7 @@ class GetDefaultStarterFilesResponse(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postget_default_starter_files_response_validate(
+    def _post_get_default_starter_files_response_validate(
         cls, values: GetDefaultStarterFilesResponse.Partial
     ) -> GetDefaultStarterFilesResponse.Partial:
         for validator in GetDefaultStarterFilesResponse.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_problem_get_default_starter_files_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_problem_get_default_starter_files_response.py
@@ -125,7 +125,7 @@ class GetDefaultStarterFilesResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_get_default_starter_files_response_validate(
+    def _pre_validate_get_default_starter_files_response(
         cls, values: GetDefaultStarterFilesResponse.Partial
     ) -> GetDefaultStarterFilesResponse.Partial:
         for validator in GetDefaultStarterFilesResponse.Validators._pre_validators:
@@ -133,7 +133,7 @@ class GetDefaultStarterFilesResponse(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_get_default_starter_files_response_validate(
+    def _post_validate_get_default_starter_files_response(
         cls, values: GetDefaultStarterFilesResponse.Partial
     ) -> GetDefaultStarterFilesResponse.Partial:
         for validator in GetDefaultStarterFilesResponse.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_problem_get_default_starter_files_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_problem_get_default_starter_files_response.py
@@ -125,13 +125,17 @@ class GetDefaultStarterFilesResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: GetDefaultStarterFilesResponse.Partial) -> GetDefaultStarterFilesResponse.Partial:
+    def _preget_default_starter_files_response_validate(
+        cls, values: GetDefaultStarterFilesResponse.Partial
+    ) -> GetDefaultStarterFilesResponse.Partial:
         for validator in GetDefaultStarterFilesResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: GetDefaultStarterFilesResponse.Partial) -> GetDefaultStarterFilesResponse.Partial:
+    def _postget_default_starter_files_response_validate(
+        cls, values: GetDefaultStarterFilesResponse.Partial
+    ) -> GetDefaultStarterFilesResponse.Partial:
         for validator in GetDefaultStarterFilesResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_problem_problem_description.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_problem_problem_description.py
@@ -114,13 +114,13 @@ class ProblemDescription(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_problem_description_validate(cls, values: ProblemDescription.Partial) -> ProblemDescription.Partial:
+    def _pre_validate_problem_description(cls, values: ProblemDescription.Partial) -> ProblemDescription.Partial:
         for validator in ProblemDescription.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_problem_description_validate(cls, values: ProblemDescription.Partial) -> ProblemDescription.Partial:
+    def _post_validate_problem_description(cls, values: ProblemDescription.Partial) -> ProblemDescription.Partial:
         for validator in ProblemDescription.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_problem_problem_description.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_problem_problem_description.py
@@ -114,13 +114,13 @@ class ProblemDescription(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: ProblemDescription.Partial) -> ProblemDescription.Partial:
+    def _preproblem_description_validate(cls, values: ProblemDescription.Partial) -> ProblemDescription.Partial:
         for validator in ProblemDescription.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: ProblemDescription.Partial) -> ProblemDescription.Partial:
+    def _postproblem_description_validate(cls, values: ProblemDescription.Partial) -> ProblemDescription.Partial:
         for validator in ProblemDescription.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_problem_problem_description.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_problem_problem_description.py
@@ -114,13 +114,13 @@ class ProblemDescription(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preproblem_description_validate(cls, values: ProblemDescription.Partial) -> ProblemDescription.Partial:
+    def _pre_problem_description_validate(cls, values: ProblemDescription.Partial) -> ProblemDescription.Partial:
         for validator in ProblemDescription.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postproblem_description_validate(cls, values: ProblemDescription.Partial) -> ProblemDescription.Partial:
+    def _post_problem_description_validate(cls, values: ProblemDescription.Partial) -> ProblemDescription.Partial:
         for validator in ProblemDescription.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_problem_problem_files.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_problem_problem_files.py
@@ -159,13 +159,13 @@ class ProblemFiles(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preproblem_files_validate(cls, values: ProblemFiles.Partial) -> ProblemFiles.Partial:
+    def _pre_problem_files_validate(cls, values: ProblemFiles.Partial) -> ProblemFiles.Partial:
         for validator in ProblemFiles.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postproblem_files_validate(cls, values: ProblemFiles.Partial) -> ProblemFiles.Partial:
+    def _post_problem_files_validate(cls, values: ProblemFiles.Partial) -> ProblemFiles.Partial:
         for validator in ProblemFiles.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_problem_problem_files.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_problem_problem_files.py
@@ -159,13 +159,13 @@ class ProblemFiles(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_problem_files_validate(cls, values: ProblemFiles.Partial) -> ProblemFiles.Partial:
+    def _pre_validate_problem_files(cls, values: ProblemFiles.Partial) -> ProblemFiles.Partial:
         for validator in ProblemFiles.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_problem_files_validate(cls, values: ProblemFiles.Partial) -> ProblemFiles.Partial:
+    def _post_validate_problem_files(cls, values: ProblemFiles.Partial) -> ProblemFiles.Partial:
         for validator in ProblemFiles.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_problem_problem_files.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_problem_problem_files.py
@@ -159,13 +159,13 @@ class ProblemFiles(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: ProblemFiles.Partial) -> ProblemFiles.Partial:
+    def _preproblem_files_validate(cls, values: ProblemFiles.Partial) -> ProblemFiles.Partial:
         for validator in ProblemFiles.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: ProblemFiles.Partial) -> ProblemFiles.Partial:
+    def _postproblem_files_validate(cls, values: ProblemFiles.Partial) -> ProblemFiles.Partial:
         for validator in ProblemFiles.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_problem_problem_info.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_problem_problem_info.py
@@ -486,13 +486,13 @@ class ProblemInfo(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: ProblemInfo.Partial) -> ProblemInfo.Partial:
+    def _preproblem_info_validate(cls, values: ProblemInfo.Partial) -> ProblemInfo.Partial:
         for validator in ProblemInfo.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: ProblemInfo.Partial) -> ProblemInfo.Partial:
+    def _postproblem_info_validate(cls, values: ProblemInfo.Partial) -> ProblemInfo.Partial:
         for validator in ProblemInfo.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_problem_problem_info.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_problem_problem_info.py
@@ -486,13 +486,13 @@ class ProblemInfo(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_problem_info_validate(cls, values: ProblemInfo.Partial) -> ProblemInfo.Partial:
+    def _pre_validate_problem_info(cls, values: ProblemInfo.Partial) -> ProblemInfo.Partial:
         for validator in ProblemInfo.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_problem_info_validate(cls, values: ProblemInfo.Partial) -> ProblemInfo.Partial:
+    def _post_validate_problem_info(cls, values: ProblemInfo.Partial) -> ProblemInfo.Partial:
         for validator in ProblemInfo.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_problem_problem_info.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_problem_problem_info.py
@@ -486,13 +486,13 @@ class ProblemInfo(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preproblem_info_validate(cls, values: ProblemInfo.Partial) -> ProblemInfo.Partial:
+    def _pre_problem_info_validate(cls, values: ProblemInfo.Partial) -> ProblemInfo.Partial:
         for validator in ProblemInfo.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postproblem_info_validate(cls, values: ProblemInfo.Partial) -> ProblemInfo.Partial:
+    def _post_problem_info_validate(cls, values: ProblemInfo.Partial) -> ProblemInfo.Partial:
         for validator in ProblemInfo.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_problem_update_problem_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_problem_update_problem_response.py
@@ -120,7 +120,7 @@ class UpdateProblemResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preupdate_problem_response_validate(
+    def _pre_update_problem_response_validate(
         cls, values: UpdateProblemResponse.Partial
     ) -> UpdateProblemResponse.Partial:
         for validator in UpdateProblemResponse.Validators._pre_validators:
@@ -128,7 +128,7 @@ class UpdateProblemResponse(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postupdate_problem_response_validate(
+    def _post_update_problem_response_validate(
         cls, values: UpdateProblemResponse.Partial
     ) -> UpdateProblemResponse.Partial:
         for validator in UpdateProblemResponse.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_problem_update_problem_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_problem_update_problem_response.py
@@ -120,7 +120,7 @@ class UpdateProblemResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_update_problem_response_validate(
+    def _pre_validate_update_problem_response(
         cls, values: UpdateProblemResponse.Partial
     ) -> UpdateProblemResponse.Partial:
         for validator in UpdateProblemResponse.Validators._pre_validators:
@@ -128,7 +128,7 @@ class UpdateProblemResponse(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_update_problem_response_validate(
+    def _post_validate_update_problem_response(
         cls, values: UpdateProblemResponse.Partial
     ) -> UpdateProblemResponse.Partial:
         for validator in UpdateProblemResponse.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_problem_update_problem_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_problem_update_problem_response.py
@@ -120,13 +120,17 @@ class UpdateProblemResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: UpdateProblemResponse.Partial) -> UpdateProblemResponse.Partial:
+    def _preupdate_problem_response_validate(
+        cls, values: UpdateProblemResponse.Partial
+    ) -> UpdateProblemResponse.Partial:
         for validator in UpdateProblemResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: UpdateProblemResponse.Partial) -> UpdateProblemResponse.Partial:
+    def _postupdate_problem_response_validate(
+        cls, values: UpdateProblemResponse.Partial
+    ) -> UpdateProblemResponse.Partial:
         for validator in UpdateProblemResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_problem_variable_type_and_name.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_problem_variable_type_and_name.py
@@ -159,13 +159,13 @@ class VariableTypeAndName(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_variable_type_and_name_validate(cls, values: VariableTypeAndName.Partial) -> VariableTypeAndName.Partial:
+    def _pre_validate_variable_type_and_name(cls, values: VariableTypeAndName.Partial) -> VariableTypeAndName.Partial:
         for validator in VariableTypeAndName.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_variable_type_and_name_validate(cls, values: VariableTypeAndName.Partial) -> VariableTypeAndName.Partial:
+    def _post_validate_variable_type_and_name(cls, values: VariableTypeAndName.Partial) -> VariableTypeAndName.Partial:
         for validator in VariableTypeAndName.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_problem_variable_type_and_name.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_problem_variable_type_and_name.py
@@ -159,13 +159,13 @@ class VariableTypeAndName(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: VariableTypeAndName.Partial) -> VariableTypeAndName.Partial:
+    def _prevariable_type_and_name_validate(cls, values: VariableTypeAndName.Partial) -> VariableTypeAndName.Partial:
         for validator in VariableTypeAndName.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: VariableTypeAndName.Partial) -> VariableTypeAndName.Partial:
+    def _postvariable_type_and_name_validate(cls, values: VariableTypeAndName.Partial) -> VariableTypeAndName.Partial:
         for validator in VariableTypeAndName.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_problem_variable_type_and_name.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_problem_variable_type_and_name.py
@@ -159,13 +159,13 @@ class VariableTypeAndName(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prevariable_type_and_name_validate(cls, values: VariableTypeAndName.Partial) -> VariableTypeAndName.Partial:
+    def _pre_variable_type_and_name_validate(cls, values: VariableTypeAndName.Partial) -> VariableTypeAndName.Partial:
         for validator in VariableTypeAndName.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postvariable_type_and_name_validate(cls, values: VariableTypeAndName.Partial) -> VariableTypeAndName.Partial:
+    def _post_variable_type_and_name_validate(cls, values: VariableTypeAndName.Partial) -> VariableTypeAndName.Partial:
         for validator in VariableTypeAndName.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_building_executor_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_building_executor_response.py
@@ -167,13 +167,17 @@ class BuildingExecutorResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: BuildingExecutorResponse.Partial) -> BuildingExecutorResponse.Partial:
+    def _prebuilding_executor_response_validate(
+        cls, values: BuildingExecutorResponse.Partial
+    ) -> BuildingExecutorResponse.Partial:
         for validator in BuildingExecutorResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: BuildingExecutorResponse.Partial) -> BuildingExecutorResponse.Partial:
+    def _postbuilding_executor_response_validate(
+        cls, values: BuildingExecutorResponse.Partial
+    ) -> BuildingExecutorResponse.Partial:
         for validator in BuildingExecutorResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_building_executor_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_building_executor_response.py
@@ -167,7 +167,7 @@ class BuildingExecutorResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_building_executor_response_validate(
+    def _pre_validate_building_executor_response(
         cls, values: BuildingExecutorResponse.Partial
     ) -> BuildingExecutorResponse.Partial:
         for validator in BuildingExecutorResponse.Validators._pre_validators:
@@ -175,7 +175,7 @@ class BuildingExecutorResponse(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_building_executor_response_validate(
+    def _post_validate_building_executor_response(
         cls, values: BuildingExecutorResponse.Partial
     ) -> BuildingExecutorResponse.Partial:
         for validator in BuildingExecutorResponse.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_building_executor_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_building_executor_response.py
@@ -167,7 +167,7 @@ class BuildingExecutorResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prebuilding_executor_response_validate(
+    def _pre_building_executor_response_validate(
         cls, values: BuildingExecutorResponse.Partial
     ) -> BuildingExecutorResponse.Partial:
         for validator in BuildingExecutorResponse.Validators._pre_validators:
@@ -175,7 +175,7 @@ class BuildingExecutorResponse(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postbuilding_executor_response_validate(
+    def _post_building_executor_response_validate(
         cls, values: BuildingExecutorResponse.Partial
     ) -> BuildingExecutorResponse.Partial:
         for validator in BuildingExecutorResponse.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_compile_error.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_compile_error.py
@@ -105,13 +105,13 @@ class CompileError(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: CompileError.Partial) -> CompileError.Partial:
+    def _precompile_error_validate(cls, values: CompileError.Partial) -> CompileError.Partial:
         for validator in CompileError.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: CompileError.Partial) -> CompileError.Partial:
+    def _postcompile_error_validate(cls, values: CompileError.Partial) -> CompileError.Partial:
         for validator in CompileError.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_compile_error.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_compile_error.py
@@ -105,13 +105,13 @@ class CompileError(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _precompile_error_validate(cls, values: CompileError.Partial) -> CompileError.Partial:
+    def _pre_compile_error_validate(cls, values: CompileError.Partial) -> CompileError.Partial:
         for validator in CompileError.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postcompile_error_validate(cls, values: CompileError.Partial) -> CompileError.Partial:
+    def _post_compile_error_validate(cls, values: CompileError.Partial) -> CompileError.Partial:
         for validator in CompileError.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_compile_error.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_compile_error.py
@@ -105,13 +105,13 @@ class CompileError(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_compile_error_validate(cls, values: CompileError.Partial) -> CompileError.Partial:
+    def _pre_validate_compile_error(cls, values: CompileError.Partial) -> CompileError.Partial:
         for validator in CompileError.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_compile_error_validate(cls, values: CompileError.Partial) -> CompileError.Partial:
+    def _post_validate_compile_error(cls, values: CompileError.Partial) -> CompileError.Partial:
         for validator in CompileError.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_custom_test_cases_unsupported.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_custom_test_cases_unsupported.py
@@ -168,7 +168,7 @@ class CustomTestCasesUnsupported(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _precustom_test_cases_unsupported_validate(
+    def _pre_custom_test_cases_unsupported_validate(
         cls, values: CustomTestCasesUnsupported.Partial
     ) -> CustomTestCasesUnsupported.Partial:
         for validator in CustomTestCasesUnsupported.Validators._pre_validators:
@@ -176,7 +176,7 @@ class CustomTestCasesUnsupported(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postcustom_test_cases_unsupported_validate(
+    def _post_custom_test_cases_unsupported_validate(
         cls, values: CustomTestCasesUnsupported.Partial
     ) -> CustomTestCasesUnsupported.Partial:
         for validator in CustomTestCasesUnsupported.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_custom_test_cases_unsupported.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_custom_test_cases_unsupported.py
@@ -168,13 +168,17 @@ class CustomTestCasesUnsupported(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: CustomTestCasesUnsupported.Partial) -> CustomTestCasesUnsupported.Partial:
+    def _precustom_test_cases_unsupported_validate(
+        cls, values: CustomTestCasesUnsupported.Partial
+    ) -> CustomTestCasesUnsupported.Partial:
         for validator in CustomTestCasesUnsupported.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: CustomTestCasesUnsupported.Partial) -> CustomTestCasesUnsupported.Partial:
+    def _postcustom_test_cases_unsupported_validate(
+        cls, values: CustomTestCasesUnsupported.Partial
+    ) -> CustomTestCasesUnsupported.Partial:
         for validator in CustomTestCasesUnsupported.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_custom_test_cases_unsupported.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_custom_test_cases_unsupported.py
@@ -168,7 +168,7 @@ class CustomTestCasesUnsupported(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_custom_test_cases_unsupported_validate(
+    def _pre_validate_custom_test_cases_unsupported(
         cls, values: CustomTestCasesUnsupported.Partial
     ) -> CustomTestCasesUnsupported.Partial:
         for validator in CustomTestCasesUnsupported.Validators._pre_validators:
@@ -176,7 +176,7 @@ class CustomTestCasesUnsupported(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_custom_test_cases_unsupported_validate(
+    def _post_validate_custom_test_cases_unsupported(
         cls, values: CustomTestCasesUnsupported.Partial
     ) -> CustomTestCasesUnsupported.Partial:
         for validator in CustomTestCasesUnsupported.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_errored_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_errored_response.py
@@ -157,13 +157,13 @@ class ErroredResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: ErroredResponse.Partial) -> ErroredResponse.Partial:
+    def _preerrored_response_validate(cls, values: ErroredResponse.Partial) -> ErroredResponse.Partial:
         for validator in ErroredResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: ErroredResponse.Partial) -> ErroredResponse.Partial:
+    def _posterrored_response_validate(cls, values: ErroredResponse.Partial) -> ErroredResponse.Partial:
         for validator in ErroredResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_errored_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_errored_response.py
@@ -157,13 +157,13 @@ class ErroredResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_errored_response_validate(cls, values: ErroredResponse.Partial) -> ErroredResponse.Partial:
+    def _pre_validate_errored_response(cls, values: ErroredResponse.Partial) -> ErroredResponse.Partial:
         for validator in ErroredResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_errored_response_validate(cls, values: ErroredResponse.Partial) -> ErroredResponse.Partial:
+    def _post_validate_errored_response(cls, values: ErroredResponse.Partial) -> ErroredResponse.Partial:
         for validator in ErroredResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_errored_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_errored_response.py
@@ -157,13 +157,13 @@ class ErroredResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preerrored_response_validate(cls, values: ErroredResponse.Partial) -> ErroredResponse.Partial:
+    def _pre_errored_response_validate(cls, values: ErroredResponse.Partial) -> ErroredResponse.Partial:
         for validator in ErroredResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _posterrored_response_validate(cls, values: ErroredResponse.Partial) -> ErroredResponse.Partial:
+    def _post_errored_response_validate(cls, values: ErroredResponse.Partial) -> ErroredResponse.Partial:
         for validator in ErroredResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_exception_info.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_exception_info.py
@@ -209,13 +209,13 @@ class ExceptionInfo(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: ExceptionInfo.Partial) -> ExceptionInfo.Partial:
+    def _preexception_info_validate(cls, values: ExceptionInfo.Partial) -> ExceptionInfo.Partial:
         for validator in ExceptionInfo.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: ExceptionInfo.Partial) -> ExceptionInfo.Partial:
+    def _postexception_info_validate(cls, values: ExceptionInfo.Partial) -> ExceptionInfo.Partial:
         for validator in ExceptionInfo.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_exception_info.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_exception_info.py
@@ -209,13 +209,13 @@ class ExceptionInfo(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_exception_info_validate(cls, values: ExceptionInfo.Partial) -> ExceptionInfo.Partial:
+    def _pre_validate_exception_info(cls, values: ExceptionInfo.Partial) -> ExceptionInfo.Partial:
         for validator in ExceptionInfo.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_exception_info_validate(cls, values: ExceptionInfo.Partial) -> ExceptionInfo.Partial:
+    def _post_validate_exception_info(cls, values: ExceptionInfo.Partial) -> ExceptionInfo.Partial:
         for validator in ExceptionInfo.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_exception_info.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_exception_info.py
@@ -209,13 +209,13 @@ class ExceptionInfo(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preexception_info_validate(cls, values: ExceptionInfo.Partial) -> ExceptionInfo.Partial:
+    def _pre_exception_info_validate(cls, values: ExceptionInfo.Partial) -> ExceptionInfo.Partial:
         for validator in ExceptionInfo.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postexception_info_validate(cls, values: ExceptionInfo.Partial) -> ExceptionInfo.Partial:
+    def _post_exception_info_validate(cls, values: ExceptionInfo.Partial) -> ExceptionInfo.Partial:
         for validator in ExceptionInfo.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_execution_session_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_execution_session_response.py
@@ -259,7 +259,7 @@ class ExecutionSessionResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preexecution_session_response_validate(
+    def _pre_execution_session_response_validate(
         cls, values: ExecutionSessionResponse.Partial
     ) -> ExecutionSessionResponse.Partial:
         for validator in ExecutionSessionResponse.Validators._pre_validators:
@@ -267,7 +267,7 @@ class ExecutionSessionResponse(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postexecution_session_response_validate(
+    def _post_execution_session_response_validate(
         cls, values: ExecutionSessionResponse.Partial
     ) -> ExecutionSessionResponse.Partial:
         for validator in ExecutionSessionResponse.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_execution_session_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_execution_session_response.py
@@ -259,7 +259,7 @@ class ExecutionSessionResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_execution_session_response_validate(
+    def _pre_validate_execution_session_response(
         cls, values: ExecutionSessionResponse.Partial
     ) -> ExecutionSessionResponse.Partial:
         for validator in ExecutionSessionResponse.Validators._pre_validators:
@@ -267,7 +267,7 @@ class ExecutionSessionResponse(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_execution_session_response_validate(
+    def _post_validate_execution_session_response(
         cls, values: ExecutionSessionResponse.Partial
     ) -> ExecutionSessionResponse.Partial:
         for validator in ExecutionSessionResponse.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_execution_session_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_execution_session_response.py
@@ -259,13 +259,17 @@ class ExecutionSessionResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: ExecutionSessionResponse.Partial) -> ExecutionSessionResponse.Partial:
+    def _preexecution_session_response_validate(
+        cls, values: ExecutionSessionResponse.Partial
+    ) -> ExecutionSessionResponse.Partial:
         for validator in ExecutionSessionResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: ExecutionSessionResponse.Partial) -> ExecutionSessionResponse.Partial:
+    def _postexecution_session_response_validate(
+        cls, values: ExecutionSessionResponse.Partial
+    ) -> ExecutionSessionResponse.Partial:
         for validator in ExecutionSessionResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_execution_session_state.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_execution_session_state.py
@@ -347,7 +347,7 @@ class ExecutionSessionState(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_execution_session_state_validate(
+    def _pre_validate_execution_session_state(
         cls, values: ExecutionSessionState.Partial
     ) -> ExecutionSessionState.Partial:
         for validator in ExecutionSessionState.Validators._pre_validators:
@@ -355,7 +355,7 @@ class ExecutionSessionState(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_execution_session_state_validate(
+    def _post_validate_execution_session_state(
         cls, values: ExecutionSessionState.Partial
     ) -> ExecutionSessionState.Partial:
         for validator in ExecutionSessionState.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_execution_session_state.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_execution_session_state.py
@@ -347,13 +347,17 @@ class ExecutionSessionState(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: ExecutionSessionState.Partial) -> ExecutionSessionState.Partial:
+    def _preexecution_session_state_validate(
+        cls, values: ExecutionSessionState.Partial
+    ) -> ExecutionSessionState.Partial:
         for validator in ExecutionSessionState.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: ExecutionSessionState.Partial) -> ExecutionSessionState.Partial:
+    def _postexecution_session_state_validate(
+        cls, values: ExecutionSessionState.Partial
+    ) -> ExecutionSessionState.Partial:
         for validator in ExecutionSessionState.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_execution_session_state.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_execution_session_state.py
@@ -347,7 +347,7 @@ class ExecutionSessionState(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preexecution_session_state_validate(
+    def _pre_execution_session_state_validate(
         cls, values: ExecutionSessionState.Partial
     ) -> ExecutionSessionState.Partial:
         for validator in ExecutionSessionState.Validators._pre_validators:
@@ -355,7 +355,7 @@ class ExecutionSessionState(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postexecution_session_state_validate(
+    def _post_execution_session_state_validate(
         cls, values: ExecutionSessionState.Partial
     ) -> ExecutionSessionState.Partial:
         for validator in ExecutionSessionState.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_existing_submission_executing.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_existing_submission_executing.py
@@ -123,7 +123,7 @@ class ExistingSubmissionExecuting(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_existing_submission_executing_validate(
+    def _pre_validate_existing_submission_executing(
         cls, values: ExistingSubmissionExecuting.Partial
     ) -> ExistingSubmissionExecuting.Partial:
         for validator in ExistingSubmissionExecuting.Validators._pre_validators:
@@ -131,7 +131,7 @@ class ExistingSubmissionExecuting(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_existing_submission_executing_validate(
+    def _post_validate_existing_submission_executing(
         cls, values: ExistingSubmissionExecuting.Partial
     ) -> ExistingSubmissionExecuting.Partial:
         for validator in ExistingSubmissionExecuting.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_existing_submission_executing.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_existing_submission_executing.py
@@ -123,13 +123,17 @@ class ExistingSubmissionExecuting(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: ExistingSubmissionExecuting.Partial) -> ExistingSubmissionExecuting.Partial:
+    def _preexisting_submission_executing_validate(
+        cls, values: ExistingSubmissionExecuting.Partial
+    ) -> ExistingSubmissionExecuting.Partial:
         for validator in ExistingSubmissionExecuting.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: ExistingSubmissionExecuting.Partial) -> ExistingSubmissionExecuting.Partial:
+    def _postexisting_submission_executing_validate(
+        cls, values: ExistingSubmissionExecuting.Partial
+    ) -> ExistingSubmissionExecuting.Partial:
         for validator in ExistingSubmissionExecuting.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_existing_submission_executing.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_existing_submission_executing.py
@@ -123,7 +123,7 @@ class ExistingSubmissionExecuting(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preexisting_submission_executing_validate(
+    def _pre_existing_submission_executing_validate(
         cls, values: ExistingSubmissionExecuting.Partial
     ) -> ExistingSubmissionExecuting.Partial:
         for validator in ExistingSubmissionExecuting.Validators._pre_validators:
@@ -131,7 +131,7 @@ class ExistingSubmissionExecuting(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postexisting_submission_executing_validate(
+    def _post_existing_submission_executing_validate(
         cls, values: ExistingSubmissionExecuting.Partial
     ) -> ExistingSubmissionExecuting.Partial:
         for validator in ExistingSubmissionExecuting.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_expression_location.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_expression_location.py
@@ -150,13 +150,13 @@ class ExpressionLocation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_expression_location_validate(cls, values: ExpressionLocation.Partial) -> ExpressionLocation.Partial:
+    def _pre_validate_expression_location(cls, values: ExpressionLocation.Partial) -> ExpressionLocation.Partial:
         for validator in ExpressionLocation.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_expression_location_validate(cls, values: ExpressionLocation.Partial) -> ExpressionLocation.Partial:
+    def _post_validate_expression_location(cls, values: ExpressionLocation.Partial) -> ExpressionLocation.Partial:
         for validator in ExpressionLocation.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_expression_location.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_expression_location.py
@@ -150,13 +150,13 @@ class ExpressionLocation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preexpression_location_validate(cls, values: ExpressionLocation.Partial) -> ExpressionLocation.Partial:
+    def _pre_expression_location_validate(cls, values: ExpressionLocation.Partial) -> ExpressionLocation.Partial:
         for validator in ExpressionLocation.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postexpression_location_validate(cls, values: ExpressionLocation.Partial) -> ExpressionLocation.Partial:
+    def _post_expression_location_validate(cls, values: ExpressionLocation.Partial) -> ExpressionLocation.Partial:
         for validator in ExpressionLocation.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_expression_location.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_expression_location.py
@@ -150,13 +150,13 @@ class ExpressionLocation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: ExpressionLocation.Partial) -> ExpressionLocation.Partial:
+    def _preexpression_location_validate(cls, values: ExpressionLocation.Partial) -> ExpressionLocation.Partial:
         for validator in ExpressionLocation.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: ExpressionLocation.Partial) -> ExpressionLocation.Partial:
+    def _postexpression_location_validate(cls, values: ExpressionLocation.Partial) -> ExpressionLocation.Partial:
         for validator in ExpressionLocation.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_finished_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_finished_response.py
@@ -117,13 +117,13 @@ class FinishedResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prefinished_response_validate(cls, values: FinishedResponse.Partial) -> FinishedResponse.Partial:
+    def _pre_finished_response_validate(cls, values: FinishedResponse.Partial) -> FinishedResponse.Partial:
         for validator in FinishedResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postfinished_response_validate(cls, values: FinishedResponse.Partial) -> FinishedResponse.Partial:
+    def _post_finished_response_validate(cls, values: FinishedResponse.Partial) -> FinishedResponse.Partial:
         for validator in FinishedResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_finished_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_finished_response.py
@@ -117,13 +117,13 @@ class FinishedResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: FinishedResponse.Partial) -> FinishedResponse.Partial:
+    def _prefinished_response_validate(cls, values: FinishedResponse.Partial) -> FinishedResponse.Partial:
         for validator in FinishedResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: FinishedResponse.Partial) -> FinishedResponse.Partial:
+    def _postfinished_response_validate(cls, values: FinishedResponse.Partial) -> FinishedResponse.Partial:
         for validator in FinishedResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_finished_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_finished_response.py
@@ -117,13 +117,13 @@ class FinishedResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_finished_response_validate(cls, values: FinishedResponse.Partial) -> FinishedResponse.Partial:
+    def _pre_validate_finished_response(cls, values: FinishedResponse.Partial) -> FinishedResponse.Partial:
         for validator in FinishedResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_finished_response_validate(cls, values: FinishedResponse.Partial) -> FinishedResponse.Partial:
+    def _post_validate_finished_response(cls, values: FinishedResponse.Partial) -> FinishedResponse.Partial:
         for validator in FinishedResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_get_execution_session_state_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_get_execution_session_state_response.py
@@ -226,7 +226,7 @@ class GetExecutionSessionStateResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(
+    def _preget_execution_session_state_response_validate(
         cls, values: GetExecutionSessionStateResponse.Partial
     ) -> GetExecutionSessionStateResponse.Partial:
         for validator in GetExecutionSessionStateResponse.Validators._pre_validators:
@@ -234,7 +234,7 @@ class GetExecutionSessionStateResponse(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(
+    def _postget_execution_session_state_response_validate(
         cls, values: GetExecutionSessionStateResponse.Partial
     ) -> GetExecutionSessionStateResponse.Partial:
         for validator in GetExecutionSessionStateResponse.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_get_execution_session_state_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_get_execution_session_state_response.py
@@ -226,7 +226,7 @@ class GetExecutionSessionStateResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_get_execution_session_state_response_validate(
+    def _pre_validate_get_execution_session_state_response(
         cls, values: GetExecutionSessionStateResponse.Partial
     ) -> GetExecutionSessionStateResponse.Partial:
         for validator in GetExecutionSessionStateResponse.Validators._pre_validators:
@@ -234,7 +234,7 @@ class GetExecutionSessionStateResponse(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_get_execution_session_state_response_validate(
+    def _post_validate_get_execution_session_state_response(
         cls, values: GetExecutionSessionStateResponse.Partial
     ) -> GetExecutionSessionStateResponse.Partial:
         for validator in GetExecutionSessionStateResponse.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_get_execution_session_state_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_get_execution_session_state_response.py
@@ -226,7 +226,7 @@ class GetExecutionSessionStateResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preget_execution_session_state_response_validate(
+    def _pre_get_execution_session_state_response_validate(
         cls, values: GetExecutionSessionStateResponse.Partial
     ) -> GetExecutionSessionStateResponse.Partial:
         for validator in GetExecutionSessionStateResponse.Validators._pre_validators:
@@ -234,7 +234,7 @@ class GetExecutionSessionStateResponse(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postget_execution_session_state_response_validate(
+    def _post_get_execution_session_state_response_validate(
         cls, values: GetExecutionSessionStateResponse.Partial
     ) -> GetExecutionSessionStateResponse.Partial:
         for validator in GetExecutionSessionStateResponse.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_get_submission_state_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_get_submission_state_response.py
@@ -265,13 +265,17 @@ class GetSubmissionStateResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: GetSubmissionStateResponse.Partial) -> GetSubmissionStateResponse.Partial:
+    def _preget_submission_state_response_validate(
+        cls, values: GetSubmissionStateResponse.Partial
+    ) -> GetSubmissionStateResponse.Partial:
         for validator in GetSubmissionStateResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: GetSubmissionStateResponse.Partial) -> GetSubmissionStateResponse.Partial:
+    def _postget_submission_state_response_validate(
+        cls, values: GetSubmissionStateResponse.Partial
+    ) -> GetSubmissionStateResponse.Partial:
         for validator in GetSubmissionStateResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_get_submission_state_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_get_submission_state_response.py
@@ -265,7 +265,7 @@ class GetSubmissionStateResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_get_submission_state_response_validate(
+    def _pre_validate_get_submission_state_response(
         cls, values: GetSubmissionStateResponse.Partial
     ) -> GetSubmissionStateResponse.Partial:
         for validator in GetSubmissionStateResponse.Validators._pre_validators:
@@ -273,7 +273,7 @@ class GetSubmissionStateResponse(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_get_submission_state_response_validate(
+    def _post_validate_get_submission_state_response(
         cls, values: GetSubmissionStateResponse.Partial
     ) -> GetSubmissionStateResponse.Partial:
         for validator in GetSubmissionStateResponse.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_get_submission_state_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_get_submission_state_response.py
@@ -265,7 +265,7 @@ class GetSubmissionStateResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preget_submission_state_response_validate(
+    def _pre_get_submission_state_response_validate(
         cls, values: GetSubmissionStateResponse.Partial
     ) -> GetSubmissionStateResponse.Partial:
         for validator in GetSubmissionStateResponse.Validators._pre_validators:
@@ -273,7 +273,7 @@ class GetSubmissionStateResponse(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postget_submission_state_response_validate(
+    def _post_get_submission_state_response_validate(
         cls, values: GetSubmissionStateResponse.Partial
     ) -> GetSubmissionStateResponse.Partial:
         for validator in GetSubmissionStateResponse.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_get_trace_responses_page_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_get_trace_responses_page_request.py
@@ -121,7 +121,7 @@ class GetTraceResponsesPageRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preget_trace_responses_page_request_validate(
+    def _pre_get_trace_responses_page_request_validate(
         cls, values: GetTraceResponsesPageRequest.Partial
     ) -> GetTraceResponsesPageRequest.Partial:
         for validator in GetTraceResponsesPageRequest.Validators._pre_validators:
@@ -129,7 +129,7 @@ class GetTraceResponsesPageRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postget_trace_responses_page_request_validate(
+    def _post_get_trace_responses_page_request_validate(
         cls, values: GetTraceResponsesPageRequest.Partial
     ) -> GetTraceResponsesPageRequest.Partial:
         for validator in GetTraceResponsesPageRequest.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_get_trace_responses_page_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_get_trace_responses_page_request.py
@@ -121,13 +121,17 @@ class GetTraceResponsesPageRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: GetTraceResponsesPageRequest.Partial) -> GetTraceResponsesPageRequest.Partial:
+    def _preget_trace_responses_page_request_validate(
+        cls, values: GetTraceResponsesPageRequest.Partial
+    ) -> GetTraceResponsesPageRequest.Partial:
         for validator in GetTraceResponsesPageRequest.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: GetTraceResponsesPageRequest.Partial) -> GetTraceResponsesPageRequest.Partial:
+    def _postget_trace_responses_page_request_validate(
+        cls, values: GetTraceResponsesPageRequest.Partial
+    ) -> GetTraceResponsesPageRequest.Partial:
         for validator in GetTraceResponsesPageRequest.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_get_trace_responses_page_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_get_trace_responses_page_request.py
@@ -121,7 +121,7 @@ class GetTraceResponsesPageRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_get_trace_responses_page_request_validate(
+    def _pre_validate_get_trace_responses_page_request(
         cls, values: GetTraceResponsesPageRequest.Partial
     ) -> GetTraceResponsesPageRequest.Partial:
         for validator in GetTraceResponsesPageRequest.Validators._pre_validators:
@@ -129,7 +129,7 @@ class GetTraceResponsesPageRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_get_trace_responses_page_request_validate(
+    def _post_validate_get_trace_responses_page_request(
         cls, values: GetTraceResponsesPageRequest.Partial
     ) -> GetTraceResponsesPageRequest.Partial:
         for validator in GetTraceResponsesPageRequest.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_graded_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_graded_response.py
@@ -159,13 +159,13 @@ class GradedResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: GradedResponse.Partial) -> GradedResponse.Partial:
+    def _pregraded_response_validate(cls, values: GradedResponse.Partial) -> GradedResponse.Partial:
         for validator in GradedResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: GradedResponse.Partial) -> GradedResponse.Partial:
+    def _postgraded_response_validate(cls, values: GradedResponse.Partial) -> GradedResponse.Partial:
         for validator in GradedResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_graded_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_graded_response.py
@@ -159,13 +159,13 @@ class GradedResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_graded_response_validate(cls, values: GradedResponse.Partial) -> GradedResponse.Partial:
+    def _pre_validate_graded_response(cls, values: GradedResponse.Partial) -> GradedResponse.Partial:
         for validator in GradedResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_graded_response_validate(cls, values: GradedResponse.Partial) -> GradedResponse.Partial:
+    def _post_validate_graded_response(cls, values: GradedResponse.Partial) -> GradedResponse.Partial:
         for validator in GradedResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_graded_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_graded_response.py
@@ -159,13 +159,13 @@ class GradedResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pregraded_response_validate(cls, values: GradedResponse.Partial) -> GradedResponse.Partial:
+    def _pre_graded_response_validate(cls, values: GradedResponse.Partial) -> GradedResponse.Partial:
         for validator in GradedResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postgraded_response_validate(cls, values: GradedResponse.Partial) -> GradedResponse.Partial:
+    def _post_graded_response_validate(cls, values: GradedResponse.Partial) -> GradedResponse.Partial:
         for validator in GradedResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_graded_response_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_graded_response_v_2.py
@@ -160,13 +160,13 @@ class GradedResponseV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pregraded_response_v_2_validate(cls, values: GradedResponseV2.Partial) -> GradedResponseV2.Partial:
+    def _pre_graded_response_v_2_validate(cls, values: GradedResponseV2.Partial) -> GradedResponseV2.Partial:
         for validator in GradedResponseV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postgraded_response_v_2_validate(cls, values: GradedResponseV2.Partial) -> GradedResponseV2.Partial:
+    def _post_graded_response_v_2_validate(cls, values: GradedResponseV2.Partial) -> GradedResponseV2.Partial:
         for validator in GradedResponseV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_graded_response_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_graded_response_v_2.py
@@ -160,13 +160,13 @@ class GradedResponseV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_graded_response_v_2_validate(cls, values: GradedResponseV2.Partial) -> GradedResponseV2.Partial:
+    def _pre_validate_graded_response_v_2(cls, values: GradedResponseV2.Partial) -> GradedResponseV2.Partial:
         for validator in GradedResponseV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_graded_response_v_2_validate(cls, values: GradedResponseV2.Partial) -> GradedResponseV2.Partial:
+    def _post_validate_graded_response_v_2(cls, values: GradedResponseV2.Partial) -> GradedResponseV2.Partial:
         for validator in GradedResponseV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_graded_response_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_graded_response_v_2.py
@@ -160,13 +160,13 @@ class GradedResponseV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: GradedResponseV2.Partial) -> GradedResponseV2.Partial:
+    def _pregraded_response_v_2_validate(cls, values: GradedResponseV2.Partial) -> GradedResponseV2.Partial:
         for validator in GradedResponseV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: GradedResponseV2.Partial) -> GradedResponseV2.Partial:
+    def _postgraded_response_v_2_validate(cls, values: GradedResponseV2.Partial) -> GradedResponseV2.Partial:
         for validator in GradedResponseV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_graded_test_case_update.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_graded_test_case_update.py
@@ -157,7 +157,7 @@ class GradedTestCaseUpdate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_graded_test_case_update_validate(
+    def _pre_validate_graded_test_case_update(
         cls, values: GradedTestCaseUpdate.Partial
     ) -> GradedTestCaseUpdate.Partial:
         for validator in GradedTestCaseUpdate.Validators._pre_validators:
@@ -165,7 +165,7 @@ class GradedTestCaseUpdate(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_graded_test_case_update_validate(
+    def _post_validate_graded_test_case_update(
         cls, values: GradedTestCaseUpdate.Partial
     ) -> GradedTestCaseUpdate.Partial:
         for validator in GradedTestCaseUpdate.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_graded_test_case_update.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_graded_test_case_update.py
@@ -157,13 +157,15 @@ class GradedTestCaseUpdate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: GradedTestCaseUpdate.Partial) -> GradedTestCaseUpdate.Partial:
+    def _pregraded_test_case_update_validate(cls, values: GradedTestCaseUpdate.Partial) -> GradedTestCaseUpdate.Partial:
         for validator in GradedTestCaseUpdate.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: GradedTestCaseUpdate.Partial) -> GradedTestCaseUpdate.Partial:
+    def _postgraded_test_case_update_validate(
+        cls, values: GradedTestCaseUpdate.Partial
+    ) -> GradedTestCaseUpdate.Partial:
         for validator in GradedTestCaseUpdate.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_graded_test_case_update.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_graded_test_case_update.py
@@ -157,13 +157,15 @@ class GradedTestCaseUpdate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pregraded_test_case_update_validate(cls, values: GradedTestCaseUpdate.Partial) -> GradedTestCaseUpdate.Partial:
+    def _pre_graded_test_case_update_validate(
+        cls, values: GradedTestCaseUpdate.Partial
+    ) -> GradedTestCaseUpdate.Partial:
         for validator in GradedTestCaseUpdate.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postgraded_test_case_update_validate(
+    def _post_graded_test_case_update_validate(
         cls, values: GradedTestCaseUpdate.Partial
     ) -> GradedTestCaseUpdate.Partial:
         for validator in GradedTestCaseUpdate.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_initialize_problem_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_initialize_problem_request.py
@@ -169,13 +169,17 @@ class InitializeProblemRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: InitializeProblemRequest.Partial) -> InitializeProblemRequest.Partial:
+    def _preinitialize_problem_request_validate(
+        cls, values: InitializeProblemRequest.Partial
+    ) -> InitializeProblemRequest.Partial:
         for validator in InitializeProblemRequest.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: InitializeProblemRequest.Partial) -> InitializeProblemRequest.Partial:
+    def _postinitialize_problem_request_validate(
+        cls, values: InitializeProblemRequest.Partial
+    ) -> InitializeProblemRequest.Partial:
         for validator in InitializeProblemRequest.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_initialize_problem_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_initialize_problem_request.py
@@ -169,7 +169,7 @@ class InitializeProblemRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_initialize_problem_request_validate(
+    def _pre_validate_initialize_problem_request(
         cls, values: InitializeProblemRequest.Partial
     ) -> InitializeProblemRequest.Partial:
         for validator in InitializeProblemRequest.Validators._pre_validators:
@@ -177,7 +177,7 @@ class InitializeProblemRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_initialize_problem_request_validate(
+    def _post_validate_initialize_problem_request(
         cls, values: InitializeProblemRequest.Partial
     ) -> InitializeProblemRequest.Partial:
         for validator in InitializeProblemRequest.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_initialize_problem_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_initialize_problem_request.py
@@ -169,7 +169,7 @@ class InitializeProblemRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preinitialize_problem_request_validate(
+    def _pre_initialize_problem_request_validate(
         cls, values: InitializeProblemRequest.Partial
     ) -> InitializeProblemRequest.Partial:
         for validator in InitializeProblemRequest.Validators._pre_validators:
@@ -177,7 +177,7 @@ class InitializeProblemRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postinitialize_problem_request_validate(
+    def _post_initialize_problem_request_validate(
         cls, values: InitializeProblemRequest.Partial
     ) -> InitializeProblemRequest.Partial:
         for validator in InitializeProblemRequest.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_internal_error.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_internal_error.py
@@ -115,13 +115,13 @@ class InternalError(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: InternalError.Partial) -> InternalError.Partial:
+    def _preinternal_error_validate(cls, values: InternalError.Partial) -> InternalError.Partial:
         for validator in InternalError.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: InternalError.Partial) -> InternalError.Partial:
+    def _postinternal_error_validate(cls, values: InternalError.Partial) -> InternalError.Partial:
         for validator in InternalError.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_internal_error.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_internal_error.py
@@ -115,13 +115,13 @@ class InternalError(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preinternal_error_validate(cls, values: InternalError.Partial) -> InternalError.Partial:
+    def _pre_internal_error_validate(cls, values: InternalError.Partial) -> InternalError.Partial:
         for validator in InternalError.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postinternal_error_validate(cls, values: InternalError.Partial) -> InternalError.Partial:
+    def _post_internal_error_validate(cls, values: InternalError.Partial) -> InternalError.Partial:
         for validator in InternalError.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_internal_error.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_internal_error.py
@@ -115,13 +115,13 @@ class InternalError(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_internal_error_validate(cls, values: InternalError.Partial) -> InternalError.Partial:
+    def _pre_validate_internal_error(cls, values: InternalError.Partial) -> InternalError.Partial:
         for validator in InternalError.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_internal_error_validate(cls, values: InternalError.Partial) -> InternalError.Partial:
+    def _post_validate_internal_error(cls, values: InternalError.Partial) -> InternalError.Partial:
         for validator in InternalError.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_invalid_request_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_invalid_request_response.py
@@ -157,7 +157,7 @@ class InvalidRequestResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_invalid_request_response_validate(
+    def _pre_validate_invalid_request_response(
         cls, values: InvalidRequestResponse.Partial
     ) -> InvalidRequestResponse.Partial:
         for validator in InvalidRequestResponse.Validators._pre_validators:
@@ -165,7 +165,7 @@ class InvalidRequestResponse(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_invalid_request_response_validate(
+    def _post_validate_invalid_request_response(
         cls, values: InvalidRequestResponse.Partial
     ) -> InvalidRequestResponse.Partial:
         for validator in InvalidRequestResponse.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_invalid_request_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_invalid_request_response.py
@@ -157,7 +157,7 @@ class InvalidRequestResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preinvalid_request_response_validate(
+    def _pre_invalid_request_response_validate(
         cls, values: InvalidRequestResponse.Partial
     ) -> InvalidRequestResponse.Partial:
         for validator in InvalidRequestResponse.Validators._pre_validators:
@@ -165,7 +165,7 @@ class InvalidRequestResponse(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postinvalid_request_response_validate(
+    def _post_invalid_request_response_validate(
         cls, values: InvalidRequestResponse.Partial
     ) -> InvalidRequestResponse.Partial:
         for validator in InvalidRequestResponse.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_invalid_request_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_invalid_request_response.py
@@ -157,13 +157,17 @@ class InvalidRequestResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: InvalidRequestResponse.Partial) -> InvalidRequestResponse.Partial:
+    def _preinvalid_request_response_validate(
+        cls, values: InvalidRequestResponse.Partial
+    ) -> InvalidRequestResponse.Partial:
         for validator in InvalidRequestResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: InvalidRequestResponse.Partial) -> InvalidRequestResponse.Partial:
+    def _postinvalid_request_response_validate(
+        cls, values: InvalidRequestResponse.Partial
+    ) -> InvalidRequestResponse.Partial:
         for validator in InvalidRequestResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_lightweight_stackframe_information.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_lightweight_stackframe_information.py
@@ -177,7 +177,7 @@ class LightweightStackframeInformation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_lightweight_stackframe_information_validate(
+    def _pre_validate_lightweight_stackframe_information(
         cls, values: LightweightStackframeInformation.Partial
     ) -> LightweightStackframeInformation.Partial:
         for validator in LightweightStackframeInformation.Validators._pre_validators:
@@ -185,7 +185,7 @@ class LightweightStackframeInformation(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_lightweight_stackframe_information_validate(
+    def _post_validate_lightweight_stackframe_information(
         cls, values: LightweightStackframeInformation.Partial
     ) -> LightweightStackframeInformation.Partial:
         for validator in LightweightStackframeInformation.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_lightweight_stackframe_information.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_lightweight_stackframe_information.py
@@ -177,7 +177,7 @@ class LightweightStackframeInformation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prelightweight_stackframe_information_validate(
+    def _pre_lightweight_stackframe_information_validate(
         cls, values: LightweightStackframeInformation.Partial
     ) -> LightweightStackframeInformation.Partial:
         for validator in LightweightStackframeInformation.Validators._pre_validators:
@@ -185,7 +185,7 @@ class LightweightStackframeInformation(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postlightweight_stackframe_information_validate(
+    def _post_lightweight_stackframe_information_validate(
         cls, values: LightweightStackframeInformation.Partial
     ) -> LightweightStackframeInformation.Partial:
         for validator in LightweightStackframeInformation.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_lightweight_stackframe_information.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_lightweight_stackframe_information.py
@@ -177,7 +177,7 @@ class LightweightStackframeInformation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(
+    def _prelightweight_stackframe_information_validate(
         cls, values: LightweightStackframeInformation.Partial
     ) -> LightweightStackframeInformation.Partial:
         for validator in LightweightStackframeInformation.Validators._pre_validators:
@@ -185,7 +185,7 @@ class LightweightStackframeInformation(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(
+    def _postlightweight_stackframe_information_validate(
         cls, values: LightweightStackframeInformation.Partial
     ) -> LightweightStackframeInformation.Partial:
         for validator in LightweightStackframeInformation.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_recorded_response_notification.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_recorded_response_notification.py
@@ -218,7 +218,7 @@ class RecordedResponseNotification(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prerecorded_response_notification_validate(
+    def _pre_recorded_response_notification_validate(
         cls, values: RecordedResponseNotification.Partial
     ) -> RecordedResponseNotification.Partial:
         for validator in RecordedResponseNotification.Validators._pre_validators:
@@ -226,7 +226,7 @@ class RecordedResponseNotification(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postrecorded_response_notification_validate(
+    def _post_recorded_response_notification_validate(
         cls, values: RecordedResponseNotification.Partial
     ) -> RecordedResponseNotification.Partial:
         for validator in RecordedResponseNotification.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_recorded_response_notification.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_recorded_response_notification.py
@@ -218,7 +218,7 @@ class RecordedResponseNotification(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_recorded_response_notification_validate(
+    def _pre_validate_recorded_response_notification(
         cls, values: RecordedResponseNotification.Partial
     ) -> RecordedResponseNotification.Partial:
         for validator in RecordedResponseNotification.Validators._pre_validators:
@@ -226,7 +226,7 @@ class RecordedResponseNotification(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_recorded_response_notification_validate(
+    def _post_validate_recorded_response_notification(
         cls, values: RecordedResponseNotification.Partial
     ) -> RecordedResponseNotification.Partial:
         for validator in RecordedResponseNotification.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_recorded_response_notification.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_recorded_response_notification.py
@@ -218,13 +218,17 @@ class RecordedResponseNotification(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: RecordedResponseNotification.Partial) -> RecordedResponseNotification.Partial:
+    def _prerecorded_response_notification_validate(
+        cls, values: RecordedResponseNotification.Partial
+    ) -> RecordedResponseNotification.Partial:
         for validator in RecordedResponseNotification.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: RecordedResponseNotification.Partial) -> RecordedResponseNotification.Partial:
+    def _postrecorded_response_notification_validate(
+        cls, values: RecordedResponseNotification.Partial
+    ) -> RecordedResponseNotification.Partial:
         for validator in RecordedResponseNotification.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_recorded_test_case_update.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_recorded_test_case_update.py
@@ -166,13 +166,17 @@ class RecordedTestCaseUpdate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: RecordedTestCaseUpdate.Partial) -> RecordedTestCaseUpdate.Partial:
+    def _prerecorded_test_case_update_validate(
+        cls, values: RecordedTestCaseUpdate.Partial
+    ) -> RecordedTestCaseUpdate.Partial:
         for validator in RecordedTestCaseUpdate.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: RecordedTestCaseUpdate.Partial) -> RecordedTestCaseUpdate.Partial:
+    def _postrecorded_test_case_update_validate(
+        cls, values: RecordedTestCaseUpdate.Partial
+    ) -> RecordedTestCaseUpdate.Partial:
         for validator in RecordedTestCaseUpdate.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_recorded_test_case_update.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_recorded_test_case_update.py
@@ -166,7 +166,7 @@ class RecordedTestCaseUpdate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_recorded_test_case_update_validate(
+    def _pre_validate_recorded_test_case_update(
         cls, values: RecordedTestCaseUpdate.Partial
     ) -> RecordedTestCaseUpdate.Partial:
         for validator in RecordedTestCaseUpdate.Validators._pre_validators:
@@ -174,7 +174,7 @@ class RecordedTestCaseUpdate(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_recorded_test_case_update_validate(
+    def _post_validate_recorded_test_case_update(
         cls, values: RecordedTestCaseUpdate.Partial
     ) -> RecordedTestCaseUpdate.Partial:
         for validator in RecordedTestCaseUpdate.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_recorded_test_case_update.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_recorded_test_case_update.py
@@ -166,7 +166,7 @@ class RecordedTestCaseUpdate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prerecorded_test_case_update_validate(
+    def _pre_recorded_test_case_update_validate(
         cls, values: RecordedTestCaseUpdate.Partial
     ) -> RecordedTestCaseUpdate.Partial:
         for validator in RecordedTestCaseUpdate.Validators._pre_validators:
@@ -174,7 +174,7 @@ class RecordedTestCaseUpdate(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postrecorded_test_case_update_validate(
+    def _post_recorded_test_case_update_validate(
         cls, values: RecordedTestCaseUpdate.Partial
     ) -> RecordedTestCaseUpdate.Partial:
         for validator in RecordedTestCaseUpdate.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_recording_response_notification.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_recording_response_notification.py
@@ -319,7 +319,7 @@ class RecordingResponseNotification(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_recording_response_notification_validate(
+    def _pre_validate_recording_response_notification(
         cls, values: RecordingResponseNotification.Partial
     ) -> RecordingResponseNotification.Partial:
         for validator in RecordingResponseNotification.Validators._pre_validators:
@@ -327,7 +327,7 @@ class RecordingResponseNotification(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_recording_response_notification_validate(
+    def _post_validate_recording_response_notification(
         cls, values: RecordingResponseNotification.Partial
     ) -> RecordingResponseNotification.Partial:
         for validator in RecordingResponseNotification.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_recording_response_notification.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_recording_response_notification.py
@@ -319,7 +319,7 @@ class RecordingResponseNotification(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prerecording_response_notification_validate(
+    def _pre_recording_response_notification_validate(
         cls, values: RecordingResponseNotification.Partial
     ) -> RecordingResponseNotification.Partial:
         for validator in RecordingResponseNotification.Validators._pre_validators:
@@ -327,7 +327,7 @@ class RecordingResponseNotification(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postrecording_response_notification_validate(
+    def _post_recording_response_notification_validate(
         cls, values: RecordingResponseNotification.Partial
     ) -> RecordingResponseNotification.Partial:
         for validator in RecordingResponseNotification.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_recording_response_notification.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_recording_response_notification.py
@@ -319,13 +319,17 @@ class RecordingResponseNotification(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: RecordingResponseNotification.Partial) -> RecordingResponseNotification.Partial:
+    def _prerecording_response_notification_validate(
+        cls, values: RecordingResponseNotification.Partial
+    ) -> RecordingResponseNotification.Partial:
         for validator in RecordingResponseNotification.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: RecordingResponseNotification.Partial) -> RecordingResponseNotification.Partial:
+    def _postrecording_response_notification_validate(
+        cls, values: RecordingResponseNotification.Partial
+    ) -> RecordingResponseNotification.Partial:
         for validator in RecordingResponseNotification.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_running_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_running_response.py
@@ -157,13 +157,13 @@ class RunningResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prerunning_response_validate(cls, values: RunningResponse.Partial) -> RunningResponse.Partial:
+    def _pre_running_response_validate(cls, values: RunningResponse.Partial) -> RunningResponse.Partial:
         for validator in RunningResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postrunning_response_validate(cls, values: RunningResponse.Partial) -> RunningResponse.Partial:
+    def _post_running_response_validate(cls, values: RunningResponse.Partial) -> RunningResponse.Partial:
         for validator in RunningResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_running_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_running_response.py
@@ -157,13 +157,13 @@ class RunningResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: RunningResponse.Partial) -> RunningResponse.Partial:
+    def _prerunning_response_validate(cls, values: RunningResponse.Partial) -> RunningResponse.Partial:
         for validator in RunningResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: RunningResponse.Partial) -> RunningResponse.Partial:
+    def _postrunning_response_validate(cls, values: RunningResponse.Partial) -> RunningResponse.Partial:
         for validator in RunningResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_running_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_running_response.py
@@ -157,13 +157,13 @@ class RunningResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_running_response_validate(cls, values: RunningResponse.Partial) -> RunningResponse.Partial:
+    def _pre_validate_running_response(cls, values: RunningResponse.Partial) -> RunningResponse.Partial:
         for validator in RunningResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_running_response_validate(cls, values: RunningResponse.Partial) -> RunningResponse.Partial:
+    def _post_validate_running_response(cls, values: RunningResponse.Partial) -> RunningResponse.Partial:
         for validator in RunningResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_runtime_error.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_runtime_error.py
@@ -105,13 +105,13 @@ class RuntimeError(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_runtime_error_validate(cls, values: RuntimeError.Partial) -> RuntimeError.Partial:
+    def _pre_validate_runtime_error(cls, values: RuntimeError.Partial) -> RuntimeError.Partial:
         for validator in RuntimeError.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_runtime_error_validate(cls, values: RuntimeError.Partial) -> RuntimeError.Partial:
+    def _post_validate_runtime_error(cls, values: RuntimeError.Partial) -> RuntimeError.Partial:
         for validator in RuntimeError.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_runtime_error.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_runtime_error.py
@@ -105,13 +105,13 @@ class RuntimeError(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: RuntimeError.Partial) -> RuntimeError.Partial:
+    def _preruntime_error_validate(cls, values: RuntimeError.Partial) -> RuntimeError.Partial:
         for validator in RuntimeError.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: RuntimeError.Partial) -> RuntimeError.Partial:
+    def _postruntime_error_validate(cls, values: RuntimeError.Partial) -> RuntimeError.Partial:
         for validator in RuntimeError.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_runtime_error.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_runtime_error.py
@@ -105,13 +105,13 @@ class RuntimeError(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preruntime_error_validate(cls, values: RuntimeError.Partial) -> RuntimeError.Partial:
+    def _pre_runtime_error_validate(cls, values: RuntimeError.Partial) -> RuntimeError.Partial:
         for validator in RuntimeError.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postruntime_error_validate(cls, values: RuntimeError.Partial) -> RuntimeError.Partial:
+    def _post_runtime_error_validate(cls, values: RuntimeError.Partial) -> RuntimeError.Partial:
         for validator in RuntimeError.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_scope.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_scope.py
@@ -106,13 +106,13 @@ class Scope(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prescope_validate(cls, values: Scope.Partial) -> Scope.Partial:
+    def _pre_scope_validate(cls, values: Scope.Partial) -> Scope.Partial:
         for validator in Scope.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postscope_validate(cls, values: Scope.Partial) -> Scope.Partial:
+    def _post_scope_validate(cls, values: Scope.Partial) -> Scope.Partial:
         for validator in Scope.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_scope.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_scope.py
@@ -106,13 +106,13 @@ class Scope(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: Scope.Partial) -> Scope.Partial:
+    def _prescope_validate(cls, values: Scope.Partial) -> Scope.Partial:
         for validator in Scope.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: Scope.Partial) -> Scope.Partial:
+    def _postscope_validate(cls, values: Scope.Partial) -> Scope.Partial:
         for validator in Scope.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_scope.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_scope.py
@@ -106,13 +106,13 @@ class Scope(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_scope_validate(cls, values: Scope.Partial) -> Scope.Partial:
+    def _pre_validate_scope(cls, values: Scope.Partial) -> Scope.Partial:
         for validator in Scope.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_scope_validate(cls, values: Scope.Partial) -> Scope.Partial:
+    def _post_validate_scope(cls, values: Scope.Partial) -> Scope.Partial:
         for validator in Scope.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_stack_frame.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_stack_frame.py
@@ -178,13 +178,13 @@ class StackFrame(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prestack_frame_validate(cls, values: StackFrame.Partial) -> StackFrame.Partial:
+    def _pre_stack_frame_validate(cls, values: StackFrame.Partial) -> StackFrame.Partial:
         for validator in StackFrame.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _poststack_frame_validate(cls, values: StackFrame.Partial) -> StackFrame.Partial:
+    def _post_stack_frame_validate(cls, values: StackFrame.Partial) -> StackFrame.Partial:
         for validator in StackFrame.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_stack_frame.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_stack_frame.py
@@ -178,13 +178,13 @@ class StackFrame(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_stack_frame_validate(cls, values: StackFrame.Partial) -> StackFrame.Partial:
+    def _pre_validate_stack_frame(cls, values: StackFrame.Partial) -> StackFrame.Partial:
         for validator in StackFrame.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_stack_frame_validate(cls, values: StackFrame.Partial) -> StackFrame.Partial:
+    def _post_validate_stack_frame(cls, values: StackFrame.Partial) -> StackFrame.Partial:
         for validator in StackFrame.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_stack_frame.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_stack_frame.py
@@ -178,13 +178,13 @@ class StackFrame(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: StackFrame.Partial) -> StackFrame.Partial:
+    def _prestack_frame_validate(cls, values: StackFrame.Partial) -> StackFrame.Partial:
         for validator in StackFrame.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: StackFrame.Partial) -> StackFrame.Partial:
+    def _poststack_frame_validate(cls, values: StackFrame.Partial) -> StackFrame.Partial:
         for validator in StackFrame.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_stack_information.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_stack_information.py
@@ -167,13 +167,13 @@ class StackInformation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prestack_information_validate(cls, values: StackInformation.Partial) -> StackInformation.Partial:
+    def _pre_stack_information_validate(cls, values: StackInformation.Partial) -> StackInformation.Partial:
         for validator in StackInformation.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _poststack_information_validate(cls, values: StackInformation.Partial) -> StackInformation.Partial:
+    def _post_stack_information_validate(cls, values: StackInformation.Partial) -> StackInformation.Partial:
         for validator in StackInformation.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_stack_information.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_stack_information.py
@@ -167,13 +167,13 @@ class StackInformation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: StackInformation.Partial) -> StackInformation.Partial:
+    def _prestack_information_validate(cls, values: StackInformation.Partial) -> StackInformation.Partial:
         for validator in StackInformation.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: StackInformation.Partial) -> StackInformation.Partial:
+    def _poststack_information_validate(cls, values: StackInformation.Partial) -> StackInformation.Partial:
         for validator in StackInformation.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_stack_information.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_stack_information.py
@@ -167,13 +167,13 @@ class StackInformation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_stack_information_validate(cls, values: StackInformation.Partial) -> StackInformation.Partial:
+    def _pre_validate_stack_information(cls, values: StackInformation.Partial) -> StackInformation.Partial:
         for validator in StackInformation.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_stack_information_validate(cls, values: StackInformation.Partial) -> StackInformation.Partial:
+    def _post_validate_stack_information(cls, values: StackInformation.Partial) -> StackInformation.Partial:
         for validator in StackInformation.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_stderr_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_stderr_response.py
@@ -154,13 +154,13 @@ class StderrResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: StderrResponse.Partial) -> StderrResponse.Partial:
+    def _prestderr_response_validate(cls, values: StderrResponse.Partial) -> StderrResponse.Partial:
         for validator in StderrResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: StderrResponse.Partial) -> StderrResponse.Partial:
+    def _poststderr_response_validate(cls, values: StderrResponse.Partial) -> StderrResponse.Partial:
         for validator in StderrResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_stderr_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_stderr_response.py
@@ -154,13 +154,13 @@ class StderrResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prestderr_response_validate(cls, values: StderrResponse.Partial) -> StderrResponse.Partial:
+    def _pre_stderr_response_validate(cls, values: StderrResponse.Partial) -> StderrResponse.Partial:
         for validator in StderrResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _poststderr_response_validate(cls, values: StderrResponse.Partial) -> StderrResponse.Partial:
+    def _post_stderr_response_validate(cls, values: StderrResponse.Partial) -> StderrResponse.Partial:
         for validator in StderrResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_stderr_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_stderr_response.py
@@ -154,13 +154,13 @@ class StderrResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_stderr_response_validate(cls, values: StderrResponse.Partial) -> StderrResponse.Partial:
+    def _pre_validate_stderr_response(cls, values: StderrResponse.Partial) -> StderrResponse.Partial:
         for validator in StderrResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_stderr_response_validate(cls, values: StderrResponse.Partial) -> StderrResponse.Partial:
+    def _post_validate_stderr_response(cls, values: StderrResponse.Partial) -> StderrResponse.Partial:
         for validator in StderrResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_stdout_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_stdout_response.py
@@ -154,13 +154,13 @@ class StdoutResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: StdoutResponse.Partial) -> StdoutResponse.Partial:
+    def _prestdout_response_validate(cls, values: StdoutResponse.Partial) -> StdoutResponse.Partial:
         for validator in StdoutResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: StdoutResponse.Partial) -> StdoutResponse.Partial:
+    def _poststdout_response_validate(cls, values: StdoutResponse.Partial) -> StdoutResponse.Partial:
         for validator in StdoutResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_stdout_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_stdout_response.py
@@ -154,13 +154,13 @@ class StdoutResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prestdout_response_validate(cls, values: StdoutResponse.Partial) -> StdoutResponse.Partial:
+    def _pre_stdout_response_validate(cls, values: StdoutResponse.Partial) -> StdoutResponse.Partial:
         for validator in StdoutResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _poststdout_response_validate(cls, values: StdoutResponse.Partial) -> StdoutResponse.Partial:
+    def _post_stdout_response_validate(cls, values: StdoutResponse.Partial) -> StdoutResponse.Partial:
         for validator in StdoutResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_stdout_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_stdout_response.py
@@ -154,13 +154,13 @@ class StdoutResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_stdout_response_validate(cls, values: StdoutResponse.Partial) -> StdoutResponse.Partial:
+    def _pre_validate_stdout_response(cls, values: StdoutResponse.Partial) -> StdoutResponse.Partial:
         for validator in StdoutResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_stdout_response_validate(cls, values: StdoutResponse.Partial) -> StdoutResponse.Partial:
+    def _post_validate_stdout_response(cls, values: StdoutResponse.Partial) -> StdoutResponse.Partial:
         for validator in StdoutResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_stop_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_stop_request.py
@@ -113,13 +113,13 @@ class StopRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: StopRequest.Partial) -> StopRequest.Partial:
+    def _prestop_request_validate(cls, values: StopRequest.Partial) -> StopRequest.Partial:
         for validator in StopRequest.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: StopRequest.Partial) -> StopRequest.Partial:
+    def _poststop_request_validate(cls, values: StopRequest.Partial) -> StopRequest.Partial:
         for validator in StopRequest.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_stop_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_stop_request.py
@@ -113,13 +113,13 @@ class StopRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_stop_request_validate(cls, values: StopRequest.Partial) -> StopRequest.Partial:
+    def _pre_validate_stop_request(cls, values: StopRequest.Partial) -> StopRequest.Partial:
         for validator in StopRequest.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_stop_request_validate(cls, values: StopRequest.Partial) -> StopRequest.Partial:
+    def _post_validate_stop_request(cls, values: StopRequest.Partial) -> StopRequest.Partial:
         for validator in StopRequest.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_stop_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_stop_request.py
@@ -113,13 +113,13 @@ class StopRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prestop_request_validate(cls, values: StopRequest.Partial) -> StopRequest.Partial:
+    def _pre_stop_request_validate(cls, values: StopRequest.Partial) -> StopRequest.Partial:
         for validator in StopRequest.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _poststop_request_validate(cls, values: StopRequest.Partial) -> StopRequest.Partial:
+    def _post_stop_request_validate(cls, values: StopRequest.Partial) -> StopRequest.Partial:
         for validator in StopRequest.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_stopped_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_stopped_response.py
@@ -117,13 +117,13 @@ class StoppedResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prestopped_response_validate(cls, values: StoppedResponse.Partial) -> StoppedResponse.Partial:
+    def _pre_stopped_response_validate(cls, values: StoppedResponse.Partial) -> StoppedResponse.Partial:
         for validator in StoppedResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _poststopped_response_validate(cls, values: StoppedResponse.Partial) -> StoppedResponse.Partial:
+    def _post_stopped_response_validate(cls, values: StoppedResponse.Partial) -> StoppedResponse.Partial:
         for validator in StoppedResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_stopped_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_stopped_response.py
@@ -117,13 +117,13 @@ class StoppedResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: StoppedResponse.Partial) -> StoppedResponse.Partial:
+    def _prestopped_response_validate(cls, values: StoppedResponse.Partial) -> StoppedResponse.Partial:
         for validator in StoppedResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: StoppedResponse.Partial) -> StoppedResponse.Partial:
+    def _poststopped_response_validate(cls, values: StoppedResponse.Partial) -> StoppedResponse.Partial:
         for validator in StoppedResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_stopped_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_stopped_response.py
@@ -117,13 +117,13 @@ class StoppedResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_stopped_response_validate(cls, values: StoppedResponse.Partial) -> StoppedResponse.Partial:
+    def _pre_validate_stopped_response(cls, values: StoppedResponse.Partial) -> StoppedResponse.Partial:
         for validator in StoppedResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_stopped_response_validate(cls, values: StoppedResponse.Partial) -> StoppedResponse.Partial:
+    def _post_validate_stopped_response(cls, values: StoppedResponse.Partial) -> StoppedResponse.Partial:
         for validator in StoppedResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_submission_file_info.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_submission_file_info.py
@@ -191,13 +191,13 @@ class SubmissionFileInfo(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_submission_file_info_validate(cls, values: SubmissionFileInfo.Partial) -> SubmissionFileInfo.Partial:
+    def _pre_validate_submission_file_info(cls, values: SubmissionFileInfo.Partial) -> SubmissionFileInfo.Partial:
         for validator in SubmissionFileInfo.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_submission_file_info_validate(cls, values: SubmissionFileInfo.Partial) -> SubmissionFileInfo.Partial:
+    def _post_validate_submission_file_info(cls, values: SubmissionFileInfo.Partial) -> SubmissionFileInfo.Partial:
         for validator in SubmissionFileInfo.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_submission_file_info.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_submission_file_info.py
@@ -191,13 +191,13 @@ class SubmissionFileInfo(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _presubmission_file_info_validate(cls, values: SubmissionFileInfo.Partial) -> SubmissionFileInfo.Partial:
+    def _pre_submission_file_info_validate(cls, values: SubmissionFileInfo.Partial) -> SubmissionFileInfo.Partial:
         for validator in SubmissionFileInfo.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postsubmission_file_info_validate(cls, values: SubmissionFileInfo.Partial) -> SubmissionFileInfo.Partial:
+    def _post_submission_file_info_validate(cls, values: SubmissionFileInfo.Partial) -> SubmissionFileInfo.Partial:
         for validator in SubmissionFileInfo.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_submission_file_info.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_submission_file_info.py
@@ -191,13 +191,13 @@ class SubmissionFileInfo(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: SubmissionFileInfo.Partial) -> SubmissionFileInfo.Partial:
+    def _presubmission_file_info_validate(cls, values: SubmissionFileInfo.Partial) -> SubmissionFileInfo.Partial:
         for validator in SubmissionFileInfo.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: SubmissionFileInfo.Partial) -> SubmissionFileInfo.Partial:
+    def _postsubmission_file_info_validate(cls, values: SubmissionFileInfo.Partial) -> SubmissionFileInfo.Partial:
         for validator in SubmissionFileInfo.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_submission_id_not_found.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_submission_id_not_found.py
@@ -121,13 +121,15 @@ class SubmissionIdNotFound(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: SubmissionIdNotFound.Partial) -> SubmissionIdNotFound.Partial:
+    def _presubmission_id_not_found_validate(cls, values: SubmissionIdNotFound.Partial) -> SubmissionIdNotFound.Partial:
         for validator in SubmissionIdNotFound.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: SubmissionIdNotFound.Partial) -> SubmissionIdNotFound.Partial:
+    def _postsubmission_id_not_found_validate(
+        cls, values: SubmissionIdNotFound.Partial
+    ) -> SubmissionIdNotFound.Partial:
         for validator in SubmissionIdNotFound.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_submission_id_not_found.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_submission_id_not_found.py
@@ -121,7 +121,7 @@ class SubmissionIdNotFound(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_submission_id_not_found_validate(
+    def _pre_validate_submission_id_not_found(
         cls, values: SubmissionIdNotFound.Partial
     ) -> SubmissionIdNotFound.Partial:
         for validator in SubmissionIdNotFound.Validators._pre_validators:
@@ -129,7 +129,7 @@ class SubmissionIdNotFound(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_submission_id_not_found_validate(
+    def _post_validate_submission_id_not_found(
         cls, values: SubmissionIdNotFound.Partial
     ) -> SubmissionIdNotFound.Partial:
         for validator in SubmissionIdNotFound.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_submission_id_not_found.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_submission_id_not_found.py
@@ -121,13 +121,15 @@ class SubmissionIdNotFound(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _presubmission_id_not_found_validate(cls, values: SubmissionIdNotFound.Partial) -> SubmissionIdNotFound.Partial:
+    def _pre_submission_id_not_found_validate(
+        cls, values: SubmissionIdNotFound.Partial
+    ) -> SubmissionIdNotFound.Partial:
         for validator in SubmissionIdNotFound.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postsubmission_id_not_found_validate(
+    def _post_submission_id_not_found_validate(
         cls, values: SubmissionIdNotFound.Partial
     ) -> SubmissionIdNotFound.Partial:
         for validator in SubmissionIdNotFound.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_submit_request_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_submit_request_v_2.py
@@ -331,13 +331,13 @@ class SubmitRequestV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: SubmitRequestV2.Partial) -> SubmitRequestV2.Partial:
+    def _presubmit_request_v_2_validate(cls, values: SubmitRequestV2.Partial) -> SubmitRequestV2.Partial:
         for validator in SubmitRequestV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: SubmitRequestV2.Partial) -> SubmitRequestV2.Partial:
+    def _postsubmit_request_v_2_validate(cls, values: SubmitRequestV2.Partial) -> SubmitRequestV2.Partial:
         for validator in SubmitRequestV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_submit_request_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_submit_request_v_2.py
@@ -331,13 +331,13 @@ class SubmitRequestV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _presubmit_request_v_2_validate(cls, values: SubmitRequestV2.Partial) -> SubmitRequestV2.Partial:
+    def _pre_submit_request_v_2_validate(cls, values: SubmitRequestV2.Partial) -> SubmitRequestV2.Partial:
         for validator in SubmitRequestV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postsubmit_request_v_2_validate(cls, values: SubmitRequestV2.Partial) -> SubmitRequestV2.Partial:
+    def _post_submit_request_v_2_validate(cls, values: SubmitRequestV2.Partial) -> SubmitRequestV2.Partial:
         for validator in SubmitRequestV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_submit_request_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_submit_request_v_2.py
@@ -331,13 +331,13 @@ class SubmitRequestV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_submit_request_v_2_validate(cls, values: SubmitRequestV2.Partial) -> SubmitRequestV2.Partial:
+    def _pre_validate_submit_request_v_2(cls, values: SubmitRequestV2.Partial) -> SubmitRequestV2.Partial:
         for validator in SubmitRequestV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_submit_request_v_2_validate(cls, values: SubmitRequestV2.Partial) -> SubmitRequestV2.Partial:
+    def _post_validate_submit_request_v_2(cls, values: SubmitRequestV2.Partial) -> SubmitRequestV2.Partial:
         for validator in SubmitRequestV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_terminated_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_terminated_response.py
@@ -65,13 +65,13 @@ class TerminatedResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_terminated_response_validate(cls, values: TerminatedResponse.Partial) -> TerminatedResponse.Partial:
+    def _pre_validate_terminated_response(cls, values: TerminatedResponse.Partial) -> TerminatedResponse.Partial:
         for validator in TerminatedResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_terminated_response_validate(cls, values: TerminatedResponse.Partial) -> TerminatedResponse.Partial:
+    def _post_validate_terminated_response(cls, values: TerminatedResponse.Partial) -> TerminatedResponse.Partial:
         for validator in TerminatedResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_terminated_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_terminated_response.py
@@ -65,13 +65,13 @@ class TerminatedResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TerminatedResponse.Partial) -> TerminatedResponse.Partial:
+    def _preterminated_response_validate(cls, values: TerminatedResponse.Partial) -> TerminatedResponse.Partial:
         for validator in TerminatedResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TerminatedResponse.Partial) -> TerminatedResponse.Partial:
+    def _postterminated_response_validate(cls, values: TerminatedResponse.Partial) -> TerminatedResponse.Partial:
         for validator in TerminatedResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_terminated_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_terminated_response.py
@@ -65,13 +65,13 @@ class TerminatedResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preterminated_response_validate(cls, values: TerminatedResponse.Partial) -> TerminatedResponse.Partial:
+    def _pre_terminated_response_validate(cls, values: TerminatedResponse.Partial) -> TerminatedResponse.Partial:
         for validator in TerminatedResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postterminated_response_validate(cls, values: TerminatedResponse.Partial) -> TerminatedResponse.Partial:
+    def _post_terminated_response_validate(cls, values: TerminatedResponse.Partial) -> TerminatedResponse.Partial:
         for validator in TerminatedResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_test_case_hidden_grade.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_test_case_hidden_grade.py
@@ -111,13 +111,13 @@ class TestCaseHiddenGrade(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TestCaseHiddenGrade.Partial) -> TestCaseHiddenGrade.Partial:
+    def _pretest_case_hidden_grade_validate(cls, values: TestCaseHiddenGrade.Partial) -> TestCaseHiddenGrade.Partial:
         for validator in TestCaseHiddenGrade.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TestCaseHiddenGrade.Partial) -> TestCaseHiddenGrade.Partial:
+    def _posttest_case_hidden_grade_validate(cls, values: TestCaseHiddenGrade.Partial) -> TestCaseHiddenGrade.Partial:
         for validator in TestCaseHiddenGrade.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_test_case_hidden_grade.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_test_case_hidden_grade.py
@@ -111,13 +111,13 @@ class TestCaseHiddenGrade(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_test_case_hidden_grade_validate(cls, values: TestCaseHiddenGrade.Partial) -> TestCaseHiddenGrade.Partial:
+    def _pre_validate_test_case_hidden_grade(cls, values: TestCaseHiddenGrade.Partial) -> TestCaseHiddenGrade.Partial:
         for validator in TestCaseHiddenGrade.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_test_case_hidden_grade_validate(cls, values: TestCaseHiddenGrade.Partial) -> TestCaseHiddenGrade.Partial:
+    def _post_validate_test_case_hidden_grade(cls, values: TestCaseHiddenGrade.Partial) -> TestCaseHiddenGrade.Partial:
         for validator in TestCaseHiddenGrade.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_test_case_hidden_grade.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_test_case_hidden_grade.py
@@ -111,13 +111,13 @@ class TestCaseHiddenGrade(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pretest_case_hidden_grade_validate(cls, values: TestCaseHiddenGrade.Partial) -> TestCaseHiddenGrade.Partial:
+    def _pre_test_case_hidden_grade_validate(cls, values: TestCaseHiddenGrade.Partial) -> TestCaseHiddenGrade.Partial:
         for validator in TestCaseHiddenGrade.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _posttest_case_hidden_grade_validate(cls, values: TestCaseHiddenGrade.Partial) -> TestCaseHiddenGrade.Partial:
+    def _post_test_case_hidden_grade_validate(cls, values: TestCaseHiddenGrade.Partial) -> TestCaseHiddenGrade.Partial:
         for validator in TestCaseHiddenGrade.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_test_case_non_hidden_grade.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_test_case_non_hidden_grade.py
@@ -248,13 +248,17 @@ class TestCaseNonHiddenGrade(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TestCaseNonHiddenGrade.Partial) -> TestCaseNonHiddenGrade.Partial:
+    def _pretest_case_non_hidden_grade_validate(
+        cls, values: TestCaseNonHiddenGrade.Partial
+    ) -> TestCaseNonHiddenGrade.Partial:
         for validator in TestCaseNonHiddenGrade.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TestCaseNonHiddenGrade.Partial) -> TestCaseNonHiddenGrade.Partial:
+    def _posttest_case_non_hidden_grade_validate(
+        cls, values: TestCaseNonHiddenGrade.Partial
+    ) -> TestCaseNonHiddenGrade.Partial:
         for validator in TestCaseNonHiddenGrade.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_test_case_non_hidden_grade.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_test_case_non_hidden_grade.py
@@ -248,7 +248,7 @@ class TestCaseNonHiddenGrade(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_test_case_non_hidden_grade_validate(
+    def _pre_validate_test_case_non_hidden_grade(
         cls, values: TestCaseNonHiddenGrade.Partial
     ) -> TestCaseNonHiddenGrade.Partial:
         for validator in TestCaseNonHiddenGrade.Validators._pre_validators:
@@ -256,7 +256,7 @@ class TestCaseNonHiddenGrade(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_test_case_non_hidden_grade_validate(
+    def _post_validate_test_case_non_hidden_grade(
         cls, values: TestCaseNonHiddenGrade.Partial
     ) -> TestCaseNonHiddenGrade.Partial:
         for validator in TestCaseNonHiddenGrade.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_test_case_non_hidden_grade.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_test_case_non_hidden_grade.py
@@ -248,7 +248,7 @@ class TestCaseNonHiddenGrade(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pretest_case_non_hidden_grade_validate(
+    def _pre_test_case_non_hidden_grade_validate(
         cls, values: TestCaseNonHiddenGrade.Partial
     ) -> TestCaseNonHiddenGrade.Partial:
         for validator in TestCaseNonHiddenGrade.Validators._pre_validators:
@@ -256,7 +256,7 @@ class TestCaseNonHiddenGrade(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _posttest_case_non_hidden_grade_validate(
+    def _post_test_case_non_hidden_grade_validate(
         cls, values: TestCaseNonHiddenGrade.Partial
     ) -> TestCaseNonHiddenGrade.Partial:
         for validator in TestCaseNonHiddenGrade.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_test_case_result.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_test_case_result.py
@@ -201,13 +201,13 @@ class TestCaseResult(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_test_case_result_validate(cls, values: TestCaseResult.Partial) -> TestCaseResult.Partial:
+    def _pre_validate_test_case_result(cls, values: TestCaseResult.Partial) -> TestCaseResult.Partial:
         for validator in TestCaseResult.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_test_case_result_validate(cls, values: TestCaseResult.Partial) -> TestCaseResult.Partial:
+    def _post_validate_test_case_result(cls, values: TestCaseResult.Partial) -> TestCaseResult.Partial:
         for validator in TestCaseResult.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_test_case_result.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_test_case_result.py
@@ -201,13 +201,13 @@ class TestCaseResult(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TestCaseResult.Partial) -> TestCaseResult.Partial:
+    def _pretest_case_result_validate(cls, values: TestCaseResult.Partial) -> TestCaseResult.Partial:
         for validator in TestCaseResult.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TestCaseResult.Partial) -> TestCaseResult.Partial:
+    def _posttest_case_result_validate(cls, values: TestCaseResult.Partial) -> TestCaseResult.Partial:
         for validator in TestCaseResult.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_test_case_result.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_test_case_result.py
@@ -201,13 +201,13 @@ class TestCaseResult(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pretest_case_result_validate(cls, values: TestCaseResult.Partial) -> TestCaseResult.Partial:
+    def _pre_test_case_result_validate(cls, values: TestCaseResult.Partial) -> TestCaseResult.Partial:
         for validator in TestCaseResult.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _posttest_case_result_validate(cls, values: TestCaseResult.Partial) -> TestCaseResult.Partial:
+    def _post_test_case_result_validate(cls, values: TestCaseResult.Partial) -> TestCaseResult.Partial:
         for validator in TestCaseResult.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_test_case_result_with_stdout.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_test_case_result_with_stdout.py
@@ -158,7 +158,7 @@ class TestCaseResultWithStdout(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_test_case_result_with_stdout_validate(
+    def _pre_validate_test_case_result_with_stdout(
         cls, values: TestCaseResultWithStdout.Partial
     ) -> TestCaseResultWithStdout.Partial:
         for validator in TestCaseResultWithStdout.Validators._pre_validators:
@@ -166,7 +166,7 @@ class TestCaseResultWithStdout(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_test_case_result_with_stdout_validate(
+    def _post_validate_test_case_result_with_stdout(
         cls, values: TestCaseResultWithStdout.Partial
     ) -> TestCaseResultWithStdout.Partial:
         for validator in TestCaseResultWithStdout.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_test_case_result_with_stdout.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_test_case_result_with_stdout.py
@@ -158,13 +158,17 @@ class TestCaseResultWithStdout(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TestCaseResultWithStdout.Partial) -> TestCaseResultWithStdout.Partial:
+    def _pretest_case_result_with_stdout_validate(
+        cls, values: TestCaseResultWithStdout.Partial
+    ) -> TestCaseResultWithStdout.Partial:
         for validator in TestCaseResultWithStdout.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TestCaseResultWithStdout.Partial) -> TestCaseResultWithStdout.Partial:
+    def _posttest_case_result_with_stdout_validate(
+        cls, values: TestCaseResultWithStdout.Partial
+    ) -> TestCaseResultWithStdout.Partial:
         for validator in TestCaseResultWithStdout.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_test_case_result_with_stdout.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_test_case_result_with_stdout.py
@@ -158,7 +158,7 @@ class TestCaseResultWithStdout(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pretest_case_result_with_stdout_validate(
+    def _pre_test_case_result_with_stdout_validate(
         cls, values: TestCaseResultWithStdout.Partial
     ) -> TestCaseResultWithStdout.Partial:
         for validator in TestCaseResultWithStdout.Validators._pre_validators:
@@ -166,7 +166,7 @@ class TestCaseResultWithStdout(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _posttest_case_result_with_stdout_validate(
+    def _post_test_case_result_with_stdout_validate(
         cls, values: TestCaseResultWithStdout.Partial
     ) -> TestCaseResultWithStdout.Partial:
         for validator in TestCaseResultWithStdout.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_test_submission_state.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_test_submission_state.py
@@ -259,13 +259,13 @@ class TestSubmissionState(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_test_submission_state_validate(cls, values: TestSubmissionState.Partial) -> TestSubmissionState.Partial:
+    def _pre_validate_test_submission_state(cls, values: TestSubmissionState.Partial) -> TestSubmissionState.Partial:
         for validator in TestSubmissionState.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_test_submission_state_validate(cls, values: TestSubmissionState.Partial) -> TestSubmissionState.Partial:
+    def _post_validate_test_submission_state(cls, values: TestSubmissionState.Partial) -> TestSubmissionState.Partial:
         for validator in TestSubmissionState.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_test_submission_state.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_test_submission_state.py
@@ -259,13 +259,13 @@ class TestSubmissionState(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pretest_submission_state_validate(cls, values: TestSubmissionState.Partial) -> TestSubmissionState.Partial:
+    def _pre_test_submission_state_validate(cls, values: TestSubmissionState.Partial) -> TestSubmissionState.Partial:
         for validator in TestSubmissionState.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _posttest_submission_state_validate(cls, values: TestSubmissionState.Partial) -> TestSubmissionState.Partial:
+    def _post_test_submission_state_validate(cls, values: TestSubmissionState.Partial) -> TestSubmissionState.Partial:
         for validator in TestSubmissionState.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_test_submission_state.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_test_submission_state.py
@@ -259,13 +259,13 @@ class TestSubmissionState(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TestSubmissionState.Partial) -> TestSubmissionState.Partial:
+    def _pretest_submission_state_validate(cls, values: TestSubmissionState.Partial) -> TestSubmissionState.Partial:
         for validator in TestSubmissionState.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TestSubmissionState.Partial) -> TestSubmissionState.Partial:
+    def _posttest_submission_state_validate(cls, values: TestSubmissionState.Partial) -> TestSubmissionState.Partial:
         for validator in TestSubmissionState.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_test_submission_status_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_test_submission_status_v_2.py
@@ -256,7 +256,7 @@ class TestSubmissionStatusV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_test_submission_status_v_2_validate(
+    def _pre_validate_test_submission_status_v_2(
         cls, values: TestSubmissionStatusV2.Partial
     ) -> TestSubmissionStatusV2.Partial:
         for validator in TestSubmissionStatusV2.Validators._pre_validators:
@@ -264,7 +264,7 @@ class TestSubmissionStatusV2(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_test_submission_status_v_2_validate(
+    def _post_validate_test_submission_status_v_2(
         cls, values: TestSubmissionStatusV2.Partial
     ) -> TestSubmissionStatusV2.Partial:
         for validator in TestSubmissionStatusV2.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_test_submission_status_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_test_submission_status_v_2.py
@@ -256,13 +256,17 @@ class TestSubmissionStatusV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TestSubmissionStatusV2.Partial) -> TestSubmissionStatusV2.Partial:
+    def _pretest_submission_status_v_2_validate(
+        cls, values: TestSubmissionStatusV2.Partial
+    ) -> TestSubmissionStatusV2.Partial:
         for validator in TestSubmissionStatusV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TestSubmissionStatusV2.Partial) -> TestSubmissionStatusV2.Partial:
+    def _posttest_submission_status_v_2_validate(
+        cls, values: TestSubmissionStatusV2.Partial
+    ) -> TestSubmissionStatusV2.Partial:
         for validator in TestSubmissionStatusV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_test_submission_status_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_test_submission_status_v_2.py
@@ -256,7 +256,7 @@ class TestSubmissionStatusV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pretest_submission_status_v_2_validate(
+    def _pre_test_submission_status_v_2_validate(
         cls, values: TestSubmissionStatusV2.Partial
     ) -> TestSubmissionStatusV2.Partial:
         for validator in TestSubmissionStatusV2.Validators._pre_validators:
@@ -264,7 +264,7 @@ class TestSubmissionStatusV2(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _posttest_submission_status_v_2_validate(
+    def _post_test_submission_status_v_2_validate(
         cls, values: TestSubmissionStatusV2.Partial
     ) -> TestSubmissionStatusV2.Partial:
         for validator in TestSubmissionStatusV2.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_test_submission_update.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_test_submission_update.py
@@ -163,13 +163,13 @@ class TestSubmissionUpdate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_test_submission_update_validate(cls, values: TestSubmissionUpdate.Partial) -> TestSubmissionUpdate.Partial:
+    def _pre_validate_test_submission_update(cls, values: TestSubmissionUpdate.Partial) -> TestSubmissionUpdate.Partial:
         for validator in TestSubmissionUpdate.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_test_submission_update_validate(
+    def _post_validate_test_submission_update(
         cls, values: TestSubmissionUpdate.Partial
     ) -> TestSubmissionUpdate.Partial:
         for validator in TestSubmissionUpdate.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_test_submission_update.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_test_submission_update.py
@@ -163,13 +163,15 @@ class TestSubmissionUpdate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pretest_submission_update_validate(cls, values: TestSubmissionUpdate.Partial) -> TestSubmissionUpdate.Partial:
+    def _pre_test_submission_update_validate(cls, values: TestSubmissionUpdate.Partial) -> TestSubmissionUpdate.Partial:
         for validator in TestSubmissionUpdate.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _posttest_submission_update_validate(cls, values: TestSubmissionUpdate.Partial) -> TestSubmissionUpdate.Partial:
+    def _post_test_submission_update_validate(
+        cls, values: TestSubmissionUpdate.Partial
+    ) -> TestSubmissionUpdate.Partial:
         for validator in TestSubmissionUpdate.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_test_submission_update.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_test_submission_update.py
@@ -163,13 +163,13 @@ class TestSubmissionUpdate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TestSubmissionUpdate.Partial) -> TestSubmissionUpdate.Partial:
+    def _pretest_submission_update_validate(cls, values: TestSubmissionUpdate.Partial) -> TestSubmissionUpdate.Partial:
         for validator in TestSubmissionUpdate.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TestSubmissionUpdate.Partial) -> TestSubmissionUpdate.Partial:
+    def _posttest_submission_update_validate(cls, values: TestSubmissionUpdate.Partial) -> TestSubmissionUpdate.Partial:
         for validator in TestSubmissionUpdate.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_trace_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_trace_response.py
@@ -321,13 +321,13 @@ class TraceResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pretrace_response_validate(cls, values: TraceResponse.Partial) -> TraceResponse.Partial:
+    def _pre_trace_response_validate(cls, values: TraceResponse.Partial) -> TraceResponse.Partial:
         for validator in TraceResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _posttrace_response_validate(cls, values: TraceResponse.Partial) -> TraceResponse.Partial:
+    def _post_trace_response_validate(cls, values: TraceResponse.Partial) -> TraceResponse.Partial:
         for validator in TraceResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_trace_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_trace_response.py
@@ -321,13 +321,13 @@ class TraceResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_trace_response_validate(cls, values: TraceResponse.Partial) -> TraceResponse.Partial:
+    def _pre_validate_trace_response(cls, values: TraceResponse.Partial) -> TraceResponse.Partial:
         for validator in TraceResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_trace_response_validate(cls, values: TraceResponse.Partial) -> TraceResponse.Partial:
+    def _post_validate_trace_response(cls, values: TraceResponse.Partial) -> TraceResponse.Partial:
         for validator in TraceResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_trace_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_trace_response.py
@@ -321,13 +321,13 @@ class TraceResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TraceResponse.Partial) -> TraceResponse.Partial:
+    def _pretrace_response_validate(cls, values: TraceResponse.Partial) -> TraceResponse.Partial:
         for validator in TraceResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TraceResponse.Partial) -> TraceResponse.Partial:
+    def _posttrace_response_validate(cls, values: TraceResponse.Partial) -> TraceResponse.Partial:
         for validator in TraceResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_trace_response_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_trace_response_v_2.py
@@ -368,13 +368,13 @@ class TraceResponseV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pretrace_response_v_2_validate(cls, values: TraceResponseV2.Partial) -> TraceResponseV2.Partial:
+    def _pre_trace_response_v_2_validate(cls, values: TraceResponseV2.Partial) -> TraceResponseV2.Partial:
         for validator in TraceResponseV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _posttrace_response_v_2_validate(cls, values: TraceResponseV2.Partial) -> TraceResponseV2.Partial:
+    def _post_trace_response_v_2_validate(cls, values: TraceResponseV2.Partial) -> TraceResponseV2.Partial:
         for validator in TraceResponseV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_trace_response_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_trace_response_v_2.py
@@ -368,13 +368,13 @@ class TraceResponseV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_trace_response_v_2_validate(cls, values: TraceResponseV2.Partial) -> TraceResponseV2.Partial:
+    def _pre_validate_trace_response_v_2(cls, values: TraceResponseV2.Partial) -> TraceResponseV2.Partial:
         for validator in TraceResponseV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_trace_response_v_2_validate(cls, values: TraceResponseV2.Partial) -> TraceResponseV2.Partial:
+    def _post_validate_trace_response_v_2(cls, values: TraceResponseV2.Partial) -> TraceResponseV2.Partial:
         for validator in TraceResponseV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_trace_response_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_trace_response_v_2.py
@@ -368,13 +368,13 @@ class TraceResponseV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TraceResponseV2.Partial) -> TraceResponseV2.Partial:
+    def _pretrace_response_v_2_validate(cls, values: TraceResponseV2.Partial) -> TraceResponseV2.Partial:
         for validator in TraceResponseV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TraceResponseV2.Partial) -> TraceResponseV2.Partial:
+    def _posttrace_response_v_2_validate(cls, values: TraceResponseV2.Partial) -> TraceResponseV2.Partial:
         for validator in TraceResponseV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_trace_responses_page.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_trace_responses_page.py
@@ -167,13 +167,13 @@ class TraceResponsesPage(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pretrace_responses_page_validate(cls, values: TraceResponsesPage.Partial) -> TraceResponsesPage.Partial:
+    def _pre_trace_responses_page_validate(cls, values: TraceResponsesPage.Partial) -> TraceResponsesPage.Partial:
         for validator in TraceResponsesPage.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _posttrace_responses_page_validate(cls, values: TraceResponsesPage.Partial) -> TraceResponsesPage.Partial:
+    def _post_trace_responses_page_validate(cls, values: TraceResponsesPage.Partial) -> TraceResponsesPage.Partial:
         for validator in TraceResponsesPage.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_trace_responses_page.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_trace_responses_page.py
@@ -167,13 +167,13 @@ class TraceResponsesPage(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_trace_responses_page_validate(cls, values: TraceResponsesPage.Partial) -> TraceResponsesPage.Partial:
+    def _pre_validate_trace_responses_page(cls, values: TraceResponsesPage.Partial) -> TraceResponsesPage.Partial:
         for validator in TraceResponsesPage.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_trace_responses_page_validate(cls, values: TraceResponsesPage.Partial) -> TraceResponsesPage.Partial:
+    def _post_validate_trace_responses_page(cls, values: TraceResponsesPage.Partial) -> TraceResponsesPage.Partial:
         for validator in TraceResponsesPage.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_trace_responses_page.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_trace_responses_page.py
@@ -167,13 +167,13 @@ class TraceResponsesPage(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TraceResponsesPage.Partial) -> TraceResponsesPage.Partial:
+    def _pretrace_responses_page_validate(cls, values: TraceResponsesPage.Partial) -> TraceResponsesPage.Partial:
         for validator in TraceResponsesPage.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TraceResponsesPage.Partial) -> TraceResponsesPage.Partial:
+    def _posttrace_responses_page_validate(cls, values: TraceResponsesPage.Partial) -> TraceResponsesPage.Partial:
         for validator in TraceResponsesPage.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_trace_responses_page_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_trace_responses_page_v_2.py
@@ -169,7 +169,7 @@ class TraceResponsesPageV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pretrace_responses_page_v_2_validate(
+    def _pre_trace_responses_page_v_2_validate(
         cls, values: TraceResponsesPageV2.Partial
     ) -> TraceResponsesPageV2.Partial:
         for validator in TraceResponsesPageV2.Validators._pre_validators:
@@ -177,7 +177,7 @@ class TraceResponsesPageV2(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _posttrace_responses_page_v_2_validate(
+    def _post_trace_responses_page_v_2_validate(
         cls, values: TraceResponsesPageV2.Partial
     ) -> TraceResponsesPageV2.Partial:
         for validator in TraceResponsesPageV2.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_trace_responses_page_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_trace_responses_page_v_2.py
@@ -169,7 +169,7 @@ class TraceResponsesPageV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_trace_responses_page_v_2_validate(
+    def _pre_validate_trace_responses_page_v_2(
         cls, values: TraceResponsesPageV2.Partial
     ) -> TraceResponsesPageV2.Partial:
         for validator in TraceResponsesPageV2.Validators._pre_validators:
@@ -177,7 +177,7 @@ class TraceResponsesPageV2(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_trace_responses_page_v_2_validate(
+    def _post_validate_trace_responses_page_v_2(
         cls, values: TraceResponsesPageV2.Partial
     ) -> TraceResponsesPageV2.Partial:
         for validator in TraceResponsesPageV2.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_trace_responses_page_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_trace_responses_page_v_2.py
@@ -169,13 +169,17 @@ class TraceResponsesPageV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TraceResponsesPageV2.Partial) -> TraceResponsesPageV2.Partial:
+    def _pretrace_responses_page_v_2_validate(
+        cls, values: TraceResponsesPageV2.Partial
+    ) -> TraceResponsesPageV2.Partial:
         for validator in TraceResponsesPageV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TraceResponsesPageV2.Partial) -> TraceResponsesPageV2.Partial:
+    def _posttrace_responses_page_v_2_validate(
+        cls, values: TraceResponsesPageV2.Partial
+    ) -> TraceResponsesPageV2.Partial:
         for validator in TraceResponsesPageV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_traced_file.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_traced_file.py
@@ -140,13 +140,13 @@ class TracedFile(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TracedFile.Partial) -> TracedFile.Partial:
+    def _pretraced_file_validate(cls, values: TracedFile.Partial) -> TracedFile.Partial:
         for validator in TracedFile.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TracedFile.Partial) -> TracedFile.Partial:
+    def _posttraced_file_validate(cls, values: TracedFile.Partial) -> TracedFile.Partial:
         for validator in TracedFile.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_traced_file.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_traced_file.py
@@ -140,13 +140,13 @@ class TracedFile(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_traced_file_validate(cls, values: TracedFile.Partial) -> TracedFile.Partial:
+    def _pre_validate_traced_file(cls, values: TracedFile.Partial) -> TracedFile.Partial:
         for validator in TracedFile.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_traced_file_validate(cls, values: TracedFile.Partial) -> TracedFile.Partial:
+    def _post_validate_traced_file(cls, values: TracedFile.Partial) -> TracedFile.Partial:
         for validator in TracedFile.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_traced_file.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_traced_file.py
@@ -140,13 +140,13 @@ class TracedFile(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pretraced_file_validate(cls, values: TracedFile.Partial) -> TracedFile.Partial:
+    def _pre_traced_file_validate(cls, values: TracedFile.Partial) -> TracedFile.Partial:
         for validator in TracedFile.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _posttraced_file_validate(cls, values: TracedFile.Partial) -> TracedFile.Partial:
+    def _post_traced_file_validate(cls, values: TracedFile.Partial) -> TracedFile.Partial:
         for validator in TracedFile.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_traced_test_case.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_traced_test_case.py
@@ -158,13 +158,13 @@ class TracedTestCase(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pretraced_test_case_validate(cls, values: TracedTestCase.Partial) -> TracedTestCase.Partial:
+    def _pre_traced_test_case_validate(cls, values: TracedTestCase.Partial) -> TracedTestCase.Partial:
         for validator in TracedTestCase.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _posttraced_test_case_validate(cls, values: TracedTestCase.Partial) -> TracedTestCase.Partial:
+    def _post_traced_test_case_validate(cls, values: TracedTestCase.Partial) -> TracedTestCase.Partial:
         for validator in TracedTestCase.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_traced_test_case.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_traced_test_case.py
@@ -158,13 +158,13 @@ class TracedTestCase(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TracedTestCase.Partial) -> TracedTestCase.Partial:
+    def _pretraced_test_case_validate(cls, values: TracedTestCase.Partial) -> TracedTestCase.Partial:
         for validator in TracedTestCase.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TracedTestCase.Partial) -> TracedTestCase.Partial:
+    def _posttraced_test_case_validate(cls, values: TracedTestCase.Partial) -> TracedTestCase.Partial:
         for validator in TracedTestCase.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_traced_test_case.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_traced_test_case.py
@@ -158,13 +158,13 @@ class TracedTestCase(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_traced_test_case_validate(cls, values: TracedTestCase.Partial) -> TracedTestCase.Partial:
+    def _pre_validate_traced_test_case(cls, values: TracedTestCase.Partial) -> TracedTestCase.Partial:
         for validator in TracedTestCase.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_traced_test_case_validate(cls, values: TracedTestCase.Partial) -> TracedTestCase.Partial:
+    def _post_validate_traced_test_case(cls, values: TracedTestCase.Partial) -> TracedTestCase.Partial:
         for validator in TracedTestCase.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_unexpected_language_error.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_unexpected_language_error.py
@@ -169,7 +169,7 @@ class UnexpectedLanguageError(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preunexpected_language_error_validate(
+    def _pre_unexpected_language_error_validate(
         cls, values: UnexpectedLanguageError.Partial
     ) -> UnexpectedLanguageError.Partial:
         for validator in UnexpectedLanguageError.Validators._pre_validators:
@@ -177,7 +177,7 @@ class UnexpectedLanguageError(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postunexpected_language_error_validate(
+    def _post_unexpected_language_error_validate(
         cls, values: UnexpectedLanguageError.Partial
     ) -> UnexpectedLanguageError.Partial:
         for validator in UnexpectedLanguageError.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_unexpected_language_error.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_unexpected_language_error.py
@@ -169,7 +169,7 @@ class UnexpectedLanguageError(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_unexpected_language_error_validate(
+    def _pre_validate_unexpected_language_error(
         cls, values: UnexpectedLanguageError.Partial
     ) -> UnexpectedLanguageError.Partial:
         for validator in UnexpectedLanguageError.Validators._pre_validators:
@@ -177,7 +177,7 @@ class UnexpectedLanguageError(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_unexpected_language_error_validate(
+    def _post_validate_unexpected_language_error(
         cls, values: UnexpectedLanguageError.Partial
     ) -> UnexpectedLanguageError.Partial:
         for validator in UnexpectedLanguageError.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_unexpected_language_error.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_unexpected_language_error.py
@@ -169,13 +169,17 @@ class UnexpectedLanguageError(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: UnexpectedLanguageError.Partial) -> UnexpectedLanguageError.Partial:
+    def _preunexpected_language_error_validate(
+        cls, values: UnexpectedLanguageError.Partial
+    ) -> UnexpectedLanguageError.Partial:
         for validator in UnexpectedLanguageError.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: UnexpectedLanguageError.Partial) -> UnexpectedLanguageError.Partial:
+    def _postunexpected_language_error_validate(
+        cls, values: UnexpectedLanguageError.Partial
+    ) -> UnexpectedLanguageError.Partial:
         for validator in UnexpectedLanguageError.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_files.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_files.py
@@ -156,13 +156,13 @@ class WorkspaceFiles(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_workspace_files_validate(cls, values: WorkspaceFiles.Partial) -> WorkspaceFiles.Partial:
+    def _pre_validate_workspace_files(cls, values: WorkspaceFiles.Partial) -> WorkspaceFiles.Partial:
         for validator in WorkspaceFiles.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_workspace_files_validate(cls, values: WorkspaceFiles.Partial) -> WorkspaceFiles.Partial:
+    def _post_validate_workspace_files(cls, values: WorkspaceFiles.Partial) -> WorkspaceFiles.Partial:
         for validator in WorkspaceFiles.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_files.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_files.py
@@ -156,13 +156,13 @@ class WorkspaceFiles(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preworkspace_files_validate(cls, values: WorkspaceFiles.Partial) -> WorkspaceFiles.Partial:
+    def _pre_workspace_files_validate(cls, values: WorkspaceFiles.Partial) -> WorkspaceFiles.Partial:
         for validator in WorkspaceFiles.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postworkspace_files_validate(cls, values: WorkspaceFiles.Partial) -> WorkspaceFiles.Partial:
+    def _post_workspace_files_validate(cls, values: WorkspaceFiles.Partial) -> WorkspaceFiles.Partial:
         for validator in WorkspaceFiles.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_files.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_files.py
@@ -156,13 +156,13 @@ class WorkspaceFiles(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: WorkspaceFiles.Partial) -> WorkspaceFiles.Partial:
+    def _preworkspace_files_validate(cls, values: WorkspaceFiles.Partial) -> WorkspaceFiles.Partial:
         for validator in WorkspaceFiles.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: WorkspaceFiles.Partial) -> WorkspaceFiles.Partial:
+    def _postworkspace_files_validate(cls, values: WorkspaceFiles.Partial) -> WorkspaceFiles.Partial:
         for validator in WorkspaceFiles.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_ran_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_ran_response.py
@@ -166,13 +166,13 @@ class WorkspaceRanResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: WorkspaceRanResponse.Partial) -> WorkspaceRanResponse.Partial:
+    def _preworkspace_ran_response_validate(cls, values: WorkspaceRanResponse.Partial) -> WorkspaceRanResponse.Partial:
         for validator in WorkspaceRanResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: WorkspaceRanResponse.Partial) -> WorkspaceRanResponse.Partial:
+    def _postworkspace_ran_response_validate(cls, values: WorkspaceRanResponse.Partial) -> WorkspaceRanResponse.Partial:
         for validator in WorkspaceRanResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_ran_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_ran_response.py
@@ -166,13 +166,13 @@ class WorkspaceRanResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_workspace_ran_response_validate(cls, values: WorkspaceRanResponse.Partial) -> WorkspaceRanResponse.Partial:
+    def _pre_validate_workspace_ran_response(cls, values: WorkspaceRanResponse.Partial) -> WorkspaceRanResponse.Partial:
         for validator in WorkspaceRanResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_workspace_ran_response_validate(
+    def _post_validate_workspace_ran_response(
         cls, values: WorkspaceRanResponse.Partial
     ) -> WorkspaceRanResponse.Partial:
         for validator in WorkspaceRanResponse.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_ran_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_ran_response.py
@@ -166,13 +166,15 @@ class WorkspaceRanResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preworkspace_ran_response_validate(cls, values: WorkspaceRanResponse.Partial) -> WorkspaceRanResponse.Partial:
+    def _pre_workspace_ran_response_validate(cls, values: WorkspaceRanResponse.Partial) -> WorkspaceRanResponse.Partial:
         for validator in WorkspaceRanResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postworkspace_ran_response_validate(cls, values: WorkspaceRanResponse.Partial) -> WorkspaceRanResponse.Partial:
+    def _post_workspace_ran_response_validate(
+        cls, values: WorkspaceRanResponse.Partial
+    ) -> WorkspaceRanResponse.Partial:
         for validator in WorkspaceRanResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_run_details.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_run_details.py
@@ -205,13 +205,13 @@ class WorkspaceRunDetails(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preworkspace_run_details_validate(cls, values: WorkspaceRunDetails.Partial) -> WorkspaceRunDetails.Partial:
+    def _pre_workspace_run_details_validate(cls, values: WorkspaceRunDetails.Partial) -> WorkspaceRunDetails.Partial:
         for validator in WorkspaceRunDetails.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postworkspace_run_details_validate(cls, values: WorkspaceRunDetails.Partial) -> WorkspaceRunDetails.Partial:
+    def _post_workspace_run_details_validate(cls, values: WorkspaceRunDetails.Partial) -> WorkspaceRunDetails.Partial:
         for validator in WorkspaceRunDetails.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_run_details.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_run_details.py
@@ -205,13 +205,13 @@ class WorkspaceRunDetails(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_workspace_run_details_validate(cls, values: WorkspaceRunDetails.Partial) -> WorkspaceRunDetails.Partial:
+    def _pre_validate_workspace_run_details(cls, values: WorkspaceRunDetails.Partial) -> WorkspaceRunDetails.Partial:
         for validator in WorkspaceRunDetails.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_workspace_run_details_validate(cls, values: WorkspaceRunDetails.Partial) -> WorkspaceRunDetails.Partial:
+    def _post_validate_workspace_run_details(cls, values: WorkspaceRunDetails.Partial) -> WorkspaceRunDetails.Partial:
         for validator in WorkspaceRunDetails.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_run_details.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_run_details.py
@@ -205,13 +205,13 @@ class WorkspaceRunDetails(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: WorkspaceRunDetails.Partial) -> WorkspaceRunDetails.Partial:
+    def _preworkspace_run_details_validate(cls, values: WorkspaceRunDetails.Partial) -> WorkspaceRunDetails.Partial:
         for validator in WorkspaceRunDetails.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: WorkspaceRunDetails.Partial) -> WorkspaceRunDetails.Partial:
+    def _postworkspace_run_details_validate(cls, values: WorkspaceRunDetails.Partial) -> WorkspaceRunDetails.Partial:
         for validator in WorkspaceRunDetails.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_starter_files_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_starter_files_response.py
@@ -125,7 +125,7 @@ class WorkspaceStarterFilesResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_workspace_starter_files_response_validate(
+    def _pre_validate_workspace_starter_files_response(
         cls, values: WorkspaceStarterFilesResponse.Partial
     ) -> WorkspaceStarterFilesResponse.Partial:
         for validator in WorkspaceStarterFilesResponse.Validators._pre_validators:
@@ -133,7 +133,7 @@ class WorkspaceStarterFilesResponse(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_workspace_starter_files_response_validate(
+    def _post_validate_workspace_starter_files_response(
         cls, values: WorkspaceStarterFilesResponse.Partial
     ) -> WorkspaceStarterFilesResponse.Partial:
         for validator in WorkspaceStarterFilesResponse.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_starter_files_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_starter_files_response.py
@@ -125,13 +125,17 @@ class WorkspaceStarterFilesResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: WorkspaceStarterFilesResponse.Partial) -> WorkspaceStarterFilesResponse.Partial:
+    def _preworkspace_starter_files_response_validate(
+        cls, values: WorkspaceStarterFilesResponse.Partial
+    ) -> WorkspaceStarterFilesResponse.Partial:
         for validator in WorkspaceStarterFilesResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: WorkspaceStarterFilesResponse.Partial) -> WorkspaceStarterFilesResponse.Partial:
+    def _postworkspace_starter_files_response_validate(
+        cls, values: WorkspaceStarterFilesResponse.Partial
+    ) -> WorkspaceStarterFilesResponse.Partial:
         for validator in WorkspaceStarterFilesResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_starter_files_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_starter_files_response.py
@@ -125,7 +125,7 @@ class WorkspaceStarterFilesResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preworkspace_starter_files_response_validate(
+    def _pre_workspace_starter_files_response_validate(
         cls, values: WorkspaceStarterFilesResponse.Partial
     ) -> WorkspaceStarterFilesResponse.Partial:
         for validator in WorkspaceStarterFilesResponse.Validators._pre_validators:
@@ -133,7 +133,7 @@ class WorkspaceStarterFilesResponse(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postworkspace_starter_files_response_validate(
+    def _post_workspace_starter_files_response_validate(
         cls, values: WorkspaceStarterFilesResponse.Partial
     ) -> WorkspaceStarterFilesResponse.Partial:
         for validator in WorkspaceStarterFilesResponse.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_starter_files_response_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_starter_files_response_v_2.py
@@ -128,7 +128,7 @@ class WorkspaceStarterFilesResponseV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_workspace_starter_files_response_v_2_validate(
+    def _pre_validate_workspace_starter_files_response_v_2(
         cls, values: WorkspaceStarterFilesResponseV2.Partial
     ) -> WorkspaceStarterFilesResponseV2.Partial:
         for validator in WorkspaceStarterFilesResponseV2.Validators._pre_validators:
@@ -136,7 +136,7 @@ class WorkspaceStarterFilesResponseV2(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_workspace_starter_files_response_v_2_validate(
+    def _post_validate_workspace_starter_files_response_v_2(
         cls, values: WorkspaceStarterFilesResponseV2.Partial
     ) -> WorkspaceStarterFilesResponseV2.Partial:
         for validator in WorkspaceStarterFilesResponseV2.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_starter_files_response_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_starter_files_response_v_2.py
@@ -128,13 +128,17 @@ class WorkspaceStarterFilesResponseV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: WorkspaceStarterFilesResponseV2.Partial) -> WorkspaceStarterFilesResponseV2.Partial:
+    def _preworkspace_starter_files_response_v_2_validate(
+        cls, values: WorkspaceStarterFilesResponseV2.Partial
+    ) -> WorkspaceStarterFilesResponseV2.Partial:
         for validator in WorkspaceStarterFilesResponseV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: WorkspaceStarterFilesResponseV2.Partial) -> WorkspaceStarterFilesResponseV2.Partial:
+    def _postworkspace_starter_files_response_v_2_validate(
+        cls, values: WorkspaceStarterFilesResponseV2.Partial
+    ) -> WorkspaceStarterFilesResponseV2.Partial:
         for validator in WorkspaceStarterFilesResponseV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_starter_files_response_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_starter_files_response_v_2.py
@@ -128,7 +128,7 @@ class WorkspaceStarterFilesResponseV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preworkspace_starter_files_response_v_2_validate(
+    def _pre_workspace_starter_files_response_v_2_validate(
         cls, values: WorkspaceStarterFilesResponseV2.Partial
     ) -> WorkspaceStarterFilesResponseV2.Partial:
         for validator in WorkspaceStarterFilesResponseV2.Validators._pre_validators:
@@ -136,7 +136,7 @@ class WorkspaceStarterFilesResponseV2(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postworkspace_starter_files_response_v_2_validate(
+    def _post_workspace_starter_files_response_v_2_validate(
         cls, values: WorkspaceStarterFilesResponseV2.Partial
     ) -> WorkspaceStarterFilesResponseV2.Partial:
         for validator in WorkspaceStarterFilesResponseV2.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_submission_state.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_submission_state.py
@@ -118,13 +118,17 @@ class WorkspaceSubmissionState(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: WorkspaceSubmissionState.Partial) -> WorkspaceSubmissionState.Partial:
+    def _preworkspace_submission_state_validate(
+        cls, values: WorkspaceSubmissionState.Partial
+    ) -> WorkspaceSubmissionState.Partial:
         for validator in WorkspaceSubmissionState.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: WorkspaceSubmissionState.Partial) -> WorkspaceSubmissionState.Partial:
+    def _postworkspace_submission_state_validate(
+        cls, values: WorkspaceSubmissionState.Partial
+    ) -> WorkspaceSubmissionState.Partial:
         for validator in WorkspaceSubmissionState.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_submission_state.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_submission_state.py
@@ -118,7 +118,7 @@ class WorkspaceSubmissionState(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_workspace_submission_state_validate(
+    def _pre_validate_workspace_submission_state(
         cls, values: WorkspaceSubmissionState.Partial
     ) -> WorkspaceSubmissionState.Partial:
         for validator in WorkspaceSubmissionState.Validators._pre_validators:
@@ -126,7 +126,7 @@ class WorkspaceSubmissionState(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_workspace_submission_state_validate(
+    def _post_validate_workspace_submission_state(
         cls, values: WorkspaceSubmissionState.Partial
     ) -> WorkspaceSubmissionState.Partial:
         for validator in WorkspaceSubmissionState.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_submission_state.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_submission_state.py
@@ -118,7 +118,7 @@ class WorkspaceSubmissionState(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preworkspace_submission_state_validate(
+    def _pre_workspace_submission_state_validate(
         cls, values: WorkspaceSubmissionState.Partial
     ) -> WorkspaceSubmissionState.Partial:
         for validator in WorkspaceSubmissionState.Validators._pre_validators:
@@ -126,7 +126,7 @@ class WorkspaceSubmissionState(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postworkspace_submission_state_validate(
+    def _post_workspace_submission_state_validate(
         cls, values: WorkspaceSubmissionState.Partial
     ) -> WorkspaceSubmissionState.Partial:
         for validator in WorkspaceSubmissionState.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_submission_status_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_submission_status_v_2.py
@@ -122,13 +122,17 @@ class WorkspaceSubmissionStatusV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: WorkspaceSubmissionStatusV2.Partial) -> WorkspaceSubmissionStatusV2.Partial:
+    def _preworkspace_submission_status_v_2_validate(
+        cls, values: WorkspaceSubmissionStatusV2.Partial
+    ) -> WorkspaceSubmissionStatusV2.Partial:
         for validator in WorkspaceSubmissionStatusV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: WorkspaceSubmissionStatusV2.Partial) -> WorkspaceSubmissionStatusV2.Partial:
+    def _postworkspace_submission_status_v_2_validate(
+        cls, values: WorkspaceSubmissionStatusV2.Partial
+    ) -> WorkspaceSubmissionStatusV2.Partial:
         for validator in WorkspaceSubmissionStatusV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_submission_status_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_submission_status_v_2.py
@@ -122,7 +122,7 @@ class WorkspaceSubmissionStatusV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preworkspace_submission_status_v_2_validate(
+    def _pre_workspace_submission_status_v_2_validate(
         cls, values: WorkspaceSubmissionStatusV2.Partial
     ) -> WorkspaceSubmissionStatusV2.Partial:
         for validator in WorkspaceSubmissionStatusV2.Validators._pre_validators:
@@ -130,7 +130,7 @@ class WorkspaceSubmissionStatusV2(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postworkspace_submission_status_v_2_validate(
+    def _post_workspace_submission_status_v_2_validate(
         cls, values: WorkspaceSubmissionStatusV2.Partial
     ) -> WorkspaceSubmissionStatusV2.Partial:
         for validator in WorkspaceSubmissionStatusV2.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_submission_status_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_submission_status_v_2.py
@@ -122,7 +122,7 @@ class WorkspaceSubmissionStatusV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_workspace_submission_status_v_2_validate(
+    def _pre_validate_workspace_submission_status_v_2(
         cls, values: WorkspaceSubmissionStatusV2.Partial
     ) -> WorkspaceSubmissionStatusV2.Partial:
         for validator in WorkspaceSubmissionStatusV2.Validators._pre_validators:
@@ -130,7 +130,7 @@ class WorkspaceSubmissionStatusV2(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_workspace_submission_status_v_2_validate(
+    def _post_validate_workspace_submission_status_v_2(
         cls, values: WorkspaceSubmissionStatusV2.Partial
     ) -> WorkspaceSubmissionStatusV2.Partial:
         for validator in WorkspaceSubmissionStatusV2.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_submission_update.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_submission_update.py
@@ -166,13 +166,17 @@ class WorkspaceSubmissionUpdate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: WorkspaceSubmissionUpdate.Partial) -> WorkspaceSubmissionUpdate.Partial:
+    def _preworkspace_submission_update_validate(
+        cls, values: WorkspaceSubmissionUpdate.Partial
+    ) -> WorkspaceSubmissionUpdate.Partial:
         for validator in WorkspaceSubmissionUpdate.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: WorkspaceSubmissionUpdate.Partial) -> WorkspaceSubmissionUpdate.Partial:
+    def _postworkspace_submission_update_validate(
+        cls, values: WorkspaceSubmissionUpdate.Partial
+    ) -> WorkspaceSubmissionUpdate.Partial:
         for validator in WorkspaceSubmissionUpdate.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_submission_update.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_submission_update.py
@@ -166,7 +166,7 @@ class WorkspaceSubmissionUpdate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preworkspace_submission_update_validate(
+    def _pre_workspace_submission_update_validate(
         cls, values: WorkspaceSubmissionUpdate.Partial
     ) -> WorkspaceSubmissionUpdate.Partial:
         for validator in WorkspaceSubmissionUpdate.Validators._pre_validators:
@@ -174,7 +174,7 @@ class WorkspaceSubmissionUpdate(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postworkspace_submission_update_validate(
+    def _post_workspace_submission_update_validate(
         cls, values: WorkspaceSubmissionUpdate.Partial
     ) -> WorkspaceSubmissionUpdate.Partial:
         for validator in WorkspaceSubmissionUpdate.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_submission_update.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_submission_update.py
@@ -166,7 +166,7 @@ class WorkspaceSubmissionUpdate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_workspace_submission_update_validate(
+    def _pre_validate_workspace_submission_update(
         cls, values: WorkspaceSubmissionUpdate.Partial
     ) -> WorkspaceSubmissionUpdate.Partial:
         for validator in WorkspaceSubmissionUpdate.Validators._pre_validators:
@@ -174,7 +174,7 @@ class WorkspaceSubmissionUpdate(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_workspace_submission_update_validate(
+    def _post_validate_workspace_submission_update(
         cls, values: WorkspaceSubmissionUpdate.Partial
     ) -> WorkspaceSubmissionUpdate.Partial:
         for validator in WorkspaceSubmissionUpdate.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_submit_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_submit_request.py
@@ -258,7 +258,7 @@ class WorkspaceSubmitRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preworkspace_submit_request_validate(
+    def _pre_workspace_submit_request_validate(
         cls, values: WorkspaceSubmitRequest.Partial
     ) -> WorkspaceSubmitRequest.Partial:
         for validator in WorkspaceSubmitRequest.Validators._pre_validators:
@@ -266,7 +266,7 @@ class WorkspaceSubmitRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postworkspace_submit_request_validate(
+    def _post_workspace_submit_request_validate(
         cls, values: WorkspaceSubmitRequest.Partial
     ) -> WorkspaceSubmitRequest.Partial:
         for validator in WorkspaceSubmitRequest.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_submit_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_submit_request.py
@@ -258,13 +258,17 @@ class WorkspaceSubmitRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: WorkspaceSubmitRequest.Partial) -> WorkspaceSubmitRequest.Partial:
+    def _preworkspace_submit_request_validate(
+        cls, values: WorkspaceSubmitRequest.Partial
+    ) -> WorkspaceSubmitRequest.Partial:
         for validator in WorkspaceSubmitRequest.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: WorkspaceSubmitRequest.Partial) -> WorkspaceSubmitRequest.Partial:
+    def _postworkspace_submit_request_validate(
+        cls, values: WorkspaceSubmitRequest.Partial
+    ) -> WorkspaceSubmitRequest.Partial:
         for validator in WorkspaceSubmitRequest.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_submit_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_submit_request.py
@@ -258,7 +258,7 @@ class WorkspaceSubmitRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_workspace_submit_request_validate(
+    def _pre_validate_workspace_submit_request(
         cls, values: WorkspaceSubmitRequest.Partial
     ) -> WorkspaceSubmitRequest.Partial:
         for validator in WorkspaceSubmitRequest.Validators._pre_validators:
@@ -266,7 +266,7 @@ class WorkspaceSubmitRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_workspace_submit_request_validate(
+    def _post_validate_workspace_submit_request(
         cls, values: WorkspaceSubmitRequest.Partial
     ) -> WorkspaceSubmitRequest.Partial:
         for validator in WorkspaceSubmitRequest.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_traced_update.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_traced_update.py
@@ -120,13 +120,17 @@ class WorkspaceTracedUpdate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: WorkspaceTracedUpdate.Partial) -> WorkspaceTracedUpdate.Partial:
+    def _preworkspace_traced_update_validate(
+        cls, values: WorkspaceTracedUpdate.Partial
+    ) -> WorkspaceTracedUpdate.Partial:
         for validator in WorkspaceTracedUpdate.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: WorkspaceTracedUpdate.Partial) -> WorkspaceTracedUpdate.Partial:
+    def _postworkspace_traced_update_validate(
+        cls, values: WorkspaceTracedUpdate.Partial
+    ) -> WorkspaceTracedUpdate.Partial:
         for validator in WorkspaceTracedUpdate.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_traced_update.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_traced_update.py
@@ -120,7 +120,7 @@ class WorkspaceTracedUpdate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _preworkspace_traced_update_validate(
+    def _pre_workspace_traced_update_validate(
         cls, values: WorkspaceTracedUpdate.Partial
     ) -> WorkspaceTracedUpdate.Partial:
         for validator in WorkspaceTracedUpdate.Validators._pre_validators:
@@ -128,7 +128,7 @@ class WorkspaceTracedUpdate(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postworkspace_traced_update_validate(
+    def _post_workspace_traced_update_validate(
         cls, values: WorkspaceTracedUpdate.Partial
     ) -> WorkspaceTracedUpdate.Partial:
         for validator in WorkspaceTracedUpdate.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_traced_update.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_submission_workspace_traced_update.py
@@ -120,7 +120,7 @@ class WorkspaceTracedUpdate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_workspace_traced_update_validate(
+    def _pre_validate_workspace_traced_update(
         cls, values: WorkspaceTracedUpdate.Partial
     ) -> WorkspaceTracedUpdate.Partial:
         for validator in WorkspaceTracedUpdate.Validators._pre_validators:
@@ -128,7 +128,7 @@ class WorkspaceTracedUpdate(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_workspace_traced_update_validate(
+    def _post_validate_workspace_traced_update(
         cls, values: WorkspaceTracedUpdate.Partial
     ) -> WorkspaceTracedUpdate.Partial:
         for validator in WorkspaceTracedUpdate.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_basic_custom_files.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_basic_custom_files.py
@@ -256,13 +256,13 @@ class BasicCustomFiles(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
+    def _prev_2_basic_custom_files_validate(cls, values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
         for validator in BasicCustomFiles.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
+    def _postv_2_basic_custom_files_validate(cls, values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
         for validator in BasicCustomFiles.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_basic_custom_files.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_basic_custom_files.py
@@ -256,13 +256,13 @@ class BasicCustomFiles(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_basic_custom_files_validate(cls, values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
+    def _pre_validate_v_2_basic_custom_files(cls, values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
         for validator in BasicCustomFiles.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_basic_custom_files_validate(cls, values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
+    def _post_validate_v_2_basic_custom_files(cls, values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
         for validator in BasicCustomFiles.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_basic_custom_files.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_basic_custom_files.py
@@ -256,13 +256,13 @@ class BasicCustomFiles(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_basic_custom_files_validate(cls, values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
+    def _pre_v_2_basic_custom_files_validate(cls, values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
         for validator in BasicCustomFiles.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_basic_custom_files_validate(cls, values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
+    def _post_v_2_basic_custom_files_validate(cls, values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
         for validator in BasicCustomFiles.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_basic_test_case_template.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_basic_test_case_template.py
@@ -256,7 +256,7 @@ class BasicTestCaseTemplate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_basic_test_case_template_validate(
+    def _pre_v_2_basic_test_case_template_validate(
         cls, values: BasicTestCaseTemplate.Partial
     ) -> BasicTestCaseTemplate.Partial:
         for validator in BasicTestCaseTemplate.Validators._pre_validators:
@@ -264,7 +264,7 @@ class BasicTestCaseTemplate(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_basic_test_case_template_validate(
+    def _post_v_2_basic_test_case_template_validate(
         cls, values: BasicTestCaseTemplate.Partial
     ) -> BasicTestCaseTemplate.Partial:
         for validator in BasicTestCaseTemplate.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_basic_test_case_template.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_basic_test_case_template.py
@@ -256,13 +256,17 @@ class BasicTestCaseTemplate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: BasicTestCaseTemplate.Partial) -> BasicTestCaseTemplate.Partial:
+    def _prev_2_basic_test_case_template_validate(
+        cls, values: BasicTestCaseTemplate.Partial
+    ) -> BasicTestCaseTemplate.Partial:
         for validator in BasicTestCaseTemplate.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: BasicTestCaseTemplate.Partial) -> BasicTestCaseTemplate.Partial:
+    def _postv_2_basic_test_case_template_validate(
+        cls, values: BasicTestCaseTemplate.Partial
+    ) -> BasicTestCaseTemplate.Partial:
         for validator in BasicTestCaseTemplate.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_basic_test_case_template.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_basic_test_case_template.py
@@ -256,7 +256,7 @@ class BasicTestCaseTemplate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_basic_test_case_template_validate(
+    def _pre_validate_v_2_basic_test_case_template(
         cls, values: BasicTestCaseTemplate.Partial
     ) -> BasicTestCaseTemplate.Partial:
         for validator in BasicTestCaseTemplate.Validators._pre_validators:
@@ -264,7 +264,7 @@ class BasicTestCaseTemplate(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_basic_test_case_template_validate(
+    def _post_validate_v_2_basic_test_case_template(
         cls, values: BasicTestCaseTemplate.Partial
     ) -> BasicTestCaseTemplate.Partial:
         for validator in BasicTestCaseTemplate.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_create_problem_request_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_create_problem_request_v_2.py
@@ -408,7 +408,7 @@ class CreateProblemRequestV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_create_problem_request_v_2_validate(
+    def _pre_validate_v_2_create_problem_request_v_2(
         cls, values: CreateProblemRequestV2.Partial
     ) -> CreateProblemRequestV2.Partial:
         for validator in CreateProblemRequestV2.Validators._pre_validators:
@@ -416,7 +416,7 @@ class CreateProblemRequestV2(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_create_problem_request_v_2_validate(
+    def _post_validate_v_2_create_problem_request_v_2(
         cls, values: CreateProblemRequestV2.Partial
     ) -> CreateProblemRequestV2.Partial:
         for validator in CreateProblemRequestV2.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_create_problem_request_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_create_problem_request_v_2.py
@@ -408,7 +408,7 @@ class CreateProblemRequestV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_create_problem_request_v_2_validate(
+    def _pre_v_2_create_problem_request_v_2_validate(
         cls, values: CreateProblemRequestV2.Partial
     ) -> CreateProblemRequestV2.Partial:
         for validator in CreateProblemRequestV2.Validators._pre_validators:
@@ -416,7 +416,7 @@ class CreateProblemRequestV2(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_create_problem_request_v_2_validate(
+    def _post_v_2_create_problem_request_v_2_validate(
         cls, values: CreateProblemRequestV2.Partial
     ) -> CreateProblemRequestV2.Partial:
         for validator in CreateProblemRequestV2.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_create_problem_request_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_create_problem_request_v_2.py
@@ -408,13 +408,17 @@ class CreateProblemRequestV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: CreateProblemRequestV2.Partial) -> CreateProblemRequestV2.Partial:
+    def _prev_2_create_problem_request_v_2_validate(
+        cls, values: CreateProblemRequestV2.Partial
+    ) -> CreateProblemRequestV2.Partial:
         for validator in CreateProblemRequestV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: CreateProblemRequestV2.Partial) -> CreateProblemRequestV2.Partial:
+    def _postv_2_create_problem_request_v_2_validate(
+        cls, values: CreateProblemRequestV2.Partial
+    ) -> CreateProblemRequestV2.Partial:
         for validator in CreateProblemRequestV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_deep_equality_correctness_check.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_deep_equality_correctness_check.py
@@ -126,13 +126,17 @@ class DeepEqualityCorrectnessCheck(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: DeepEqualityCorrectnessCheck.Partial) -> DeepEqualityCorrectnessCheck.Partial:
+    def _prev_2_deep_equality_correctness_check_validate(
+        cls, values: DeepEqualityCorrectnessCheck.Partial
+    ) -> DeepEqualityCorrectnessCheck.Partial:
         for validator in DeepEqualityCorrectnessCheck.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: DeepEqualityCorrectnessCheck.Partial) -> DeepEqualityCorrectnessCheck.Partial:
+    def _postv_2_deep_equality_correctness_check_validate(
+        cls, values: DeepEqualityCorrectnessCheck.Partial
+    ) -> DeepEqualityCorrectnessCheck.Partial:
         for validator in DeepEqualityCorrectnessCheck.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_deep_equality_correctness_check.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_deep_equality_correctness_check.py
@@ -126,7 +126,7 @@ class DeepEqualityCorrectnessCheck(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_deep_equality_correctness_check_validate(
+    def _pre_validate_v_2_deep_equality_correctness_check(
         cls, values: DeepEqualityCorrectnessCheck.Partial
     ) -> DeepEqualityCorrectnessCheck.Partial:
         for validator in DeepEqualityCorrectnessCheck.Validators._pre_validators:
@@ -134,7 +134,7 @@ class DeepEqualityCorrectnessCheck(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_deep_equality_correctness_check_validate(
+    def _post_validate_v_2_deep_equality_correctness_check(
         cls, values: DeepEqualityCorrectnessCheck.Partial
     ) -> DeepEqualityCorrectnessCheck.Partial:
         for validator in DeepEqualityCorrectnessCheck.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_deep_equality_correctness_check.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_deep_equality_correctness_check.py
@@ -126,7 +126,7 @@ class DeepEqualityCorrectnessCheck(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_deep_equality_correctness_check_validate(
+    def _pre_v_2_deep_equality_correctness_check_validate(
         cls, values: DeepEqualityCorrectnessCheck.Partial
     ) -> DeepEqualityCorrectnessCheck.Partial:
         for validator in DeepEqualityCorrectnessCheck.Validators._pre_validators:
@@ -134,7 +134,7 @@ class DeepEqualityCorrectnessCheck(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_deep_equality_correctness_check_validate(
+    def _post_v_2_deep_equality_correctness_check_validate(
         cls, values: DeepEqualityCorrectnessCheck.Partial
     ) -> DeepEqualityCorrectnessCheck.Partial:
         for validator in DeepEqualityCorrectnessCheck.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_default_provided_file.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_default_provided_file.py
@@ -162,7 +162,7 @@ class DefaultProvidedFile(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_default_provided_file_validate(
+    def _pre_validate_v_2_default_provided_file(
         cls, values: DefaultProvidedFile.Partial
     ) -> DefaultProvidedFile.Partial:
         for validator in DefaultProvidedFile.Validators._pre_validators:
@@ -170,7 +170,7 @@ class DefaultProvidedFile(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_default_provided_file_validate(
+    def _post_validate_v_2_default_provided_file(
         cls, values: DefaultProvidedFile.Partial
     ) -> DefaultProvidedFile.Partial:
         for validator in DefaultProvidedFile.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_default_provided_file.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_default_provided_file.py
@@ -162,13 +162,15 @@ class DefaultProvidedFile(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: DefaultProvidedFile.Partial) -> DefaultProvidedFile.Partial:
+    def _prev_2_default_provided_file_validate(cls, values: DefaultProvidedFile.Partial) -> DefaultProvidedFile.Partial:
         for validator in DefaultProvidedFile.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: DefaultProvidedFile.Partial) -> DefaultProvidedFile.Partial:
+    def _postv_2_default_provided_file_validate(
+        cls, values: DefaultProvidedFile.Partial
+    ) -> DefaultProvidedFile.Partial:
         for validator in DefaultProvidedFile.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_default_provided_file.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_default_provided_file.py
@@ -162,13 +162,15 @@ class DefaultProvidedFile(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_default_provided_file_validate(cls, values: DefaultProvidedFile.Partial) -> DefaultProvidedFile.Partial:
+    def _pre_v_2_default_provided_file_validate(
+        cls, values: DefaultProvidedFile.Partial
+    ) -> DefaultProvidedFile.Partial:
         for validator in DefaultProvidedFile.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_default_provided_file_validate(
+    def _post_v_2_default_provided_file_validate(
         cls, values: DefaultProvidedFile.Partial
     ) -> DefaultProvidedFile.Partial:
         for validator in DefaultProvidedFile.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_file_info_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_file_info_v_2.py
@@ -210,13 +210,13 @@ class FileInfoV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_file_info_v_2_validate(cls, values: FileInfoV2.Partial) -> FileInfoV2.Partial:
+    def _pre_validate_v_2_file_info_v_2(cls, values: FileInfoV2.Partial) -> FileInfoV2.Partial:
         for validator in FileInfoV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_file_info_v_2_validate(cls, values: FileInfoV2.Partial) -> FileInfoV2.Partial:
+    def _post_validate_v_2_file_info_v_2(cls, values: FileInfoV2.Partial) -> FileInfoV2.Partial:
         for validator in FileInfoV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_file_info_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_file_info_v_2.py
@@ -210,13 +210,13 @@ class FileInfoV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_file_info_v_2_validate(cls, values: FileInfoV2.Partial) -> FileInfoV2.Partial:
+    def _pre_v_2_file_info_v_2_validate(cls, values: FileInfoV2.Partial) -> FileInfoV2.Partial:
         for validator in FileInfoV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_file_info_v_2_validate(cls, values: FileInfoV2.Partial) -> FileInfoV2.Partial:
+    def _post_v_2_file_info_v_2_validate(cls, values: FileInfoV2.Partial) -> FileInfoV2.Partial:
         for validator in FileInfoV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_file_info_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_file_info_v_2.py
@@ -210,13 +210,13 @@ class FileInfoV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: FileInfoV2.Partial) -> FileInfoV2.Partial:
+    def _prev_2_file_info_v_2_validate(cls, values: FileInfoV2.Partial) -> FileInfoV2.Partial:
         for validator in FileInfoV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: FileInfoV2.Partial) -> FileInfoV2.Partial:
+    def _postv_2_file_info_v_2_validate(cls, values: FileInfoV2.Partial) -> FileInfoV2.Partial:
         for validator in FileInfoV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_files.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_files.py
@@ -104,13 +104,13 @@ class Files(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_files_validate(cls, values: Files.Partial) -> Files.Partial:
+    def _pre_v_2_files_validate(cls, values: Files.Partial) -> Files.Partial:
         for validator in Files.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_files_validate(cls, values: Files.Partial) -> Files.Partial:
+    def _post_v_2_files_validate(cls, values: Files.Partial) -> Files.Partial:
         for validator in Files.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_files.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_files.py
@@ -104,13 +104,13 @@ class Files(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_files_validate(cls, values: Files.Partial) -> Files.Partial:
+    def _pre_validate_v_2_files(cls, values: Files.Partial) -> Files.Partial:
         for validator in Files.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_files_validate(cls, values: Files.Partial) -> Files.Partial:
+    def _post_validate_v_2_files(cls, values: Files.Partial) -> Files.Partial:
         for validator in Files.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_files.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_files.py
@@ -104,13 +104,13 @@ class Files(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: Files.Partial) -> Files.Partial:
+    def _prev_2_files_validate(cls, values: Files.Partial) -> Files.Partial:
         for validator in Files.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: Files.Partial) -> Files.Partial:
+    def _postv_2_files_validate(cls, values: Files.Partial) -> Files.Partial:
         for validator in Files.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_function_implementation.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_function_implementation.py
@@ -155,13 +155,17 @@ class FunctionImplementation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: FunctionImplementation.Partial) -> FunctionImplementation.Partial:
+    def _prev_2_function_implementation_validate(
+        cls, values: FunctionImplementation.Partial
+    ) -> FunctionImplementation.Partial:
         for validator in FunctionImplementation.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: FunctionImplementation.Partial) -> FunctionImplementation.Partial:
+    def _postv_2_function_implementation_validate(
+        cls, values: FunctionImplementation.Partial
+    ) -> FunctionImplementation.Partial:
         for validator in FunctionImplementation.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_function_implementation.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_function_implementation.py
@@ -155,7 +155,7 @@ class FunctionImplementation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_function_implementation_validate(
+    def _pre_validate_v_2_function_implementation(
         cls, values: FunctionImplementation.Partial
     ) -> FunctionImplementation.Partial:
         for validator in FunctionImplementation.Validators._pre_validators:
@@ -163,7 +163,7 @@ class FunctionImplementation(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_function_implementation_validate(
+    def _post_validate_v_2_function_implementation(
         cls, values: FunctionImplementation.Partial
     ) -> FunctionImplementation.Partial:
         for validator in FunctionImplementation.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_function_implementation.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_function_implementation.py
@@ -155,7 +155,7 @@ class FunctionImplementation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_function_implementation_validate(
+    def _pre_v_2_function_implementation_validate(
         cls, values: FunctionImplementation.Partial
     ) -> FunctionImplementation.Partial:
         for validator in FunctionImplementation.Validators._pre_validators:
@@ -163,7 +163,7 @@ class FunctionImplementation(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_function_implementation_validate(
+    def _post_v_2_function_implementation_validate(
         cls, values: FunctionImplementation.Partial
     ) -> FunctionImplementation.Partial:
         for validator in FunctionImplementation.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_function_implementation_for_multiple_languages.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_function_implementation_for_multiple_languages.py
@@ -136,7 +136,7 @@ class FunctionImplementationForMultipleLanguages(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_function_implementation_for_multiple_languages_validate(
+    def _pre_validate_v_2_function_implementation_for_multiple_languages(
         cls, values: FunctionImplementationForMultipleLanguages.Partial
     ) -> FunctionImplementationForMultipleLanguages.Partial:
         for validator in FunctionImplementationForMultipleLanguages.Validators._pre_validators:
@@ -144,7 +144,7 @@ class FunctionImplementationForMultipleLanguages(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_function_implementation_for_multiple_languages_validate(
+    def _post_validate_v_2_function_implementation_for_multiple_languages(
         cls, values: FunctionImplementationForMultipleLanguages.Partial
     ) -> FunctionImplementationForMultipleLanguages.Partial:
         for validator in FunctionImplementationForMultipleLanguages.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_function_implementation_for_multiple_languages.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_function_implementation_for_multiple_languages.py
@@ -136,7 +136,7 @@ class FunctionImplementationForMultipleLanguages(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(
+    def _prev_2_function_implementation_for_multiple_languages_validate(
         cls, values: FunctionImplementationForMultipleLanguages.Partial
     ) -> FunctionImplementationForMultipleLanguages.Partial:
         for validator in FunctionImplementationForMultipleLanguages.Validators._pre_validators:
@@ -144,7 +144,7 @@ class FunctionImplementationForMultipleLanguages(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(
+    def _postv_2_function_implementation_for_multiple_languages_validate(
         cls, values: FunctionImplementationForMultipleLanguages.Partial
     ) -> FunctionImplementationForMultipleLanguages.Partial:
         for validator in FunctionImplementationForMultipleLanguages.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_function_implementation_for_multiple_languages.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_function_implementation_for_multiple_languages.py
@@ -136,7 +136,7 @@ class FunctionImplementationForMultipleLanguages(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_function_implementation_for_multiple_languages_validate(
+    def _pre_v_2_function_implementation_for_multiple_languages_validate(
         cls, values: FunctionImplementationForMultipleLanguages.Partial
     ) -> FunctionImplementationForMultipleLanguages.Partial:
         for validator in FunctionImplementationForMultipleLanguages.Validators._pre_validators:
@@ -144,7 +144,7 @@ class FunctionImplementationForMultipleLanguages(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_function_implementation_for_multiple_languages_validate(
+    def _post_v_2_function_implementation_for_multiple_languages_validate(
         cls, values: FunctionImplementationForMultipleLanguages.Partial
     ) -> FunctionImplementationForMultipleLanguages.Partial:
         for validator in FunctionImplementationForMultipleLanguages.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_generated_files.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_generated_files.py
@@ -217,13 +217,13 @@ class GeneratedFiles(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_generated_files_validate(cls, values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
+    def _pre_validate_v_2_generated_files(cls, values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
         for validator in GeneratedFiles.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_generated_files_validate(cls, values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
+    def _post_validate_v_2_generated_files(cls, values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
         for validator in GeneratedFiles.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_generated_files.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_generated_files.py
@@ -217,13 +217,13 @@ class GeneratedFiles(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_generated_files_validate(cls, values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
+    def _pre_v_2_generated_files_validate(cls, values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
         for validator in GeneratedFiles.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_generated_files_validate(cls, values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
+    def _post_v_2_generated_files_validate(cls, values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
         for validator in GeneratedFiles.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_generated_files.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_generated_files.py
@@ -217,13 +217,13 @@ class GeneratedFiles(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
+    def _prev_2_generated_files_validate(cls, values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
         for validator in GeneratedFiles.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
+    def _postv_2_generated_files_validate(cls, values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
         for validator in GeneratedFiles.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_get_basic_solution_file_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_get_basic_solution_file_request.py
@@ -167,7 +167,7 @@ class GetBasicSolutionFileRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_get_basic_solution_file_request_validate(
+    def _pre_validate_v_2_get_basic_solution_file_request(
         cls, values: GetBasicSolutionFileRequest.Partial
     ) -> GetBasicSolutionFileRequest.Partial:
         for validator in GetBasicSolutionFileRequest.Validators._pre_validators:
@@ -175,7 +175,7 @@ class GetBasicSolutionFileRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_get_basic_solution_file_request_validate(
+    def _post_validate_v_2_get_basic_solution_file_request(
         cls, values: GetBasicSolutionFileRequest.Partial
     ) -> GetBasicSolutionFileRequest.Partial:
         for validator in GetBasicSolutionFileRequest.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_get_basic_solution_file_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_get_basic_solution_file_request.py
@@ -167,13 +167,17 @@ class GetBasicSolutionFileRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: GetBasicSolutionFileRequest.Partial) -> GetBasicSolutionFileRequest.Partial:
+    def _prev_2_get_basic_solution_file_request_validate(
+        cls, values: GetBasicSolutionFileRequest.Partial
+    ) -> GetBasicSolutionFileRequest.Partial:
         for validator in GetBasicSolutionFileRequest.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: GetBasicSolutionFileRequest.Partial) -> GetBasicSolutionFileRequest.Partial:
+    def _postv_2_get_basic_solution_file_request_validate(
+        cls, values: GetBasicSolutionFileRequest.Partial
+    ) -> GetBasicSolutionFileRequest.Partial:
         for validator in GetBasicSolutionFileRequest.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_get_basic_solution_file_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_get_basic_solution_file_request.py
@@ -167,7 +167,7 @@ class GetBasicSolutionFileRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_get_basic_solution_file_request_validate(
+    def _pre_v_2_get_basic_solution_file_request_validate(
         cls, values: GetBasicSolutionFileRequest.Partial
     ) -> GetBasicSolutionFileRequest.Partial:
         for validator in GetBasicSolutionFileRequest.Validators._pre_validators:
@@ -175,7 +175,7 @@ class GetBasicSolutionFileRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_get_basic_solution_file_request_validate(
+    def _post_v_2_get_basic_solution_file_request_validate(
         cls, values: GetBasicSolutionFileRequest.Partial
     ) -> GetBasicSolutionFileRequest.Partial:
         for validator in GetBasicSolutionFileRequest.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_get_basic_solution_file_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_get_basic_solution_file_response.py
@@ -129,13 +129,17 @@ class GetBasicSolutionFileResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: GetBasicSolutionFileResponse.Partial) -> GetBasicSolutionFileResponse.Partial:
+    def _prev_2_get_basic_solution_file_response_validate(
+        cls, values: GetBasicSolutionFileResponse.Partial
+    ) -> GetBasicSolutionFileResponse.Partial:
         for validator in GetBasicSolutionFileResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: GetBasicSolutionFileResponse.Partial) -> GetBasicSolutionFileResponse.Partial:
+    def _postv_2_get_basic_solution_file_response_validate(
+        cls, values: GetBasicSolutionFileResponse.Partial
+    ) -> GetBasicSolutionFileResponse.Partial:
         for validator in GetBasicSolutionFileResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_get_basic_solution_file_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_get_basic_solution_file_response.py
@@ -129,7 +129,7 @@ class GetBasicSolutionFileResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_get_basic_solution_file_response_validate(
+    def _pre_v_2_get_basic_solution_file_response_validate(
         cls, values: GetBasicSolutionFileResponse.Partial
     ) -> GetBasicSolutionFileResponse.Partial:
         for validator in GetBasicSolutionFileResponse.Validators._pre_validators:
@@ -137,7 +137,7 @@ class GetBasicSolutionFileResponse(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_get_basic_solution_file_response_validate(
+    def _post_v_2_get_basic_solution_file_response_validate(
         cls, values: GetBasicSolutionFileResponse.Partial
     ) -> GetBasicSolutionFileResponse.Partial:
         for validator in GetBasicSolutionFileResponse.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_get_basic_solution_file_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_get_basic_solution_file_response.py
@@ -129,7 +129,7 @@ class GetBasicSolutionFileResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_get_basic_solution_file_response_validate(
+    def _pre_validate_v_2_get_basic_solution_file_response(
         cls, values: GetBasicSolutionFileResponse.Partial
     ) -> GetBasicSolutionFileResponse.Partial:
         for validator in GetBasicSolutionFileResponse.Validators._pre_validators:
@@ -137,7 +137,7 @@ class GetBasicSolutionFileResponse(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_get_basic_solution_file_response_validate(
+    def _post_validate_v_2_get_basic_solution_file_response(
         cls, values: GetBasicSolutionFileResponse.Partial
     ) -> GetBasicSolutionFileResponse.Partial:
         for validator in GetBasicSolutionFileResponse.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_get_function_signature_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_get_function_signature_request.py
@@ -125,7 +125,7 @@ class GetFunctionSignatureRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_get_function_signature_request_validate(
+    def _pre_validate_v_2_get_function_signature_request(
         cls, values: GetFunctionSignatureRequest.Partial
     ) -> GetFunctionSignatureRequest.Partial:
         for validator in GetFunctionSignatureRequest.Validators._pre_validators:
@@ -133,7 +133,7 @@ class GetFunctionSignatureRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_get_function_signature_request_validate(
+    def _post_validate_v_2_get_function_signature_request(
         cls, values: GetFunctionSignatureRequest.Partial
     ) -> GetFunctionSignatureRequest.Partial:
         for validator in GetFunctionSignatureRequest.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_get_function_signature_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_get_function_signature_request.py
@@ -125,13 +125,17 @@ class GetFunctionSignatureRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: GetFunctionSignatureRequest.Partial) -> GetFunctionSignatureRequest.Partial:
+    def _prev_2_get_function_signature_request_validate(
+        cls, values: GetFunctionSignatureRequest.Partial
+    ) -> GetFunctionSignatureRequest.Partial:
         for validator in GetFunctionSignatureRequest.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: GetFunctionSignatureRequest.Partial) -> GetFunctionSignatureRequest.Partial:
+    def _postv_2_get_function_signature_request_validate(
+        cls, values: GetFunctionSignatureRequest.Partial
+    ) -> GetFunctionSignatureRequest.Partial:
         for validator in GetFunctionSignatureRequest.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_get_function_signature_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_get_function_signature_request.py
@@ -125,7 +125,7 @@ class GetFunctionSignatureRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_get_function_signature_request_validate(
+    def _pre_v_2_get_function_signature_request_validate(
         cls, values: GetFunctionSignatureRequest.Partial
     ) -> GetFunctionSignatureRequest.Partial:
         for validator in GetFunctionSignatureRequest.Validators._pre_validators:
@@ -133,7 +133,7 @@ class GetFunctionSignatureRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_get_function_signature_request_validate(
+    def _post_v_2_get_function_signature_request_validate(
         cls, values: GetFunctionSignatureRequest.Partial
     ) -> GetFunctionSignatureRequest.Partial:
         for validator in GetFunctionSignatureRequest.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_get_function_signature_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_get_function_signature_response.py
@@ -125,7 +125,7 @@ class GetFunctionSignatureResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_get_function_signature_response_validate(
+    def _pre_v_2_get_function_signature_response_validate(
         cls, values: GetFunctionSignatureResponse.Partial
     ) -> GetFunctionSignatureResponse.Partial:
         for validator in GetFunctionSignatureResponse.Validators._pre_validators:
@@ -133,7 +133,7 @@ class GetFunctionSignatureResponse(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_get_function_signature_response_validate(
+    def _post_v_2_get_function_signature_response_validate(
         cls, values: GetFunctionSignatureResponse.Partial
     ) -> GetFunctionSignatureResponse.Partial:
         for validator in GetFunctionSignatureResponse.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_get_function_signature_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_get_function_signature_response.py
@@ -125,7 +125,7 @@ class GetFunctionSignatureResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_get_function_signature_response_validate(
+    def _pre_validate_v_2_get_function_signature_response(
         cls, values: GetFunctionSignatureResponse.Partial
     ) -> GetFunctionSignatureResponse.Partial:
         for validator in GetFunctionSignatureResponse.Validators._pre_validators:
@@ -133,7 +133,7 @@ class GetFunctionSignatureResponse(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_get_function_signature_response_validate(
+    def _post_validate_v_2_get_function_signature_response(
         cls, values: GetFunctionSignatureResponse.Partial
     ) -> GetFunctionSignatureResponse.Partial:
         for validator in GetFunctionSignatureResponse.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_get_function_signature_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_get_function_signature_response.py
@@ -125,13 +125,17 @@ class GetFunctionSignatureResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: GetFunctionSignatureResponse.Partial) -> GetFunctionSignatureResponse.Partial:
+    def _prev_2_get_function_signature_response_validate(
+        cls, values: GetFunctionSignatureResponse.Partial
+    ) -> GetFunctionSignatureResponse.Partial:
         for validator in GetFunctionSignatureResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: GetFunctionSignatureResponse.Partial) -> GetFunctionSignatureResponse.Partial:
+    def _postv_2_get_function_signature_response_validate(
+        cls, values: GetFunctionSignatureResponse.Partial
+    ) -> GetFunctionSignatureResponse.Partial:
         for validator in GetFunctionSignatureResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_get_generated_test_case_file_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_get_generated_test_case_file_request.py
@@ -170,13 +170,17 @@ class GetGeneratedTestCaseFileRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: GetGeneratedTestCaseFileRequest.Partial) -> GetGeneratedTestCaseFileRequest.Partial:
+    def _prev_2_get_generated_test_case_file_request_validate(
+        cls, values: GetGeneratedTestCaseFileRequest.Partial
+    ) -> GetGeneratedTestCaseFileRequest.Partial:
         for validator in GetGeneratedTestCaseFileRequest.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: GetGeneratedTestCaseFileRequest.Partial) -> GetGeneratedTestCaseFileRequest.Partial:
+    def _postv_2_get_generated_test_case_file_request_validate(
+        cls, values: GetGeneratedTestCaseFileRequest.Partial
+    ) -> GetGeneratedTestCaseFileRequest.Partial:
         for validator in GetGeneratedTestCaseFileRequest.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_get_generated_test_case_file_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_get_generated_test_case_file_request.py
@@ -170,7 +170,7 @@ class GetGeneratedTestCaseFileRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_get_generated_test_case_file_request_validate(
+    def _pre_v_2_get_generated_test_case_file_request_validate(
         cls, values: GetGeneratedTestCaseFileRequest.Partial
     ) -> GetGeneratedTestCaseFileRequest.Partial:
         for validator in GetGeneratedTestCaseFileRequest.Validators._pre_validators:
@@ -178,7 +178,7 @@ class GetGeneratedTestCaseFileRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_get_generated_test_case_file_request_validate(
+    def _post_v_2_get_generated_test_case_file_request_validate(
         cls, values: GetGeneratedTestCaseFileRequest.Partial
     ) -> GetGeneratedTestCaseFileRequest.Partial:
         for validator in GetGeneratedTestCaseFileRequest.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_get_generated_test_case_file_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_get_generated_test_case_file_request.py
@@ -170,7 +170,7 @@ class GetGeneratedTestCaseFileRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_get_generated_test_case_file_request_validate(
+    def _pre_validate_v_2_get_generated_test_case_file_request(
         cls, values: GetGeneratedTestCaseFileRequest.Partial
     ) -> GetGeneratedTestCaseFileRequest.Partial:
         for validator in GetGeneratedTestCaseFileRequest.Validators._pre_validators:
@@ -178,7 +178,7 @@ class GetGeneratedTestCaseFileRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_get_generated_test_case_file_request_validate(
+    def _post_validate_v_2_get_generated_test_case_file_request(
         cls, values: GetGeneratedTestCaseFileRequest.Partial
     ) -> GetGeneratedTestCaseFileRequest.Partial:
         for validator in GetGeneratedTestCaseFileRequest.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_get_generated_test_case_template_file_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_get_generated_test_case_template_file_request.py
@@ -130,7 +130,7 @@ class GetGeneratedTestCaseTemplateFileRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(
+    def _prev_2_get_generated_test_case_template_file_request_validate(
         cls, values: GetGeneratedTestCaseTemplateFileRequest.Partial
     ) -> GetGeneratedTestCaseTemplateFileRequest.Partial:
         for validator in GetGeneratedTestCaseTemplateFileRequest.Validators._pre_validators:
@@ -138,7 +138,7 @@ class GetGeneratedTestCaseTemplateFileRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(
+    def _postv_2_get_generated_test_case_template_file_request_validate(
         cls, values: GetGeneratedTestCaseTemplateFileRequest.Partial
     ) -> GetGeneratedTestCaseTemplateFileRequest.Partial:
         for validator in GetGeneratedTestCaseTemplateFileRequest.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_get_generated_test_case_template_file_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_get_generated_test_case_template_file_request.py
@@ -130,7 +130,7 @@ class GetGeneratedTestCaseTemplateFileRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_get_generated_test_case_template_file_request_validate(
+    def _pre_v_2_get_generated_test_case_template_file_request_validate(
         cls, values: GetGeneratedTestCaseTemplateFileRequest.Partial
     ) -> GetGeneratedTestCaseTemplateFileRequest.Partial:
         for validator in GetGeneratedTestCaseTemplateFileRequest.Validators._pre_validators:
@@ -138,7 +138,7 @@ class GetGeneratedTestCaseTemplateFileRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_get_generated_test_case_template_file_request_validate(
+    def _post_v_2_get_generated_test_case_template_file_request_validate(
         cls, values: GetGeneratedTestCaseTemplateFileRequest.Partial
     ) -> GetGeneratedTestCaseTemplateFileRequest.Partial:
         for validator in GetGeneratedTestCaseTemplateFileRequest.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_get_generated_test_case_template_file_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_get_generated_test_case_template_file_request.py
@@ -130,7 +130,7 @@ class GetGeneratedTestCaseTemplateFileRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_get_generated_test_case_template_file_request_validate(
+    def _pre_validate_v_2_get_generated_test_case_template_file_request(
         cls, values: GetGeneratedTestCaseTemplateFileRequest.Partial
     ) -> GetGeneratedTestCaseTemplateFileRequest.Partial:
         for validator in GetGeneratedTestCaseTemplateFileRequest.Validators._pre_validators:
@@ -138,7 +138,7 @@ class GetGeneratedTestCaseTemplateFileRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_get_generated_test_case_template_file_request_validate(
+    def _post_validate_v_2_get_generated_test_case_template_file_request(
         cls, values: GetGeneratedTestCaseTemplateFileRequest.Partial
     ) -> GetGeneratedTestCaseTemplateFileRequest.Partial:
         for validator in GetGeneratedTestCaseTemplateFileRequest.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_lightweight_problem_info_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_lightweight_problem_info_v_2.py
@@ -263,13 +263,17 @@ class LightweightProblemInfoV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: LightweightProblemInfoV2.Partial) -> LightweightProblemInfoV2.Partial:
+    def _prev_2_lightweight_problem_info_v_2_validate(
+        cls, values: LightweightProblemInfoV2.Partial
+    ) -> LightweightProblemInfoV2.Partial:
         for validator in LightweightProblemInfoV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: LightweightProblemInfoV2.Partial) -> LightweightProblemInfoV2.Partial:
+    def _postv_2_lightweight_problem_info_v_2_validate(
+        cls, values: LightweightProblemInfoV2.Partial
+    ) -> LightweightProblemInfoV2.Partial:
         for validator in LightweightProblemInfoV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_lightweight_problem_info_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_lightweight_problem_info_v_2.py
@@ -263,7 +263,7 @@ class LightweightProblemInfoV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_lightweight_problem_info_v_2_validate(
+    def _pre_v_2_lightweight_problem_info_v_2_validate(
         cls, values: LightweightProblemInfoV2.Partial
     ) -> LightweightProblemInfoV2.Partial:
         for validator in LightweightProblemInfoV2.Validators._pre_validators:
@@ -271,7 +271,7 @@ class LightweightProblemInfoV2(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_lightweight_problem_info_v_2_validate(
+    def _post_v_2_lightweight_problem_info_v_2_validate(
         cls, values: LightweightProblemInfoV2.Partial
     ) -> LightweightProblemInfoV2.Partial:
         for validator in LightweightProblemInfoV2.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_lightweight_problem_info_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_lightweight_problem_info_v_2.py
@@ -263,7 +263,7 @@ class LightweightProblemInfoV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_lightweight_problem_info_v_2_validate(
+    def _pre_validate_v_2_lightweight_problem_info_v_2(
         cls, values: LightweightProblemInfoV2.Partial
     ) -> LightweightProblemInfoV2.Partial:
         for validator in LightweightProblemInfoV2.Validators._pre_validators:
@@ -271,7 +271,7 @@ class LightweightProblemInfoV2(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_lightweight_problem_info_v_2_validate(
+    def _post_validate_v_2_lightweight_problem_info_v_2(
         cls, values: LightweightProblemInfoV2.Partial
     ) -> LightweightProblemInfoV2.Partial:
         for validator in LightweightProblemInfoV2.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_non_void_function_definition.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_non_void_function_definition.py
@@ -164,13 +164,17 @@ class NonVoidFunctionDefinition(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: NonVoidFunctionDefinition.Partial) -> NonVoidFunctionDefinition.Partial:
+    def _prev_2_non_void_function_definition_validate(
+        cls, values: NonVoidFunctionDefinition.Partial
+    ) -> NonVoidFunctionDefinition.Partial:
         for validator in NonVoidFunctionDefinition.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: NonVoidFunctionDefinition.Partial) -> NonVoidFunctionDefinition.Partial:
+    def _postv_2_non_void_function_definition_validate(
+        cls, values: NonVoidFunctionDefinition.Partial
+    ) -> NonVoidFunctionDefinition.Partial:
         for validator in NonVoidFunctionDefinition.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_non_void_function_definition.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_non_void_function_definition.py
@@ -164,7 +164,7 @@ class NonVoidFunctionDefinition(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_non_void_function_definition_validate(
+    def _pre_v_2_non_void_function_definition_validate(
         cls, values: NonVoidFunctionDefinition.Partial
     ) -> NonVoidFunctionDefinition.Partial:
         for validator in NonVoidFunctionDefinition.Validators._pre_validators:
@@ -172,7 +172,7 @@ class NonVoidFunctionDefinition(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_non_void_function_definition_validate(
+    def _post_v_2_non_void_function_definition_validate(
         cls, values: NonVoidFunctionDefinition.Partial
     ) -> NonVoidFunctionDefinition.Partial:
         for validator in NonVoidFunctionDefinition.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_non_void_function_definition.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_non_void_function_definition.py
@@ -164,7 +164,7 @@ class NonVoidFunctionDefinition(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_non_void_function_definition_validate(
+    def _pre_validate_v_2_non_void_function_definition(
         cls, values: NonVoidFunctionDefinition.Partial
     ) -> NonVoidFunctionDefinition.Partial:
         for validator in NonVoidFunctionDefinition.Validators._pre_validators:
@@ -172,7 +172,7 @@ class NonVoidFunctionDefinition(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_non_void_function_definition_validate(
+    def _post_validate_v_2_non_void_function_definition(
         cls, values: NonVoidFunctionDefinition.Partial
     ) -> NonVoidFunctionDefinition.Partial:
         for validator in NonVoidFunctionDefinition.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_non_void_function_signature.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_non_void_function_signature.py
@@ -167,7 +167,7 @@ class NonVoidFunctionSignature(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_non_void_function_signature_validate(
+    def _pre_validate_v_2_non_void_function_signature(
         cls, values: NonVoidFunctionSignature.Partial
     ) -> NonVoidFunctionSignature.Partial:
         for validator in NonVoidFunctionSignature.Validators._pre_validators:
@@ -175,7 +175,7 @@ class NonVoidFunctionSignature(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_non_void_function_signature_validate(
+    def _post_validate_v_2_non_void_function_signature(
         cls, values: NonVoidFunctionSignature.Partial
     ) -> NonVoidFunctionSignature.Partial:
         for validator in NonVoidFunctionSignature.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_non_void_function_signature.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_non_void_function_signature.py
@@ -167,7 +167,7 @@ class NonVoidFunctionSignature(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_non_void_function_signature_validate(
+    def _pre_v_2_non_void_function_signature_validate(
         cls, values: NonVoidFunctionSignature.Partial
     ) -> NonVoidFunctionSignature.Partial:
         for validator in NonVoidFunctionSignature.Validators._pre_validators:
@@ -175,7 +175,7 @@ class NonVoidFunctionSignature(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_non_void_function_signature_validate(
+    def _post_v_2_non_void_function_signature_validate(
         cls, values: NonVoidFunctionSignature.Partial
     ) -> NonVoidFunctionSignature.Partial:
         for validator in NonVoidFunctionSignature.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_non_void_function_signature.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_non_void_function_signature.py
@@ -167,13 +167,17 @@ class NonVoidFunctionSignature(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: NonVoidFunctionSignature.Partial) -> NonVoidFunctionSignature.Partial:
+    def _prev_2_non_void_function_signature_validate(
+        cls, values: NonVoidFunctionSignature.Partial
+    ) -> NonVoidFunctionSignature.Partial:
         for validator in NonVoidFunctionSignature.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: NonVoidFunctionSignature.Partial) -> NonVoidFunctionSignature.Partial:
+    def _postv_2_non_void_function_signature_validate(
+        cls, values: NonVoidFunctionSignature.Partial
+    ) -> NonVoidFunctionSignature.Partial:
         for validator in NonVoidFunctionSignature.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_parameter.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_parameter.py
@@ -182,13 +182,13 @@ class Parameter(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_parameter_validate(cls, values: Parameter.Partial) -> Parameter.Partial:
+    def _pre_validate_v_2_parameter(cls, values: Parameter.Partial) -> Parameter.Partial:
         for validator in Parameter.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_parameter_validate(cls, values: Parameter.Partial) -> Parameter.Partial:
+    def _post_validate_v_2_parameter(cls, values: Parameter.Partial) -> Parameter.Partial:
         for validator in Parameter.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_parameter.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_parameter.py
@@ -182,13 +182,13 @@ class Parameter(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: Parameter.Partial) -> Parameter.Partial:
+    def _prev_2_parameter_validate(cls, values: Parameter.Partial) -> Parameter.Partial:
         for validator in Parameter.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: Parameter.Partial) -> Parameter.Partial:
+    def _postv_2_parameter_validate(cls, values: Parameter.Partial) -> Parameter.Partial:
         for validator in Parameter.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_parameter.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_parameter.py
@@ -182,13 +182,13 @@ class Parameter(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_parameter_validate(cls, values: Parameter.Partial) -> Parameter.Partial:
+    def _pre_v_2_parameter_validate(cls, values: Parameter.Partial) -> Parameter.Partial:
         for validator in Parameter.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_parameter_validate(cls, values: Parameter.Partial) -> Parameter.Partial:
+    def _post_v_2_parameter_validate(cls, values: Parameter.Partial) -> Parameter.Partial:
         for validator in Parameter.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_problem_info_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_problem_info_v_2.py
@@ -513,13 +513,13 @@ class ProblemInfoV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_problem_info_v_2_validate(cls, values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
+    def _pre_v_2_problem_info_v_2_validate(cls, values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
         for validator in ProblemInfoV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_problem_info_v_2_validate(cls, values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
+    def _post_v_2_problem_info_v_2_validate(cls, values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
         for validator in ProblemInfoV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_problem_info_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_problem_info_v_2.py
@@ -513,13 +513,13 @@ class ProblemInfoV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_problem_info_v_2_validate(cls, values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
+    def _pre_validate_v_2_problem_info_v_2(cls, values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
         for validator in ProblemInfoV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_problem_info_v_2_validate(cls, values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
+    def _post_validate_v_2_problem_info_v_2(cls, values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
         for validator in ProblemInfoV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_problem_info_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_problem_info_v_2.py
@@ -513,13 +513,13 @@ class ProblemInfoV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
+    def _prev_2_problem_info_v_2_validate(cls, values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
         for validator in ProblemInfoV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
+    def _postv_2_problem_info_v_2_validate(cls, values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
         for validator in ProblemInfoV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_test_case_expects.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_test_case_expects.py
@@ -117,13 +117,13 @@ class TestCaseExpects(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
+    def _prev_2_test_case_expects_validate(cls, values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
         for validator in TestCaseExpects.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
+    def _postv_2_test_case_expects_validate(cls, values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
         for validator in TestCaseExpects.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_test_case_expects.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_test_case_expects.py
@@ -117,13 +117,13 @@ class TestCaseExpects(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_test_case_expects_validate(cls, values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
+    def _pre_v_2_test_case_expects_validate(cls, values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
         for validator in TestCaseExpects.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_test_case_expects_validate(cls, values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
+    def _post_v_2_test_case_expects_validate(cls, values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
         for validator in TestCaseExpects.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_test_case_expects.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_test_case_expects.py
@@ -117,13 +117,13 @@ class TestCaseExpects(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_test_case_expects_validate(cls, values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
+    def _pre_validate_v_2_test_case_expects(cls, values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
         for validator in TestCaseExpects.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_test_case_expects_validate(cls, values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
+    def _post_validate_v_2_test_case_expects(cls, values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
         for validator in TestCaseExpects.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_test_case_implementation.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_test_case_implementation.py
@@ -165,7 +165,7 @@ class TestCaseImplementation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_test_case_implementation_validate(
+    def _pre_v_2_test_case_implementation_validate(
         cls, values: TestCaseImplementation.Partial
     ) -> TestCaseImplementation.Partial:
         for validator in TestCaseImplementation.Validators._pre_validators:
@@ -173,7 +173,7 @@ class TestCaseImplementation(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_test_case_implementation_validate(
+    def _post_v_2_test_case_implementation_validate(
         cls, values: TestCaseImplementation.Partial
     ) -> TestCaseImplementation.Partial:
         for validator in TestCaseImplementation.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_test_case_implementation.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_test_case_implementation.py
@@ -165,13 +165,17 @@ class TestCaseImplementation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TestCaseImplementation.Partial) -> TestCaseImplementation.Partial:
+    def _prev_2_test_case_implementation_validate(
+        cls, values: TestCaseImplementation.Partial
+    ) -> TestCaseImplementation.Partial:
         for validator in TestCaseImplementation.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TestCaseImplementation.Partial) -> TestCaseImplementation.Partial:
+    def _postv_2_test_case_implementation_validate(
+        cls, values: TestCaseImplementation.Partial
+    ) -> TestCaseImplementation.Partial:
         for validator in TestCaseImplementation.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_test_case_implementation.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_test_case_implementation.py
@@ -165,7 +165,7 @@ class TestCaseImplementation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_test_case_implementation_validate(
+    def _pre_validate_v_2_test_case_implementation(
         cls, values: TestCaseImplementation.Partial
     ) -> TestCaseImplementation.Partial:
         for validator in TestCaseImplementation.Validators._pre_validators:
@@ -173,7 +173,7 @@ class TestCaseImplementation(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_test_case_implementation_validate(
+    def _post_validate_v_2_test_case_implementation(
         cls, values: TestCaseImplementation.Partial
     ) -> TestCaseImplementation.Partial:
         for validator in TestCaseImplementation.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_test_case_implementation_description.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_test_case_implementation_description.py
@@ -128,7 +128,7 @@ class TestCaseImplementationDescription(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(
+    def _prev_2_test_case_implementation_description_validate(
         cls, values: TestCaseImplementationDescription.Partial
     ) -> TestCaseImplementationDescription.Partial:
         for validator in TestCaseImplementationDescription.Validators._pre_validators:
@@ -136,7 +136,7 @@ class TestCaseImplementationDescription(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(
+    def _postv_2_test_case_implementation_description_validate(
         cls, values: TestCaseImplementationDescription.Partial
     ) -> TestCaseImplementationDescription.Partial:
         for validator in TestCaseImplementationDescription.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_test_case_implementation_description.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_test_case_implementation_description.py
@@ -128,7 +128,7 @@ class TestCaseImplementationDescription(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_test_case_implementation_description_validate(
+    def _pre_v_2_test_case_implementation_description_validate(
         cls, values: TestCaseImplementationDescription.Partial
     ) -> TestCaseImplementationDescription.Partial:
         for validator in TestCaseImplementationDescription.Validators._pre_validators:
@@ -136,7 +136,7 @@ class TestCaseImplementationDescription(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_test_case_implementation_description_validate(
+    def _post_v_2_test_case_implementation_description_validate(
         cls, values: TestCaseImplementationDescription.Partial
     ) -> TestCaseImplementationDescription.Partial:
         for validator in TestCaseImplementationDescription.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_test_case_implementation_description.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_test_case_implementation_description.py
@@ -128,7 +128,7 @@ class TestCaseImplementationDescription(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_test_case_implementation_description_validate(
+    def _pre_validate_v_2_test_case_implementation_description(
         cls, values: TestCaseImplementationDescription.Partial
     ) -> TestCaseImplementationDescription.Partial:
         for validator in TestCaseImplementationDescription.Validators._pre_validators:
@@ -136,7 +136,7 @@ class TestCaseImplementationDescription(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_test_case_implementation_description_validate(
+    def _post_validate_v_2_test_case_implementation_description(
         cls, values: TestCaseImplementationDescription.Partial
     ) -> TestCaseImplementationDescription.Partial:
         for validator in TestCaseImplementationDescription.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_test_case_metadata.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_test_case_metadata.py
@@ -182,13 +182,13 @@ class TestCaseMetadata(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_test_case_metadata_validate(cls, values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
+    def _pre_validate_v_2_test_case_metadata(cls, values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
         for validator in TestCaseMetadata.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_test_case_metadata_validate(cls, values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
+    def _post_validate_v_2_test_case_metadata(cls, values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
         for validator in TestCaseMetadata.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_test_case_metadata.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_test_case_metadata.py
@@ -182,13 +182,13 @@ class TestCaseMetadata(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_test_case_metadata_validate(cls, values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
+    def _pre_v_2_test_case_metadata_validate(cls, values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
         for validator in TestCaseMetadata.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_test_case_metadata_validate(cls, values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
+    def _post_v_2_test_case_metadata_validate(cls, values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
         for validator in TestCaseMetadata.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_test_case_metadata.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_test_case_metadata.py
@@ -182,13 +182,13 @@ class TestCaseMetadata(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
+    def _prev_2_test_case_metadata_validate(cls, values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
         for validator in TestCaseMetadata.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
+    def _postv_2_test_case_metadata_validate(cls, values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
         for validator in TestCaseMetadata.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_test_case_template.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_test_case_template.py
@@ -199,13 +199,13 @@ class TestCaseTemplate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_test_case_template_validate(cls, values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
+    def _pre_v_2_test_case_template_validate(cls, values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
         for validator in TestCaseTemplate.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_test_case_template_validate(cls, values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
+    def _post_v_2_test_case_template_validate(cls, values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
         for validator in TestCaseTemplate.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_test_case_template.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_test_case_template.py
@@ -199,13 +199,13 @@ class TestCaseTemplate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_test_case_template_validate(cls, values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
+    def _pre_validate_v_2_test_case_template(cls, values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
         for validator in TestCaseTemplate.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_test_case_template_validate(cls, values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
+    def _post_validate_v_2_test_case_template(cls, values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
         for validator in TestCaseTemplate.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_test_case_template.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_test_case_template.py
@@ -199,13 +199,13 @@ class TestCaseTemplate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
+    def _prev_2_test_case_template_validate(cls, values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
         for validator in TestCaseTemplate.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
+    def _postv_2_test_case_template_validate(cls, values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
         for validator in TestCaseTemplate.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_test_case_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_test_case_v_2.py
@@ -232,13 +232,13 @@ class TestCaseV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TestCaseV2.Partial) -> TestCaseV2.Partial:
+    def _prev_2_test_case_v_2_validate(cls, values: TestCaseV2.Partial) -> TestCaseV2.Partial:
         for validator in TestCaseV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TestCaseV2.Partial) -> TestCaseV2.Partial:
+    def _postv_2_test_case_v_2_validate(cls, values: TestCaseV2.Partial) -> TestCaseV2.Partial:
         for validator in TestCaseV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_test_case_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_test_case_v_2.py
@@ -232,13 +232,13 @@ class TestCaseV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_test_case_v_2_validate(cls, values: TestCaseV2.Partial) -> TestCaseV2.Partial:
+    def _pre_v_2_test_case_v_2_validate(cls, values: TestCaseV2.Partial) -> TestCaseV2.Partial:
         for validator in TestCaseV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_test_case_v_2_validate(cls, values: TestCaseV2.Partial) -> TestCaseV2.Partial:
+    def _post_v_2_test_case_v_2_validate(cls, values: TestCaseV2.Partial) -> TestCaseV2.Partial:
         for validator in TestCaseV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_test_case_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_test_case_v_2.py
@@ -232,13 +232,13 @@ class TestCaseV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_test_case_v_2_validate(cls, values: TestCaseV2.Partial) -> TestCaseV2.Partial:
+    def _pre_validate_v_2_test_case_v_2(cls, values: TestCaseV2.Partial) -> TestCaseV2.Partial:
         for validator in TestCaseV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_test_case_v_2_validate(cls, values: TestCaseV2.Partial) -> TestCaseV2.Partial:
+    def _post_validate_v_2_test_case_v_2(cls, values: TestCaseV2.Partial) -> TestCaseV2.Partial:
         for validator in TestCaseV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_test_case_with_actual_result_implementation.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_test_case_with_actual_result_implementation.py
@@ -185,7 +185,7 @@ class TestCaseWithActualResultImplementation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(
+    def _prev_2_test_case_with_actual_result_implementation_validate(
         cls, values: TestCaseWithActualResultImplementation.Partial
     ) -> TestCaseWithActualResultImplementation.Partial:
         for validator in TestCaseWithActualResultImplementation.Validators._pre_validators:
@@ -193,7 +193,7 @@ class TestCaseWithActualResultImplementation(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(
+    def _postv_2_test_case_with_actual_result_implementation_validate(
         cls, values: TestCaseWithActualResultImplementation.Partial
     ) -> TestCaseWithActualResultImplementation.Partial:
         for validator in TestCaseWithActualResultImplementation.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_test_case_with_actual_result_implementation.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_test_case_with_actual_result_implementation.py
@@ -185,7 +185,7 @@ class TestCaseWithActualResultImplementation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_test_case_with_actual_result_implementation_validate(
+    def _pre_v_2_test_case_with_actual_result_implementation_validate(
         cls, values: TestCaseWithActualResultImplementation.Partial
     ) -> TestCaseWithActualResultImplementation.Partial:
         for validator in TestCaseWithActualResultImplementation.Validators._pre_validators:
@@ -193,7 +193,7 @@ class TestCaseWithActualResultImplementation(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_test_case_with_actual_result_implementation_validate(
+    def _post_v_2_test_case_with_actual_result_implementation_validate(
         cls, values: TestCaseWithActualResultImplementation.Partial
     ) -> TestCaseWithActualResultImplementation.Partial:
         for validator in TestCaseWithActualResultImplementation.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_test_case_with_actual_result_implementation.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_test_case_with_actual_result_implementation.py
@@ -185,7 +185,7 @@ class TestCaseWithActualResultImplementation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_test_case_with_actual_result_implementation_validate(
+    def _pre_validate_v_2_test_case_with_actual_result_implementation(
         cls, values: TestCaseWithActualResultImplementation.Partial
     ) -> TestCaseWithActualResultImplementation.Partial:
         for validator in TestCaseWithActualResultImplementation.Validators._pre_validators:
@@ -193,7 +193,7 @@ class TestCaseWithActualResultImplementation(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_test_case_with_actual_result_implementation_validate(
+    def _post_validate_v_2_test_case_with_actual_result_implementation(
         cls, values: TestCaseWithActualResultImplementation.Partial
     ) -> TestCaseWithActualResultImplementation.Partial:
         for validator in TestCaseWithActualResultImplementation.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_void_function_definition.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_void_function_definition.py
@@ -162,7 +162,7 @@ class VoidFunctionDefinition(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_void_function_definition_validate(
+    def _pre_v_2_void_function_definition_validate(
         cls, values: VoidFunctionDefinition.Partial
     ) -> VoidFunctionDefinition.Partial:
         for validator in VoidFunctionDefinition.Validators._pre_validators:
@@ -170,7 +170,7 @@ class VoidFunctionDefinition(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_void_function_definition_validate(
+    def _post_v_2_void_function_definition_validate(
         cls, values: VoidFunctionDefinition.Partial
     ) -> VoidFunctionDefinition.Partial:
         for validator in VoidFunctionDefinition.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_void_function_definition.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_void_function_definition.py
@@ -162,13 +162,17 @@ class VoidFunctionDefinition(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: VoidFunctionDefinition.Partial) -> VoidFunctionDefinition.Partial:
+    def _prev_2_void_function_definition_validate(
+        cls, values: VoidFunctionDefinition.Partial
+    ) -> VoidFunctionDefinition.Partial:
         for validator in VoidFunctionDefinition.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: VoidFunctionDefinition.Partial) -> VoidFunctionDefinition.Partial:
+    def _postv_2_void_function_definition_validate(
+        cls, values: VoidFunctionDefinition.Partial
+    ) -> VoidFunctionDefinition.Partial:
         for validator in VoidFunctionDefinition.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_void_function_definition.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_void_function_definition.py
@@ -162,7 +162,7 @@ class VoidFunctionDefinition(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_void_function_definition_validate(
+    def _pre_validate_v_2_void_function_definition(
         cls, values: VoidFunctionDefinition.Partial
     ) -> VoidFunctionDefinition.Partial:
         for validator in VoidFunctionDefinition.Validators._pre_validators:
@@ -170,7 +170,7 @@ class VoidFunctionDefinition(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_void_function_definition_validate(
+    def _post_validate_v_2_void_function_definition(
         cls, values: VoidFunctionDefinition.Partial
     ) -> VoidFunctionDefinition.Partial:
         for validator in VoidFunctionDefinition.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_void_function_definition_that_takes_actual_result.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_void_function_definition_that_takes_actual_result.py
@@ -189,7 +189,7 @@ class VoidFunctionDefinitionThatTakesActualResult(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_void_function_definition_that_takes_actual_result_validate(
+    def _pre_v_2_void_function_definition_that_takes_actual_result_validate(
         cls, values: VoidFunctionDefinitionThatTakesActualResult.Partial
     ) -> VoidFunctionDefinitionThatTakesActualResult.Partial:
         for validator in VoidFunctionDefinitionThatTakesActualResult.Validators._pre_validators:
@@ -197,7 +197,7 @@ class VoidFunctionDefinitionThatTakesActualResult(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_void_function_definition_that_takes_actual_result_validate(
+    def _post_v_2_void_function_definition_that_takes_actual_result_validate(
         cls, values: VoidFunctionDefinitionThatTakesActualResult.Partial
     ) -> VoidFunctionDefinitionThatTakesActualResult.Partial:
         for validator in VoidFunctionDefinitionThatTakesActualResult.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_void_function_definition_that_takes_actual_result.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_void_function_definition_that_takes_actual_result.py
@@ -189,7 +189,7 @@ class VoidFunctionDefinitionThatTakesActualResult(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(
+    def _prev_2_void_function_definition_that_takes_actual_result_validate(
         cls, values: VoidFunctionDefinitionThatTakesActualResult.Partial
     ) -> VoidFunctionDefinitionThatTakesActualResult.Partial:
         for validator in VoidFunctionDefinitionThatTakesActualResult.Validators._pre_validators:
@@ -197,7 +197,7 @@ class VoidFunctionDefinitionThatTakesActualResult(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(
+    def _postv_2_void_function_definition_that_takes_actual_result_validate(
         cls, values: VoidFunctionDefinitionThatTakesActualResult.Partial
     ) -> VoidFunctionDefinitionThatTakesActualResult.Partial:
         for validator in VoidFunctionDefinitionThatTakesActualResult.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_void_function_definition_that_takes_actual_result.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_void_function_definition_that_takes_actual_result.py
@@ -189,7 +189,7 @@ class VoidFunctionDefinitionThatTakesActualResult(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_void_function_definition_that_takes_actual_result_validate(
+    def _pre_validate_v_2_void_function_definition_that_takes_actual_result(
         cls, values: VoidFunctionDefinitionThatTakesActualResult.Partial
     ) -> VoidFunctionDefinitionThatTakesActualResult.Partial:
         for validator in VoidFunctionDefinitionThatTakesActualResult.Validators._pre_validators:
@@ -197,7 +197,7 @@ class VoidFunctionDefinitionThatTakesActualResult(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_void_function_definition_that_takes_actual_result_validate(
+    def _post_validate_v_2_void_function_definition_that_takes_actual_result(
         cls, values: VoidFunctionDefinitionThatTakesActualResult.Partial
     ) -> VoidFunctionDefinitionThatTakesActualResult.Partial:
         for validator in VoidFunctionDefinitionThatTakesActualResult.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_void_function_signature.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_void_function_signature.py
@@ -119,13 +119,17 @@ class VoidFunctionSignature(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: VoidFunctionSignature.Partial) -> VoidFunctionSignature.Partial:
+    def _prev_2_void_function_signature_validate(
+        cls, values: VoidFunctionSignature.Partial
+    ) -> VoidFunctionSignature.Partial:
         for validator in VoidFunctionSignature.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: VoidFunctionSignature.Partial) -> VoidFunctionSignature.Partial:
+    def _postv_2_void_function_signature_validate(
+        cls, values: VoidFunctionSignature.Partial
+    ) -> VoidFunctionSignature.Partial:
         for validator in VoidFunctionSignature.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_void_function_signature.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_void_function_signature.py
@@ -119,7 +119,7 @@ class VoidFunctionSignature(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_void_function_signature_validate(
+    def _pre_v_2_void_function_signature_validate(
         cls, values: VoidFunctionSignature.Partial
     ) -> VoidFunctionSignature.Partial:
         for validator in VoidFunctionSignature.Validators._pre_validators:
@@ -127,7 +127,7 @@ class VoidFunctionSignature(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_void_function_signature_validate(
+    def _post_v_2_void_function_signature_validate(
         cls, values: VoidFunctionSignature.Partial
     ) -> VoidFunctionSignature.Partial:
         for validator in VoidFunctionSignature.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_void_function_signature.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_void_function_signature.py
@@ -119,7 +119,7 @@ class VoidFunctionSignature(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_void_function_signature_validate(
+    def _pre_validate_v_2_void_function_signature(
         cls, values: VoidFunctionSignature.Partial
     ) -> VoidFunctionSignature.Partial:
         for validator in VoidFunctionSignature.Validators._pre_validators:
@@ -127,7 +127,7 @@ class VoidFunctionSignature(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_void_function_signature_validate(
+    def _post_validate_v_2_void_function_signature(
         cls, values: VoidFunctionSignature.Partial
     ) -> VoidFunctionSignature.Partial:
         for validator in VoidFunctionSignature.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_void_function_signature_that_takes_actual_result.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_void_function_signature_that_takes_actual_result.py
@@ -183,7 +183,7 @@ class VoidFunctionSignatureThatTakesActualResult(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(
+    def _prev_2_void_function_signature_that_takes_actual_result_validate(
         cls, values: VoidFunctionSignatureThatTakesActualResult.Partial
     ) -> VoidFunctionSignatureThatTakesActualResult.Partial:
         for validator in VoidFunctionSignatureThatTakesActualResult.Validators._pre_validators:
@@ -191,7 +191,7 @@ class VoidFunctionSignatureThatTakesActualResult(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(
+    def _postv_2_void_function_signature_that_takes_actual_result_validate(
         cls, values: VoidFunctionSignatureThatTakesActualResult.Partial
     ) -> VoidFunctionSignatureThatTakesActualResult.Partial:
         for validator in VoidFunctionSignatureThatTakesActualResult.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_void_function_signature_that_takes_actual_result.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_void_function_signature_that_takes_actual_result.py
@@ -183,7 +183,7 @@ class VoidFunctionSignatureThatTakesActualResult(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_void_function_signature_that_takes_actual_result_validate(
+    def _pre_v_2_void_function_signature_that_takes_actual_result_validate(
         cls, values: VoidFunctionSignatureThatTakesActualResult.Partial
     ) -> VoidFunctionSignatureThatTakesActualResult.Partial:
         for validator in VoidFunctionSignatureThatTakesActualResult.Validators._pre_validators:
@@ -191,7 +191,7 @@ class VoidFunctionSignatureThatTakesActualResult(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_void_function_signature_that_takes_actual_result_validate(
+    def _post_v_2_void_function_signature_that_takes_actual_result_validate(
         cls, values: VoidFunctionSignatureThatTakesActualResult.Partial
     ) -> VoidFunctionSignatureThatTakesActualResult.Partial:
         for validator in VoidFunctionSignatureThatTakesActualResult.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_void_function_signature_that_takes_actual_result.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_problem_void_function_signature_that_takes_actual_result.py
@@ -183,7 +183,7 @@ class VoidFunctionSignatureThatTakesActualResult(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_void_function_signature_that_takes_actual_result_validate(
+    def _pre_validate_v_2_void_function_signature_that_takes_actual_result(
         cls, values: VoidFunctionSignatureThatTakesActualResult.Partial
     ) -> VoidFunctionSignatureThatTakesActualResult.Partial:
         for validator in VoidFunctionSignatureThatTakesActualResult.Validators._pre_validators:
@@ -191,7 +191,7 @@ class VoidFunctionSignatureThatTakesActualResult(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_void_function_signature_that_takes_actual_result_validate(
+    def _post_validate_v_2_void_function_signature_that_takes_actual_result(
         cls, values: VoidFunctionSignatureThatTakesActualResult.Partial
     ) -> VoidFunctionSignatureThatTakesActualResult.Partial:
         for validator in VoidFunctionSignatureThatTakesActualResult.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_basic_custom_files.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_basic_custom_files.py
@@ -256,13 +256,13 @@ class BasicCustomFiles(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
+    def _prev_2_v_3_basic_custom_files_validate(cls, values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
         for validator in BasicCustomFiles.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
+    def _postv_2_v_3_basic_custom_files_validate(cls, values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
         for validator in BasicCustomFiles.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_basic_custom_files.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_basic_custom_files.py
@@ -256,13 +256,13 @@ class BasicCustomFiles(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_basic_custom_files_validate(cls, values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
+    def _pre_v_2_v_3_basic_custom_files_validate(cls, values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
         for validator in BasicCustomFiles.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_basic_custom_files_validate(cls, values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
+    def _post_v_2_v_3_basic_custom_files_validate(cls, values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
         for validator in BasicCustomFiles.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_basic_custom_files.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_basic_custom_files.py
@@ -256,13 +256,13 @@ class BasicCustomFiles(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_basic_custom_files_validate(cls, values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
+    def _pre_validate_v_2_v_3_basic_custom_files(cls, values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
         for validator in BasicCustomFiles.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_basic_custom_files_validate(cls, values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
+    def _post_validate_v_2_v_3_basic_custom_files(cls, values: BasicCustomFiles.Partial) -> BasicCustomFiles.Partial:
         for validator in BasicCustomFiles.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_basic_test_case_template.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_basic_test_case_template.py
@@ -256,13 +256,17 @@ class BasicTestCaseTemplate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: BasicTestCaseTemplate.Partial) -> BasicTestCaseTemplate.Partial:
+    def _prev_2_v_3_basic_test_case_template_validate(
+        cls, values: BasicTestCaseTemplate.Partial
+    ) -> BasicTestCaseTemplate.Partial:
         for validator in BasicTestCaseTemplate.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: BasicTestCaseTemplate.Partial) -> BasicTestCaseTemplate.Partial:
+    def _postv_2_v_3_basic_test_case_template_validate(
+        cls, values: BasicTestCaseTemplate.Partial
+    ) -> BasicTestCaseTemplate.Partial:
         for validator in BasicTestCaseTemplate.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_basic_test_case_template.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_basic_test_case_template.py
@@ -256,7 +256,7 @@ class BasicTestCaseTemplate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_basic_test_case_template_validate(
+    def _pre_v_2_v_3_basic_test_case_template_validate(
         cls, values: BasicTestCaseTemplate.Partial
     ) -> BasicTestCaseTemplate.Partial:
         for validator in BasicTestCaseTemplate.Validators._pre_validators:
@@ -264,7 +264,7 @@ class BasicTestCaseTemplate(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_basic_test_case_template_validate(
+    def _post_v_2_v_3_basic_test_case_template_validate(
         cls, values: BasicTestCaseTemplate.Partial
     ) -> BasicTestCaseTemplate.Partial:
         for validator in BasicTestCaseTemplate.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_basic_test_case_template.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_basic_test_case_template.py
@@ -256,7 +256,7 @@ class BasicTestCaseTemplate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_basic_test_case_template_validate(
+    def _pre_validate_v_2_v_3_basic_test_case_template(
         cls, values: BasicTestCaseTemplate.Partial
     ) -> BasicTestCaseTemplate.Partial:
         for validator in BasicTestCaseTemplate.Validators._pre_validators:
@@ -264,7 +264,7 @@ class BasicTestCaseTemplate(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_basic_test_case_template_validate(
+    def _post_validate_v_2_v_3_basic_test_case_template(
         cls, values: BasicTestCaseTemplate.Partial
     ) -> BasicTestCaseTemplate.Partial:
         for validator in BasicTestCaseTemplate.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_create_problem_request_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_create_problem_request_v_2.py
@@ -408,7 +408,7 @@ class CreateProblemRequestV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_create_problem_request_v_2_validate(
+    def _pre_v_2_v_3_create_problem_request_v_2_validate(
         cls, values: CreateProblemRequestV2.Partial
     ) -> CreateProblemRequestV2.Partial:
         for validator in CreateProblemRequestV2.Validators._pre_validators:
@@ -416,7 +416,7 @@ class CreateProblemRequestV2(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_create_problem_request_v_2_validate(
+    def _post_v_2_v_3_create_problem_request_v_2_validate(
         cls, values: CreateProblemRequestV2.Partial
     ) -> CreateProblemRequestV2.Partial:
         for validator in CreateProblemRequestV2.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_create_problem_request_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_create_problem_request_v_2.py
@@ -408,13 +408,17 @@ class CreateProblemRequestV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: CreateProblemRequestV2.Partial) -> CreateProblemRequestV2.Partial:
+    def _prev_2_v_3_create_problem_request_v_2_validate(
+        cls, values: CreateProblemRequestV2.Partial
+    ) -> CreateProblemRequestV2.Partial:
         for validator in CreateProblemRequestV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: CreateProblemRequestV2.Partial) -> CreateProblemRequestV2.Partial:
+    def _postv_2_v_3_create_problem_request_v_2_validate(
+        cls, values: CreateProblemRequestV2.Partial
+    ) -> CreateProblemRequestV2.Partial:
         for validator in CreateProblemRequestV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_create_problem_request_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_create_problem_request_v_2.py
@@ -408,7 +408,7 @@ class CreateProblemRequestV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_create_problem_request_v_2_validate(
+    def _pre_validate_v_2_v_3_create_problem_request_v_2(
         cls, values: CreateProblemRequestV2.Partial
     ) -> CreateProblemRequestV2.Partial:
         for validator in CreateProblemRequestV2.Validators._pre_validators:
@@ -416,7 +416,7 @@ class CreateProblemRequestV2(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_create_problem_request_v_2_validate(
+    def _post_validate_v_2_v_3_create_problem_request_v_2(
         cls, values: CreateProblemRequestV2.Partial
     ) -> CreateProblemRequestV2.Partial:
         for validator in CreateProblemRequestV2.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_deep_equality_correctness_check.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_deep_equality_correctness_check.py
@@ -126,7 +126,7 @@ class DeepEqualityCorrectnessCheck(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_deep_equality_correctness_check_validate(
+    def _pre_v_2_v_3_deep_equality_correctness_check_validate(
         cls, values: DeepEqualityCorrectnessCheck.Partial
     ) -> DeepEqualityCorrectnessCheck.Partial:
         for validator in DeepEqualityCorrectnessCheck.Validators._pre_validators:
@@ -134,7 +134,7 @@ class DeepEqualityCorrectnessCheck(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_deep_equality_correctness_check_validate(
+    def _post_v_2_v_3_deep_equality_correctness_check_validate(
         cls, values: DeepEqualityCorrectnessCheck.Partial
     ) -> DeepEqualityCorrectnessCheck.Partial:
         for validator in DeepEqualityCorrectnessCheck.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_deep_equality_correctness_check.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_deep_equality_correctness_check.py
@@ -126,7 +126,7 @@ class DeepEqualityCorrectnessCheck(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_deep_equality_correctness_check_validate(
+    def _pre_validate_v_2_v_3_deep_equality_correctness_check(
         cls, values: DeepEqualityCorrectnessCheck.Partial
     ) -> DeepEqualityCorrectnessCheck.Partial:
         for validator in DeepEqualityCorrectnessCheck.Validators._pre_validators:
@@ -134,7 +134,7 @@ class DeepEqualityCorrectnessCheck(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_deep_equality_correctness_check_validate(
+    def _post_validate_v_2_v_3_deep_equality_correctness_check(
         cls, values: DeepEqualityCorrectnessCheck.Partial
     ) -> DeepEqualityCorrectnessCheck.Partial:
         for validator in DeepEqualityCorrectnessCheck.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_deep_equality_correctness_check.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_deep_equality_correctness_check.py
@@ -126,13 +126,17 @@ class DeepEqualityCorrectnessCheck(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: DeepEqualityCorrectnessCheck.Partial) -> DeepEqualityCorrectnessCheck.Partial:
+    def _prev_2_v_3_deep_equality_correctness_check_validate(
+        cls, values: DeepEqualityCorrectnessCheck.Partial
+    ) -> DeepEqualityCorrectnessCheck.Partial:
         for validator in DeepEqualityCorrectnessCheck.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: DeepEqualityCorrectnessCheck.Partial) -> DeepEqualityCorrectnessCheck.Partial:
+    def _postv_2_v_3_deep_equality_correctness_check_validate(
+        cls, values: DeepEqualityCorrectnessCheck.Partial
+    ) -> DeepEqualityCorrectnessCheck.Partial:
         for validator in DeepEqualityCorrectnessCheck.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_default_provided_file.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_default_provided_file.py
@@ -162,7 +162,7 @@ class DefaultProvidedFile(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_default_provided_file_validate(
+    def _pre_validate_v_2_v_3_default_provided_file(
         cls, values: DefaultProvidedFile.Partial
     ) -> DefaultProvidedFile.Partial:
         for validator in DefaultProvidedFile.Validators._pre_validators:
@@ -170,7 +170,7 @@ class DefaultProvidedFile(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_default_provided_file_validate(
+    def _post_validate_v_2_v_3_default_provided_file(
         cls, values: DefaultProvidedFile.Partial
     ) -> DefaultProvidedFile.Partial:
         for validator in DefaultProvidedFile.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_default_provided_file.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_default_provided_file.py
@@ -162,13 +162,17 @@ class DefaultProvidedFile(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: DefaultProvidedFile.Partial) -> DefaultProvidedFile.Partial:
+    def _prev_2_v_3_default_provided_file_validate(
+        cls, values: DefaultProvidedFile.Partial
+    ) -> DefaultProvidedFile.Partial:
         for validator in DefaultProvidedFile.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: DefaultProvidedFile.Partial) -> DefaultProvidedFile.Partial:
+    def _postv_2_v_3_default_provided_file_validate(
+        cls, values: DefaultProvidedFile.Partial
+    ) -> DefaultProvidedFile.Partial:
         for validator in DefaultProvidedFile.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_default_provided_file.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_default_provided_file.py
@@ -162,7 +162,7 @@ class DefaultProvidedFile(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_default_provided_file_validate(
+    def _pre_v_2_v_3_default_provided_file_validate(
         cls, values: DefaultProvidedFile.Partial
     ) -> DefaultProvidedFile.Partial:
         for validator in DefaultProvidedFile.Validators._pre_validators:
@@ -170,7 +170,7 @@ class DefaultProvidedFile(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_default_provided_file_validate(
+    def _post_v_2_v_3_default_provided_file_validate(
         cls, values: DefaultProvidedFile.Partial
     ) -> DefaultProvidedFile.Partial:
         for validator in DefaultProvidedFile.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_file_info_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_file_info_v_2.py
@@ -210,13 +210,13 @@ class FileInfoV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_file_info_v_2_validate(cls, values: FileInfoV2.Partial) -> FileInfoV2.Partial:
+    def _pre_validate_v_2_v_3_file_info_v_2(cls, values: FileInfoV2.Partial) -> FileInfoV2.Partial:
         for validator in FileInfoV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_file_info_v_2_validate(cls, values: FileInfoV2.Partial) -> FileInfoV2.Partial:
+    def _post_validate_v_2_v_3_file_info_v_2(cls, values: FileInfoV2.Partial) -> FileInfoV2.Partial:
         for validator in FileInfoV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_file_info_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_file_info_v_2.py
@@ -210,13 +210,13 @@ class FileInfoV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: FileInfoV2.Partial) -> FileInfoV2.Partial:
+    def _prev_2_v_3_file_info_v_2_validate(cls, values: FileInfoV2.Partial) -> FileInfoV2.Partial:
         for validator in FileInfoV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: FileInfoV2.Partial) -> FileInfoV2.Partial:
+    def _postv_2_v_3_file_info_v_2_validate(cls, values: FileInfoV2.Partial) -> FileInfoV2.Partial:
         for validator in FileInfoV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_file_info_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_file_info_v_2.py
@@ -210,13 +210,13 @@ class FileInfoV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_file_info_v_2_validate(cls, values: FileInfoV2.Partial) -> FileInfoV2.Partial:
+    def _pre_v_2_v_3_file_info_v_2_validate(cls, values: FileInfoV2.Partial) -> FileInfoV2.Partial:
         for validator in FileInfoV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_file_info_v_2_validate(cls, values: FileInfoV2.Partial) -> FileInfoV2.Partial:
+    def _post_v_2_v_3_file_info_v_2_validate(cls, values: FileInfoV2.Partial) -> FileInfoV2.Partial:
         for validator in FileInfoV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_files.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_files.py
@@ -104,13 +104,13 @@ class Files(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: Files.Partial) -> Files.Partial:
+    def _prev_2_v_3_files_validate(cls, values: Files.Partial) -> Files.Partial:
         for validator in Files.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: Files.Partial) -> Files.Partial:
+    def _postv_2_v_3_files_validate(cls, values: Files.Partial) -> Files.Partial:
         for validator in Files.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_files.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_files.py
@@ -104,13 +104,13 @@ class Files(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_files_validate(cls, values: Files.Partial) -> Files.Partial:
+    def _pre_validate_v_2_v_3_files(cls, values: Files.Partial) -> Files.Partial:
         for validator in Files.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_files_validate(cls, values: Files.Partial) -> Files.Partial:
+    def _post_validate_v_2_v_3_files(cls, values: Files.Partial) -> Files.Partial:
         for validator in Files.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_files.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_files.py
@@ -104,13 +104,13 @@ class Files(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_files_validate(cls, values: Files.Partial) -> Files.Partial:
+    def _pre_v_2_v_3_files_validate(cls, values: Files.Partial) -> Files.Partial:
         for validator in Files.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_files_validate(cls, values: Files.Partial) -> Files.Partial:
+    def _post_v_2_v_3_files_validate(cls, values: Files.Partial) -> Files.Partial:
         for validator in Files.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_function_implementation.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_function_implementation.py
@@ -155,7 +155,7 @@ class FunctionImplementation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_function_implementation_validate(
+    def _pre_v_2_v_3_function_implementation_validate(
         cls, values: FunctionImplementation.Partial
     ) -> FunctionImplementation.Partial:
         for validator in FunctionImplementation.Validators._pre_validators:
@@ -163,7 +163,7 @@ class FunctionImplementation(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_function_implementation_validate(
+    def _post_v_2_v_3_function_implementation_validate(
         cls, values: FunctionImplementation.Partial
     ) -> FunctionImplementation.Partial:
         for validator in FunctionImplementation.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_function_implementation.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_function_implementation.py
@@ -155,13 +155,17 @@ class FunctionImplementation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: FunctionImplementation.Partial) -> FunctionImplementation.Partial:
+    def _prev_2_v_3_function_implementation_validate(
+        cls, values: FunctionImplementation.Partial
+    ) -> FunctionImplementation.Partial:
         for validator in FunctionImplementation.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: FunctionImplementation.Partial) -> FunctionImplementation.Partial:
+    def _postv_2_v_3_function_implementation_validate(
+        cls, values: FunctionImplementation.Partial
+    ) -> FunctionImplementation.Partial:
         for validator in FunctionImplementation.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_function_implementation.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_function_implementation.py
@@ -155,7 +155,7 @@ class FunctionImplementation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_function_implementation_validate(
+    def _pre_validate_v_2_v_3_function_implementation(
         cls, values: FunctionImplementation.Partial
     ) -> FunctionImplementation.Partial:
         for validator in FunctionImplementation.Validators._pre_validators:
@@ -163,7 +163,7 @@ class FunctionImplementation(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_function_implementation_validate(
+    def _post_validate_v_2_v_3_function_implementation(
         cls, values: FunctionImplementation.Partial
     ) -> FunctionImplementation.Partial:
         for validator in FunctionImplementation.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_function_implementation_for_multiple_languages.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_function_implementation_for_multiple_languages.py
@@ -136,7 +136,7 @@ class FunctionImplementationForMultipleLanguages(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(
+    def _prev_2_v_3_function_implementation_for_multiple_languages_validate(
         cls, values: FunctionImplementationForMultipleLanguages.Partial
     ) -> FunctionImplementationForMultipleLanguages.Partial:
         for validator in FunctionImplementationForMultipleLanguages.Validators._pre_validators:
@@ -144,7 +144,7 @@ class FunctionImplementationForMultipleLanguages(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(
+    def _postv_2_v_3_function_implementation_for_multiple_languages_validate(
         cls, values: FunctionImplementationForMultipleLanguages.Partial
     ) -> FunctionImplementationForMultipleLanguages.Partial:
         for validator in FunctionImplementationForMultipleLanguages.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_function_implementation_for_multiple_languages.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_function_implementation_for_multiple_languages.py
@@ -136,7 +136,7 @@ class FunctionImplementationForMultipleLanguages(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_function_implementation_for_multiple_languages_validate(
+    def _pre_v_2_v_3_function_implementation_for_multiple_languages_validate(
         cls, values: FunctionImplementationForMultipleLanguages.Partial
     ) -> FunctionImplementationForMultipleLanguages.Partial:
         for validator in FunctionImplementationForMultipleLanguages.Validators._pre_validators:
@@ -144,7 +144,7 @@ class FunctionImplementationForMultipleLanguages(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_function_implementation_for_multiple_languages_validate(
+    def _post_v_2_v_3_function_implementation_for_multiple_languages_validate(
         cls, values: FunctionImplementationForMultipleLanguages.Partial
     ) -> FunctionImplementationForMultipleLanguages.Partial:
         for validator in FunctionImplementationForMultipleLanguages.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_function_implementation_for_multiple_languages.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_function_implementation_for_multiple_languages.py
@@ -136,7 +136,7 @@ class FunctionImplementationForMultipleLanguages(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_function_implementation_for_multiple_languages_validate(
+    def _pre_validate_v_2_v_3_function_implementation_for_multiple_languages(
         cls, values: FunctionImplementationForMultipleLanguages.Partial
     ) -> FunctionImplementationForMultipleLanguages.Partial:
         for validator in FunctionImplementationForMultipleLanguages.Validators._pre_validators:
@@ -144,7 +144,7 @@ class FunctionImplementationForMultipleLanguages(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_function_implementation_for_multiple_languages_validate(
+    def _post_validate_v_2_v_3_function_implementation_for_multiple_languages(
         cls, values: FunctionImplementationForMultipleLanguages.Partial
     ) -> FunctionImplementationForMultipleLanguages.Partial:
         for validator in FunctionImplementationForMultipleLanguages.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_generated_files.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_generated_files.py
@@ -217,13 +217,13 @@ class GeneratedFiles(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
+    def _prev_2_v_3_generated_files_validate(cls, values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
         for validator in GeneratedFiles.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
+    def _postv_2_v_3_generated_files_validate(cls, values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
         for validator in GeneratedFiles.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_generated_files.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_generated_files.py
@@ -217,13 +217,13 @@ class GeneratedFiles(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_generated_files_validate(cls, values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
+    def _pre_v_2_v_3_generated_files_validate(cls, values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
         for validator in GeneratedFiles.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_generated_files_validate(cls, values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
+    def _post_v_2_v_3_generated_files_validate(cls, values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
         for validator in GeneratedFiles.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_generated_files.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_generated_files.py
@@ -217,13 +217,13 @@ class GeneratedFiles(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_generated_files_validate(cls, values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
+    def _pre_validate_v_2_v_3_generated_files(cls, values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
         for validator in GeneratedFiles.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_generated_files_validate(cls, values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
+    def _post_validate_v_2_v_3_generated_files(cls, values: GeneratedFiles.Partial) -> GeneratedFiles.Partial:
         for validator in GeneratedFiles.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_get_basic_solution_file_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_get_basic_solution_file_request.py
@@ -167,7 +167,7 @@ class GetBasicSolutionFileRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_get_basic_solution_file_request_validate(
+    def _pre_v_2_v_3_get_basic_solution_file_request_validate(
         cls, values: GetBasicSolutionFileRequest.Partial
     ) -> GetBasicSolutionFileRequest.Partial:
         for validator in GetBasicSolutionFileRequest.Validators._pre_validators:
@@ -175,7 +175,7 @@ class GetBasicSolutionFileRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_get_basic_solution_file_request_validate(
+    def _post_v_2_v_3_get_basic_solution_file_request_validate(
         cls, values: GetBasicSolutionFileRequest.Partial
     ) -> GetBasicSolutionFileRequest.Partial:
         for validator in GetBasicSolutionFileRequest.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_get_basic_solution_file_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_get_basic_solution_file_request.py
@@ -167,13 +167,17 @@ class GetBasicSolutionFileRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: GetBasicSolutionFileRequest.Partial) -> GetBasicSolutionFileRequest.Partial:
+    def _prev_2_v_3_get_basic_solution_file_request_validate(
+        cls, values: GetBasicSolutionFileRequest.Partial
+    ) -> GetBasicSolutionFileRequest.Partial:
         for validator in GetBasicSolutionFileRequest.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: GetBasicSolutionFileRequest.Partial) -> GetBasicSolutionFileRequest.Partial:
+    def _postv_2_v_3_get_basic_solution_file_request_validate(
+        cls, values: GetBasicSolutionFileRequest.Partial
+    ) -> GetBasicSolutionFileRequest.Partial:
         for validator in GetBasicSolutionFileRequest.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_get_basic_solution_file_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_get_basic_solution_file_request.py
@@ -167,7 +167,7 @@ class GetBasicSolutionFileRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_get_basic_solution_file_request_validate(
+    def _pre_validate_v_2_v_3_get_basic_solution_file_request(
         cls, values: GetBasicSolutionFileRequest.Partial
     ) -> GetBasicSolutionFileRequest.Partial:
         for validator in GetBasicSolutionFileRequest.Validators._pre_validators:
@@ -175,7 +175,7 @@ class GetBasicSolutionFileRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_get_basic_solution_file_request_validate(
+    def _post_validate_v_2_v_3_get_basic_solution_file_request(
         cls, values: GetBasicSolutionFileRequest.Partial
     ) -> GetBasicSolutionFileRequest.Partial:
         for validator in GetBasicSolutionFileRequest.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_get_basic_solution_file_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_get_basic_solution_file_response.py
@@ -129,7 +129,7 @@ class GetBasicSolutionFileResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_get_basic_solution_file_response_validate(
+    def _pre_v_2_v_3_get_basic_solution_file_response_validate(
         cls, values: GetBasicSolutionFileResponse.Partial
     ) -> GetBasicSolutionFileResponse.Partial:
         for validator in GetBasicSolutionFileResponse.Validators._pre_validators:
@@ -137,7 +137,7 @@ class GetBasicSolutionFileResponse(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_get_basic_solution_file_response_validate(
+    def _post_v_2_v_3_get_basic_solution_file_response_validate(
         cls, values: GetBasicSolutionFileResponse.Partial
     ) -> GetBasicSolutionFileResponse.Partial:
         for validator in GetBasicSolutionFileResponse.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_get_basic_solution_file_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_get_basic_solution_file_response.py
@@ -129,7 +129,7 @@ class GetBasicSolutionFileResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_get_basic_solution_file_response_validate(
+    def _pre_validate_v_2_v_3_get_basic_solution_file_response(
         cls, values: GetBasicSolutionFileResponse.Partial
     ) -> GetBasicSolutionFileResponse.Partial:
         for validator in GetBasicSolutionFileResponse.Validators._pre_validators:
@@ -137,7 +137,7 @@ class GetBasicSolutionFileResponse(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_get_basic_solution_file_response_validate(
+    def _post_validate_v_2_v_3_get_basic_solution_file_response(
         cls, values: GetBasicSolutionFileResponse.Partial
     ) -> GetBasicSolutionFileResponse.Partial:
         for validator in GetBasicSolutionFileResponse.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_get_basic_solution_file_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_get_basic_solution_file_response.py
@@ -129,13 +129,17 @@ class GetBasicSolutionFileResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: GetBasicSolutionFileResponse.Partial) -> GetBasicSolutionFileResponse.Partial:
+    def _prev_2_v_3_get_basic_solution_file_response_validate(
+        cls, values: GetBasicSolutionFileResponse.Partial
+    ) -> GetBasicSolutionFileResponse.Partial:
         for validator in GetBasicSolutionFileResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: GetBasicSolutionFileResponse.Partial) -> GetBasicSolutionFileResponse.Partial:
+    def _postv_2_v_3_get_basic_solution_file_response_validate(
+        cls, values: GetBasicSolutionFileResponse.Partial
+    ) -> GetBasicSolutionFileResponse.Partial:
         for validator in GetBasicSolutionFileResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_get_function_signature_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_get_function_signature_request.py
@@ -125,13 +125,17 @@ class GetFunctionSignatureRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: GetFunctionSignatureRequest.Partial) -> GetFunctionSignatureRequest.Partial:
+    def _prev_2_v_3_get_function_signature_request_validate(
+        cls, values: GetFunctionSignatureRequest.Partial
+    ) -> GetFunctionSignatureRequest.Partial:
         for validator in GetFunctionSignatureRequest.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: GetFunctionSignatureRequest.Partial) -> GetFunctionSignatureRequest.Partial:
+    def _postv_2_v_3_get_function_signature_request_validate(
+        cls, values: GetFunctionSignatureRequest.Partial
+    ) -> GetFunctionSignatureRequest.Partial:
         for validator in GetFunctionSignatureRequest.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_get_function_signature_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_get_function_signature_request.py
@@ -125,7 +125,7 @@ class GetFunctionSignatureRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_get_function_signature_request_validate(
+    def _pre_v_2_v_3_get_function_signature_request_validate(
         cls, values: GetFunctionSignatureRequest.Partial
     ) -> GetFunctionSignatureRequest.Partial:
         for validator in GetFunctionSignatureRequest.Validators._pre_validators:
@@ -133,7 +133,7 @@ class GetFunctionSignatureRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_get_function_signature_request_validate(
+    def _post_v_2_v_3_get_function_signature_request_validate(
         cls, values: GetFunctionSignatureRequest.Partial
     ) -> GetFunctionSignatureRequest.Partial:
         for validator in GetFunctionSignatureRequest.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_get_function_signature_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_get_function_signature_request.py
@@ -125,7 +125,7 @@ class GetFunctionSignatureRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_get_function_signature_request_validate(
+    def _pre_validate_v_2_v_3_get_function_signature_request(
         cls, values: GetFunctionSignatureRequest.Partial
     ) -> GetFunctionSignatureRequest.Partial:
         for validator in GetFunctionSignatureRequest.Validators._pre_validators:
@@ -133,7 +133,7 @@ class GetFunctionSignatureRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_get_function_signature_request_validate(
+    def _post_validate_v_2_v_3_get_function_signature_request(
         cls, values: GetFunctionSignatureRequest.Partial
     ) -> GetFunctionSignatureRequest.Partial:
         for validator in GetFunctionSignatureRequest.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_get_function_signature_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_get_function_signature_response.py
@@ -125,13 +125,17 @@ class GetFunctionSignatureResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: GetFunctionSignatureResponse.Partial) -> GetFunctionSignatureResponse.Partial:
+    def _prev_2_v_3_get_function_signature_response_validate(
+        cls, values: GetFunctionSignatureResponse.Partial
+    ) -> GetFunctionSignatureResponse.Partial:
         for validator in GetFunctionSignatureResponse.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: GetFunctionSignatureResponse.Partial) -> GetFunctionSignatureResponse.Partial:
+    def _postv_2_v_3_get_function_signature_response_validate(
+        cls, values: GetFunctionSignatureResponse.Partial
+    ) -> GetFunctionSignatureResponse.Partial:
         for validator in GetFunctionSignatureResponse.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_get_function_signature_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_get_function_signature_response.py
@@ -125,7 +125,7 @@ class GetFunctionSignatureResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_get_function_signature_response_validate(
+    def _pre_validate_v_2_v_3_get_function_signature_response(
         cls, values: GetFunctionSignatureResponse.Partial
     ) -> GetFunctionSignatureResponse.Partial:
         for validator in GetFunctionSignatureResponse.Validators._pre_validators:
@@ -133,7 +133,7 @@ class GetFunctionSignatureResponse(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_get_function_signature_response_validate(
+    def _post_validate_v_2_v_3_get_function_signature_response(
         cls, values: GetFunctionSignatureResponse.Partial
     ) -> GetFunctionSignatureResponse.Partial:
         for validator in GetFunctionSignatureResponse.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_get_function_signature_response.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_get_function_signature_response.py
@@ -125,7 +125,7 @@ class GetFunctionSignatureResponse(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_get_function_signature_response_validate(
+    def _pre_v_2_v_3_get_function_signature_response_validate(
         cls, values: GetFunctionSignatureResponse.Partial
     ) -> GetFunctionSignatureResponse.Partial:
         for validator in GetFunctionSignatureResponse.Validators._pre_validators:
@@ -133,7 +133,7 @@ class GetFunctionSignatureResponse(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_get_function_signature_response_validate(
+    def _post_v_2_v_3_get_function_signature_response_validate(
         cls, values: GetFunctionSignatureResponse.Partial
     ) -> GetFunctionSignatureResponse.Partial:
         for validator in GetFunctionSignatureResponse.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_get_generated_test_case_file_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_get_generated_test_case_file_request.py
@@ -170,13 +170,17 @@ class GetGeneratedTestCaseFileRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: GetGeneratedTestCaseFileRequest.Partial) -> GetGeneratedTestCaseFileRequest.Partial:
+    def _prev_2_v_3_get_generated_test_case_file_request_validate(
+        cls, values: GetGeneratedTestCaseFileRequest.Partial
+    ) -> GetGeneratedTestCaseFileRequest.Partial:
         for validator in GetGeneratedTestCaseFileRequest.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: GetGeneratedTestCaseFileRequest.Partial) -> GetGeneratedTestCaseFileRequest.Partial:
+    def _postv_2_v_3_get_generated_test_case_file_request_validate(
+        cls, values: GetGeneratedTestCaseFileRequest.Partial
+    ) -> GetGeneratedTestCaseFileRequest.Partial:
         for validator in GetGeneratedTestCaseFileRequest.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_get_generated_test_case_file_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_get_generated_test_case_file_request.py
@@ -170,7 +170,7 @@ class GetGeneratedTestCaseFileRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_get_generated_test_case_file_request_validate(
+    def _pre_validate_v_2_v_3_get_generated_test_case_file_request(
         cls, values: GetGeneratedTestCaseFileRequest.Partial
     ) -> GetGeneratedTestCaseFileRequest.Partial:
         for validator in GetGeneratedTestCaseFileRequest.Validators._pre_validators:
@@ -178,7 +178,7 @@ class GetGeneratedTestCaseFileRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_get_generated_test_case_file_request_validate(
+    def _post_validate_v_2_v_3_get_generated_test_case_file_request(
         cls, values: GetGeneratedTestCaseFileRequest.Partial
     ) -> GetGeneratedTestCaseFileRequest.Partial:
         for validator in GetGeneratedTestCaseFileRequest.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_get_generated_test_case_file_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_get_generated_test_case_file_request.py
@@ -170,7 +170,7 @@ class GetGeneratedTestCaseFileRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_get_generated_test_case_file_request_validate(
+    def _pre_v_2_v_3_get_generated_test_case_file_request_validate(
         cls, values: GetGeneratedTestCaseFileRequest.Partial
     ) -> GetGeneratedTestCaseFileRequest.Partial:
         for validator in GetGeneratedTestCaseFileRequest.Validators._pre_validators:
@@ -178,7 +178,7 @@ class GetGeneratedTestCaseFileRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_get_generated_test_case_file_request_validate(
+    def _post_v_2_v_3_get_generated_test_case_file_request_validate(
         cls, values: GetGeneratedTestCaseFileRequest.Partial
     ) -> GetGeneratedTestCaseFileRequest.Partial:
         for validator in GetGeneratedTestCaseFileRequest.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_get_generated_test_case_template_file_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_get_generated_test_case_template_file_request.py
@@ -130,7 +130,7 @@ class GetGeneratedTestCaseTemplateFileRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_get_generated_test_case_template_file_request_validate(
+    def _pre_validate_v_2_v_3_get_generated_test_case_template_file_request(
         cls, values: GetGeneratedTestCaseTemplateFileRequest.Partial
     ) -> GetGeneratedTestCaseTemplateFileRequest.Partial:
         for validator in GetGeneratedTestCaseTemplateFileRequest.Validators._pre_validators:
@@ -138,7 +138,7 @@ class GetGeneratedTestCaseTemplateFileRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_get_generated_test_case_template_file_request_validate(
+    def _post_validate_v_2_v_3_get_generated_test_case_template_file_request(
         cls, values: GetGeneratedTestCaseTemplateFileRequest.Partial
     ) -> GetGeneratedTestCaseTemplateFileRequest.Partial:
         for validator in GetGeneratedTestCaseTemplateFileRequest.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_get_generated_test_case_template_file_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_get_generated_test_case_template_file_request.py
@@ -130,7 +130,7 @@ class GetGeneratedTestCaseTemplateFileRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_get_generated_test_case_template_file_request_validate(
+    def _pre_v_2_v_3_get_generated_test_case_template_file_request_validate(
         cls, values: GetGeneratedTestCaseTemplateFileRequest.Partial
     ) -> GetGeneratedTestCaseTemplateFileRequest.Partial:
         for validator in GetGeneratedTestCaseTemplateFileRequest.Validators._pre_validators:
@@ -138,7 +138,7 @@ class GetGeneratedTestCaseTemplateFileRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_get_generated_test_case_template_file_request_validate(
+    def _post_v_2_v_3_get_generated_test_case_template_file_request_validate(
         cls, values: GetGeneratedTestCaseTemplateFileRequest.Partial
     ) -> GetGeneratedTestCaseTemplateFileRequest.Partial:
         for validator in GetGeneratedTestCaseTemplateFileRequest.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_get_generated_test_case_template_file_request.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_get_generated_test_case_template_file_request.py
@@ -130,7 +130,7 @@ class GetGeneratedTestCaseTemplateFileRequest(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(
+    def _prev_2_v_3_get_generated_test_case_template_file_request_validate(
         cls, values: GetGeneratedTestCaseTemplateFileRequest.Partial
     ) -> GetGeneratedTestCaseTemplateFileRequest.Partial:
         for validator in GetGeneratedTestCaseTemplateFileRequest.Validators._pre_validators:
@@ -138,7 +138,7 @@ class GetGeneratedTestCaseTemplateFileRequest(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(
+    def _postv_2_v_3_get_generated_test_case_template_file_request_validate(
         cls, values: GetGeneratedTestCaseTemplateFileRequest.Partial
     ) -> GetGeneratedTestCaseTemplateFileRequest.Partial:
         for validator in GetGeneratedTestCaseTemplateFileRequest.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_lightweight_problem_info_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_lightweight_problem_info_v_2.py
@@ -263,7 +263,7 @@ class LightweightProblemInfoV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_lightweight_problem_info_v_2_validate(
+    def _pre_v_2_v_3_lightweight_problem_info_v_2_validate(
         cls, values: LightweightProblemInfoV2.Partial
     ) -> LightweightProblemInfoV2.Partial:
         for validator in LightweightProblemInfoV2.Validators._pre_validators:
@@ -271,7 +271,7 @@ class LightweightProblemInfoV2(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_lightweight_problem_info_v_2_validate(
+    def _post_v_2_v_3_lightweight_problem_info_v_2_validate(
         cls, values: LightweightProblemInfoV2.Partial
     ) -> LightweightProblemInfoV2.Partial:
         for validator in LightweightProblemInfoV2.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_lightweight_problem_info_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_lightweight_problem_info_v_2.py
@@ -263,7 +263,7 @@ class LightweightProblemInfoV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_lightweight_problem_info_v_2_validate(
+    def _pre_validate_v_2_v_3_lightweight_problem_info_v_2(
         cls, values: LightweightProblemInfoV2.Partial
     ) -> LightweightProblemInfoV2.Partial:
         for validator in LightweightProblemInfoV2.Validators._pre_validators:
@@ -271,7 +271,7 @@ class LightweightProblemInfoV2(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_lightweight_problem_info_v_2_validate(
+    def _post_validate_v_2_v_3_lightweight_problem_info_v_2(
         cls, values: LightweightProblemInfoV2.Partial
     ) -> LightweightProblemInfoV2.Partial:
         for validator in LightweightProblemInfoV2.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_lightweight_problem_info_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_lightweight_problem_info_v_2.py
@@ -263,13 +263,17 @@ class LightweightProblemInfoV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: LightweightProblemInfoV2.Partial) -> LightweightProblemInfoV2.Partial:
+    def _prev_2_v_3_lightweight_problem_info_v_2_validate(
+        cls, values: LightweightProblemInfoV2.Partial
+    ) -> LightweightProblemInfoV2.Partial:
         for validator in LightweightProblemInfoV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: LightweightProblemInfoV2.Partial) -> LightweightProblemInfoV2.Partial:
+    def _postv_2_v_3_lightweight_problem_info_v_2_validate(
+        cls, values: LightweightProblemInfoV2.Partial
+    ) -> LightweightProblemInfoV2.Partial:
         for validator in LightweightProblemInfoV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_non_void_function_definition.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_non_void_function_definition.py
@@ -164,13 +164,17 @@ class NonVoidFunctionDefinition(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: NonVoidFunctionDefinition.Partial) -> NonVoidFunctionDefinition.Partial:
+    def _prev_2_v_3_non_void_function_definition_validate(
+        cls, values: NonVoidFunctionDefinition.Partial
+    ) -> NonVoidFunctionDefinition.Partial:
         for validator in NonVoidFunctionDefinition.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: NonVoidFunctionDefinition.Partial) -> NonVoidFunctionDefinition.Partial:
+    def _postv_2_v_3_non_void_function_definition_validate(
+        cls, values: NonVoidFunctionDefinition.Partial
+    ) -> NonVoidFunctionDefinition.Partial:
         for validator in NonVoidFunctionDefinition.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_non_void_function_definition.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_non_void_function_definition.py
@@ -164,7 +164,7 @@ class NonVoidFunctionDefinition(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_non_void_function_definition_validate(
+    def _pre_validate_v_2_v_3_non_void_function_definition(
         cls, values: NonVoidFunctionDefinition.Partial
     ) -> NonVoidFunctionDefinition.Partial:
         for validator in NonVoidFunctionDefinition.Validators._pre_validators:
@@ -172,7 +172,7 @@ class NonVoidFunctionDefinition(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_non_void_function_definition_validate(
+    def _post_validate_v_2_v_3_non_void_function_definition(
         cls, values: NonVoidFunctionDefinition.Partial
     ) -> NonVoidFunctionDefinition.Partial:
         for validator in NonVoidFunctionDefinition.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_non_void_function_definition.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_non_void_function_definition.py
@@ -164,7 +164,7 @@ class NonVoidFunctionDefinition(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_non_void_function_definition_validate(
+    def _pre_v_2_v_3_non_void_function_definition_validate(
         cls, values: NonVoidFunctionDefinition.Partial
     ) -> NonVoidFunctionDefinition.Partial:
         for validator in NonVoidFunctionDefinition.Validators._pre_validators:
@@ -172,7 +172,7 @@ class NonVoidFunctionDefinition(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_non_void_function_definition_validate(
+    def _post_v_2_v_3_non_void_function_definition_validate(
         cls, values: NonVoidFunctionDefinition.Partial
     ) -> NonVoidFunctionDefinition.Partial:
         for validator in NonVoidFunctionDefinition.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_non_void_function_signature.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_non_void_function_signature.py
@@ -167,13 +167,17 @@ class NonVoidFunctionSignature(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: NonVoidFunctionSignature.Partial) -> NonVoidFunctionSignature.Partial:
+    def _prev_2_v_3_non_void_function_signature_validate(
+        cls, values: NonVoidFunctionSignature.Partial
+    ) -> NonVoidFunctionSignature.Partial:
         for validator in NonVoidFunctionSignature.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: NonVoidFunctionSignature.Partial) -> NonVoidFunctionSignature.Partial:
+    def _postv_2_v_3_non_void_function_signature_validate(
+        cls, values: NonVoidFunctionSignature.Partial
+    ) -> NonVoidFunctionSignature.Partial:
         for validator in NonVoidFunctionSignature.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_non_void_function_signature.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_non_void_function_signature.py
@@ -167,7 +167,7 @@ class NonVoidFunctionSignature(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_non_void_function_signature_validate(
+    def _pre_v_2_v_3_non_void_function_signature_validate(
         cls, values: NonVoidFunctionSignature.Partial
     ) -> NonVoidFunctionSignature.Partial:
         for validator in NonVoidFunctionSignature.Validators._pre_validators:
@@ -175,7 +175,7 @@ class NonVoidFunctionSignature(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_non_void_function_signature_validate(
+    def _post_v_2_v_3_non_void_function_signature_validate(
         cls, values: NonVoidFunctionSignature.Partial
     ) -> NonVoidFunctionSignature.Partial:
         for validator in NonVoidFunctionSignature.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_non_void_function_signature.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_non_void_function_signature.py
@@ -167,7 +167,7 @@ class NonVoidFunctionSignature(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_non_void_function_signature_validate(
+    def _pre_validate_v_2_v_3_non_void_function_signature(
         cls, values: NonVoidFunctionSignature.Partial
     ) -> NonVoidFunctionSignature.Partial:
         for validator in NonVoidFunctionSignature.Validators._pre_validators:
@@ -175,7 +175,7 @@ class NonVoidFunctionSignature(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_non_void_function_signature_validate(
+    def _post_validate_v_2_v_3_non_void_function_signature(
         cls, values: NonVoidFunctionSignature.Partial
     ) -> NonVoidFunctionSignature.Partial:
         for validator in NonVoidFunctionSignature.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_parameter.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_parameter.py
@@ -182,13 +182,13 @@ class Parameter(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_parameter_validate(cls, values: Parameter.Partial) -> Parameter.Partial:
+    def _pre_validate_v_2_v_3_parameter(cls, values: Parameter.Partial) -> Parameter.Partial:
         for validator in Parameter.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_parameter_validate(cls, values: Parameter.Partial) -> Parameter.Partial:
+    def _post_validate_v_2_v_3_parameter(cls, values: Parameter.Partial) -> Parameter.Partial:
         for validator in Parameter.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_parameter.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_parameter.py
@@ -182,13 +182,13 @@ class Parameter(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: Parameter.Partial) -> Parameter.Partial:
+    def _prev_2_v_3_parameter_validate(cls, values: Parameter.Partial) -> Parameter.Partial:
         for validator in Parameter.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: Parameter.Partial) -> Parameter.Partial:
+    def _postv_2_v_3_parameter_validate(cls, values: Parameter.Partial) -> Parameter.Partial:
         for validator in Parameter.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_parameter.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_parameter.py
@@ -182,13 +182,13 @@ class Parameter(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_parameter_validate(cls, values: Parameter.Partial) -> Parameter.Partial:
+    def _pre_v_2_v_3_parameter_validate(cls, values: Parameter.Partial) -> Parameter.Partial:
         for validator in Parameter.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_parameter_validate(cls, values: Parameter.Partial) -> Parameter.Partial:
+    def _post_v_2_v_3_parameter_validate(cls, values: Parameter.Partial) -> Parameter.Partial:
         for validator in Parameter.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_problem_info_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_problem_info_v_2.py
@@ -513,13 +513,13 @@ class ProblemInfoV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
+    def _prev_2_v_3_problem_info_v_2_validate(cls, values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
         for validator in ProblemInfoV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
+    def _postv_2_v_3_problem_info_v_2_validate(cls, values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
         for validator in ProblemInfoV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_problem_info_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_problem_info_v_2.py
@@ -513,13 +513,13 @@ class ProblemInfoV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_problem_info_v_2_validate(cls, values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
+    def _pre_v_2_v_3_problem_info_v_2_validate(cls, values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
         for validator in ProblemInfoV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_problem_info_v_2_validate(cls, values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
+    def _post_v_2_v_3_problem_info_v_2_validate(cls, values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
         for validator in ProblemInfoV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_problem_info_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_problem_info_v_2.py
@@ -513,13 +513,13 @@ class ProblemInfoV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_problem_info_v_2_validate(cls, values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
+    def _pre_validate_v_2_v_3_problem_info_v_2(cls, values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
         for validator in ProblemInfoV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_problem_info_v_2_validate(cls, values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
+    def _post_validate_v_2_v_3_problem_info_v_2(cls, values: ProblemInfoV2.Partial) -> ProblemInfoV2.Partial:
         for validator in ProblemInfoV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_test_case_expects.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_test_case_expects.py
@@ -117,13 +117,13 @@ class TestCaseExpects(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_test_case_expects_validate(cls, values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
+    def _pre_validate_v_2_v_3_test_case_expects(cls, values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
         for validator in TestCaseExpects.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_test_case_expects_validate(cls, values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
+    def _post_validate_v_2_v_3_test_case_expects(cls, values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
         for validator in TestCaseExpects.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_test_case_expects.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_test_case_expects.py
@@ -117,13 +117,13 @@ class TestCaseExpects(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_test_case_expects_validate(cls, values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
+    def _pre_v_2_v_3_test_case_expects_validate(cls, values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
         for validator in TestCaseExpects.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_test_case_expects_validate(cls, values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
+    def _post_v_2_v_3_test_case_expects_validate(cls, values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
         for validator in TestCaseExpects.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_test_case_expects.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_test_case_expects.py
@@ -117,13 +117,13 @@ class TestCaseExpects(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
+    def _prev_2_v_3_test_case_expects_validate(cls, values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
         for validator in TestCaseExpects.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
+    def _postv_2_v_3_test_case_expects_validate(cls, values: TestCaseExpects.Partial) -> TestCaseExpects.Partial:
         for validator in TestCaseExpects.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_test_case_implementation.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_test_case_implementation.py
@@ -165,7 +165,7 @@ class TestCaseImplementation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_test_case_implementation_validate(
+    def _pre_v_2_v_3_test_case_implementation_validate(
         cls, values: TestCaseImplementation.Partial
     ) -> TestCaseImplementation.Partial:
         for validator in TestCaseImplementation.Validators._pre_validators:
@@ -173,7 +173,7 @@ class TestCaseImplementation(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_test_case_implementation_validate(
+    def _post_v_2_v_3_test_case_implementation_validate(
         cls, values: TestCaseImplementation.Partial
     ) -> TestCaseImplementation.Partial:
         for validator in TestCaseImplementation.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_test_case_implementation.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_test_case_implementation.py
@@ -165,13 +165,17 @@ class TestCaseImplementation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TestCaseImplementation.Partial) -> TestCaseImplementation.Partial:
+    def _prev_2_v_3_test_case_implementation_validate(
+        cls, values: TestCaseImplementation.Partial
+    ) -> TestCaseImplementation.Partial:
         for validator in TestCaseImplementation.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TestCaseImplementation.Partial) -> TestCaseImplementation.Partial:
+    def _postv_2_v_3_test_case_implementation_validate(
+        cls, values: TestCaseImplementation.Partial
+    ) -> TestCaseImplementation.Partial:
         for validator in TestCaseImplementation.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_test_case_implementation.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_test_case_implementation.py
@@ -165,7 +165,7 @@ class TestCaseImplementation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_test_case_implementation_validate(
+    def _pre_validate_v_2_v_3_test_case_implementation(
         cls, values: TestCaseImplementation.Partial
     ) -> TestCaseImplementation.Partial:
         for validator in TestCaseImplementation.Validators._pre_validators:
@@ -173,7 +173,7 @@ class TestCaseImplementation(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_test_case_implementation_validate(
+    def _post_validate_v_2_v_3_test_case_implementation(
         cls, values: TestCaseImplementation.Partial
     ) -> TestCaseImplementation.Partial:
         for validator in TestCaseImplementation.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_test_case_implementation_description.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_test_case_implementation_description.py
@@ -128,7 +128,7 @@ class TestCaseImplementationDescription(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(
+    def _prev_2_v_3_test_case_implementation_description_validate(
         cls, values: TestCaseImplementationDescription.Partial
     ) -> TestCaseImplementationDescription.Partial:
         for validator in TestCaseImplementationDescription.Validators._pre_validators:
@@ -136,7 +136,7 @@ class TestCaseImplementationDescription(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(
+    def _postv_2_v_3_test_case_implementation_description_validate(
         cls, values: TestCaseImplementationDescription.Partial
     ) -> TestCaseImplementationDescription.Partial:
         for validator in TestCaseImplementationDescription.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_test_case_implementation_description.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_test_case_implementation_description.py
@@ -128,7 +128,7 @@ class TestCaseImplementationDescription(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_test_case_implementation_description_validate(
+    def _pre_v_2_v_3_test_case_implementation_description_validate(
         cls, values: TestCaseImplementationDescription.Partial
     ) -> TestCaseImplementationDescription.Partial:
         for validator in TestCaseImplementationDescription.Validators._pre_validators:
@@ -136,7 +136,7 @@ class TestCaseImplementationDescription(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_test_case_implementation_description_validate(
+    def _post_v_2_v_3_test_case_implementation_description_validate(
         cls, values: TestCaseImplementationDescription.Partial
     ) -> TestCaseImplementationDescription.Partial:
         for validator in TestCaseImplementationDescription.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_test_case_implementation_description.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_test_case_implementation_description.py
@@ -128,7 +128,7 @@ class TestCaseImplementationDescription(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_test_case_implementation_description_validate(
+    def _pre_validate_v_2_v_3_test_case_implementation_description(
         cls, values: TestCaseImplementationDescription.Partial
     ) -> TestCaseImplementationDescription.Partial:
         for validator in TestCaseImplementationDescription.Validators._pre_validators:
@@ -136,7 +136,7 @@ class TestCaseImplementationDescription(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_test_case_implementation_description_validate(
+    def _post_validate_v_2_v_3_test_case_implementation_description(
         cls, values: TestCaseImplementationDescription.Partial
     ) -> TestCaseImplementationDescription.Partial:
         for validator in TestCaseImplementationDescription.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_test_case_metadata.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_test_case_metadata.py
@@ -182,13 +182,13 @@ class TestCaseMetadata(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
+    def _prev_2_v_3_test_case_metadata_validate(cls, values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
         for validator in TestCaseMetadata.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
+    def _postv_2_v_3_test_case_metadata_validate(cls, values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
         for validator in TestCaseMetadata.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_test_case_metadata.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_test_case_metadata.py
@@ -182,13 +182,13 @@ class TestCaseMetadata(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_test_case_metadata_validate(cls, values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
+    def _pre_validate_v_2_v_3_test_case_metadata(cls, values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
         for validator in TestCaseMetadata.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_test_case_metadata_validate(cls, values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
+    def _post_validate_v_2_v_3_test_case_metadata(cls, values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
         for validator in TestCaseMetadata.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_test_case_metadata.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_test_case_metadata.py
@@ -182,13 +182,13 @@ class TestCaseMetadata(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_test_case_metadata_validate(cls, values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
+    def _pre_v_2_v_3_test_case_metadata_validate(cls, values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
         for validator in TestCaseMetadata.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_test_case_metadata_validate(cls, values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
+    def _post_v_2_v_3_test_case_metadata_validate(cls, values: TestCaseMetadata.Partial) -> TestCaseMetadata.Partial:
         for validator in TestCaseMetadata.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_test_case_template.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_test_case_template.py
@@ -199,13 +199,13 @@ class TestCaseTemplate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_test_case_template_validate(cls, values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
+    def _pre_v_2_v_3_test_case_template_validate(cls, values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
         for validator in TestCaseTemplate.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_test_case_template_validate(cls, values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
+    def _post_v_2_v_3_test_case_template_validate(cls, values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
         for validator in TestCaseTemplate.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_test_case_template.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_test_case_template.py
@@ -199,13 +199,13 @@ class TestCaseTemplate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_test_case_template_validate(cls, values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
+    def _pre_validate_v_2_v_3_test_case_template(cls, values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
         for validator in TestCaseTemplate.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_test_case_template_validate(cls, values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
+    def _post_validate_v_2_v_3_test_case_template(cls, values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
         for validator in TestCaseTemplate.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_test_case_template.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_test_case_template.py
@@ -199,13 +199,13 @@ class TestCaseTemplate(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
+    def _prev_2_v_3_test_case_template_validate(cls, values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
         for validator in TestCaseTemplate.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
+    def _postv_2_v_3_test_case_template_validate(cls, values: TestCaseTemplate.Partial) -> TestCaseTemplate.Partial:
         for validator in TestCaseTemplate.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_test_case_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_test_case_v_2.py
@@ -232,13 +232,13 @@ class TestCaseV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: TestCaseV2.Partial) -> TestCaseV2.Partial:
+    def _prev_2_v_3_test_case_v_2_validate(cls, values: TestCaseV2.Partial) -> TestCaseV2.Partial:
         for validator in TestCaseV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: TestCaseV2.Partial) -> TestCaseV2.Partial:
+    def _postv_2_v_3_test_case_v_2_validate(cls, values: TestCaseV2.Partial) -> TestCaseV2.Partial:
         for validator in TestCaseV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_test_case_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_test_case_v_2.py
@@ -232,13 +232,13 @@ class TestCaseV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_test_case_v_2_validate(cls, values: TestCaseV2.Partial) -> TestCaseV2.Partial:
+    def _pre_v_2_v_3_test_case_v_2_validate(cls, values: TestCaseV2.Partial) -> TestCaseV2.Partial:
         for validator in TestCaseV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_test_case_v_2_validate(cls, values: TestCaseV2.Partial) -> TestCaseV2.Partial:
+    def _post_v_2_v_3_test_case_v_2_validate(cls, values: TestCaseV2.Partial) -> TestCaseV2.Partial:
         for validator in TestCaseV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_test_case_v_2.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_test_case_v_2.py
@@ -232,13 +232,13 @@ class TestCaseV2(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_test_case_v_2_validate(cls, values: TestCaseV2.Partial) -> TestCaseV2.Partial:
+    def _pre_validate_v_2_v_3_test_case_v_2(cls, values: TestCaseV2.Partial) -> TestCaseV2.Partial:
         for validator in TestCaseV2.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_test_case_v_2_validate(cls, values: TestCaseV2.Partial) -> TestCaseV2.Partial:
+    def _post_validate_v_2_v_3_test_case_v_2(cls, values: TestCaseV2.Partial) -> TestCaseV2.Partial:
         for validator in TestCaseV2.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_test_case_with_actual_result_implementation.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_test_case_with_actual_result_implementation.py
@@ -185,7 +185,7 @@ class TestCaseWithActualResultImplementation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(
+    def _prev_2_v_3_test_case_with_actual_result_implementation_validate(
         cls, values: TestCaseWithActualResultImplementation.Partial
     ) -> TestCaseWithActualResultImplementation.Partial:
         for validator in TestCaseWithActualResultImplementation.Validators._pre_validators:
@@ -193,7 +193,7 @@ class TestCaseWithActualResultImplementation(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(
+    def _postv_2_v_3_test_case_with_actual_result_implementation_validate(
         cls, values: TestCaseWithActualResultImplementation.Partial
     ) -> TestCaseWithActualResultImplementation.Partial:
         for validator in TestCaseWithActualResultImplementation.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_test_case_with_actual_result_implementation.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_test_case_with_actual_result_implementation.py
@@ -185,7 +185,7 @@ class TestCaseWithActualResultImplementation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_test_case_with_actual_result_implementation_validate(
+    def _pre_validate_v_2_v_3_test_case_with_actual_result_implementation(
         cls, values: TestCaseWithActualResultImplementation.Partial
     ) -> TestCaseWithActualResultImplementation.Partial:
         for validator in TestCaseWithActualResultImplementation.Validators._pre_validators:
@@ -193,7 +193,7 @@ class TestCaseWithActualResultImplementation(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_test_case_with_actual_result_implementation_validate(
+    def _post_validate_v_2_v_3_test_case_with_actual_result_implementation(
         cls, values: TestCaseWithActualResultImplementation.Partial
     ) -> TestCaseWithActualResultImplementation.Partial:
         for validator in TestCaseWithActualResultImplementation.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_test_case_with_actual_result_implementation.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_test_case_with_actual_result_implementation.py
@@ -185,7 +185,7 @@ class TestCaseWithActualResultImplementation(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_test_case_with_actual_result_implementation_validate(
+    def _pre_v_2_v_3_test_case_with_actual_result_implementation_validate(
         cls, values: TestCaseWithActualResultImplementation.Partial
     ) -> TestCaseWithActualResultImplementation.Partial:
         for validator in TestCaseWithActualResultImplementation.Validators._pre_validators:
@@ -193,7 +193,7 @@ class TestCaseWithActualResultImplementation(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_test_case_with_actual_result_implementation_validate(
+    def _post_v_2_v_3_test_case_with_actual_result_implementation_validate(
         cls, values: TestCaseWithActualResultImplementation.Partial
     ) -> TestCaseWithActualResultImplementation.Partial:
         for validator in TestCaseWithActualResultImplementation.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_void_function_definition.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_void_function_definition.py
@@ -162,13 +162,17 @@ class VoidFunctionDefinition(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: VoidFunctionDefinition.Partial) -> VoidFunctionDefinition.Partial:
+    def _prev_2_v_3_void_function_definition_validate(
+        cls, values: VoidFunctionDefinition.Partial
+    ) -> VoidFunctionDefinition.Partial:
         for validator in VoidFunctionDefinition.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: VoidFunctionDefinition.Partial) -> VoidFunctionDefinition.Partial:
+    def _postv_2_v_3_void_function_definition_validate(
+        cls, values: VoidFunctionDefinition.Partial
+    ) -> VoidFunctionDefinition.Partial:
         for validator in VoidFunctionDefinition.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_void_function_definition.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_void_function_definition.py
@@ -162,7 +162,7 @@ class VoidFunctionDefinition(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_void_function_definition_validate(
+    def _pre_v_2_v_3_void_function_definition_validate(
         cls, values: VoidFunctionDefinition.Partial
     ) -> VoidFunctionDefinition.Partial:
         for validator in VoidFunctionDefinition.Validators._pre_validators:
@@ -170,7 +170,7 @@ class VoidFunctionDefinition(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_void_function_definition_validate(
+    def _post_v_2_v_3_void_function_definition_validate(
         cls, values: VoidFunctionDefinition.Partial
     ) -> VoidFunctionDefinition.Partial:
         for validator in VoidFunctionDefinition.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_void_function_definition.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_void_function_definition.py
@@ -162,7 +162,7 @@ class VoidFunctionDefinition(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_void_function_definition_validate(
+    def _pre_validate_v_2_v_3_void_function_definition(
         cls, values: VoidFunctionDefinition.Partial
     ) -> VoidFunctionDefinition.Partial:
         for validator in VoidFunctionDefinition.Validators._pre_validators:
@@ -170,7 +170,7 @@ class VoidFunctionDefinition(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_void_function_definition_validate(
+    def _post_validate_v_2_v_3_void_function_definition(
         cls, values: VoidFunctionDefinition.Partial
     ) -> VoidFunctionDefinition.Partial:
         for validator in VoidFunctionDefinition.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_void_function_definition_that_takes_actual_result.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_void_function_definition_that_takes_actual_result.py
@@ -189,7 +189,7 @@ class VoidFunctionDefinitionThatTakesActualResult(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(
+    def _prev_2_v_3_void_function_definition_that_takes_actual_result_validate(
         cls, values: VoidFunctionDefinitionThatTakesActualResult.Partial
     ) -> VoidFunctionDefinitionThatTakesActualResult.Partial:
         for validator in VoidFunctionDefinitionThatTakesActualResult.Validators._pre_validators:
@@ -197,7 +197,7 @@ class VoidFunctionDefinitionThatTakesActualResult(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(
+    def _postv_2_v_3_void_function_definition_that_takes_actual_result_validate(
         cls, values: VoidFunctionDefinitionThatTakesActualResult.Partial
     ) -> VoidFunctionDefinitionThatTakesActualResult.Partial:
         for validator in VoidFunctionDefinitionThatTakesActualResult.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_void_function_definition_that_takes_actual_result.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_void_function_definition_that_takes_actual_result.py
@@ -189,7 +189,7 @@ class VoidFunctionDefinitionThatTakesActualResult(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_void_function_definition_that_takes_actual_result_validate(
+    def _pre_v_2_v_3_void_function_definition_that_takes_actual_result_validate(
         cls, values: VoidFunctionDefinitionThatTakesActualResult.Partial
     ) -> VoidFunctionDefinitionThatTakesActualResult.Partial:
         for validator in VoidFunctionDefinitionThatTakesActualResult.Validators._pre_validators:
@@ -197,7 +197,7 @@ class VoidFunctionDefinitionThatTakesActualResult(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_void_function_definition_that_takes_actual_result_validate(
+    def _post_v_2_v_3_void_function_definition_that_takes_actual_result_validate(
         cls, values: VoidFunctionDefinitionThatTakesActualResult.Partial
     ) -> VoidFunctionDefinitionThatTakesActualResult.Partial:
         for validator in VoidFunctionDefinitionThatTakesActualResult.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_void_function_definition_that_takes_actual_result.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_void_function_definition_that_takes_actual_result.py
@@ -189,7 +189,7 @@ class VoidFunctionDefinitionThatTakesActualResult(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_void_function_definition_that_takes_actual_result_validate(
+    def _pre_validate_v_2_v_3_void_function_definition_that_takes_actual_result(
         cls, values: VoidFunctionDefinitionThatTakesActualResult.Partial
     ) -> VoidFunctionDefinitionThatTakesActualResult.Partial:
         for validator in VoidFunctionDefinitionThatTakesActualResult.Validators._pre_validators:
@@ -197,7 +197,7 @@ class VoidFunctionDefinitionThatTakesActualResult(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_void_function_definition_that_takes_actual_result_validate(
+    def _post_validate_v_2_v_3_void_function_definition_that_takes_actual_result(
         cls, values: VoidFunctionDefinitionThatTakesActualResult.Partial
     ) -> VoidFunctionDefinitionThatTakesActualResult.Partial:
         for validator in VoidFunctionDefinitionThatTakesActualResult.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_void_function_signature.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_void_function_signature.py
@@ -119,7 +119,7 @@ class VoidFunctionSignature(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_void_function_signature_validate(
+    def _pre_v_2_v_3_void_function_signature_validate(
         cls, values: VoidFunctionSignature.Partial
     ) -> VoidFunctionSignature.Partial:
         for validator in VoidFunctionSignature.Validators._pre_validators:
@@ -127,7 +127,7 @@ class VoidFunctionSignature(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_void_function_signature_validate(
+    def _post_v_2_v_3_void_function_signature_validate(
         cls, values: VoidFunctionSignature.Partial
     ) -> VoidFunctionSignature.Partial:
         for validator in VoidFunctionSignature.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_void_function_signature.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_void_function_signature.py
@@ -119,13 +119,17 @@ class VoidFunctionSignature(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(cls, values: VoidFunctionSignature.Partial) -> VoidFunctionSignature.Partial:
+    def _prev_2_v_3_void_function_signature_validate(
+        cls, values: VoidFunctionSignature.Partial
+    ) -> VoidFunctionSignature.Partial:
         for validator in VoidFunctionSignature.Validators._pre_validators:
             values = validator(values)
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(cls, values: VoidFunctionSignature.Partial) -> VoidFunctionSignature.Partial:
+    def _postv_2_v_3_void_function_signature_validate(
+        cls, values: VoidFunctionSignature.Partial
+    ) -> VoidFunctionSignature.Partial:
         for validator in VoidFunctionSignature.Validators._post_validators:
             values = validator(values)
         return values

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_void_function_signature.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_void_function_signature.py
@@ -119,7 +119,7 @@ class VoidFunctionSignature(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_void_function_signature_validate(
+    def _pre_validate_v_2_v_3_void_function_signature(
         cls, values: VoidFunctionSignature.Partial
     ) -> VoidFunctionSignature.Partial:
         for validator in VoidFunctionSignature.Validators._pre_validators:
@@ -127,7 +127,7 @@ class VoidFunctionSignature(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_void_function_signature_validate(
+    def _post_validate_v_2_v_3_void_function_signature(
         cls, values: VoidFunctionSignature.Partial
     ) -> VoidFunctionSignature.Partial:
         for validator in VoidFunctionSignature.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_void_function_signature_that_takes_actual_result.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_void_function_signature_that_takes_actual_result.py
@@ -183,7 +183,7 @@ class VoidFunctionSignatureThatTakesActualResult(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_validate(
+    def _prev_2_v_3_void_function_signature_that_takes_actual_result_validate(
         cls, values: VoidFunctionSignatureThatTakesActualResult.Partial
     ) -> VoidFunctionSignatureThatTakesActualResult.Partial:
         for validator in VoidFunctionSignatureThatTakesActualResult.Validators._pre_validators:
@@ -191,7 +191,7 @@ class VoidFunctionSignatureThatTakesActualResult(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_validate(
+    def _postv_2_v_3_void_function_signature_that_takes_actual_result_validate(
         cls, values: VoidFunctionSignatureThatTakesActualResult.Partial
     ) -> VoidFunctionSignatureThatTakesActualResult.Partial:
         for validator in VoidFunctionSignatureThatTakesActualResult.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_void_function_signature_that_takes_actual_result.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_void_function_signature_that_takes_actual_result.py
@@ -183,7 +183,7 @@ class VoidFunctionSignatureThatTakesActualResult(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _pre_v_2_v_3_void_function_signature_that_takes_actual_result_validate(
+    def _pre_validate_v_2_v_3_void_function_signature_that_takes_actual_result(
         cls, values: VoidFunctionSignatureThatTakesActualResult.Partial
     ) -> VoidFunctionSignatureThatTakesActualResult.Partial:
         for validator in VoidFunctionSignatureThatTakesActualResult.Validators._pre_validators:
@@ -191,7 +191,7 @@ class VoidFunctionSignatureThatTakesActualResult(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _post_v_2_v_3_void_function_signature_that_takes_actual_result_validate(
+    def _post_validate_v_2_v_3_void_function_signature_that_takes_actual_result(
         cls, values: VoidFunctionSignatureThatTakesActualResult.Partial
     ) -> VoidFunctionSignatureThatTakesActualResult.Partial:
         for validator in VoidFunctionSignatureThatTakesActualResult.Validators._post_validators:

--- a/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_void_function_signature_that_takes_actual_result.py
+++ b/tests/pydantic_model/snapshots/snap_test_pydantic_model/test_pydantic_model resources_v_2_resources_v_3_resources_problem_void_function_signature_that_takes_actual_result.py
@@ -183,7 +183,7 @@ class VoidFunctionSignatureThatTakesActualResult(pydantic.BaseModel):
                 ...
 
     @pydantic.root_validator(pre=True)
-    def _prev_2_v_3_void_function_signature_that_takes_actual_result_validate(
+    def _pre_v_2_v_3_void_function_signature_that_takes_actual_result_validate(
         cls, values: VoidFunctionSignatureThatTakesActualResult.Partial
     ) -> VoidFunctionSignatureThatTakesActualResult.Partial:
         for validator in VoidFunctionSignatureThatTakesActualResult.Validators._pre_validators:
@@ -191,7 +191,7 @@ class VoidFunctionSignatureThatTakesActualResult(pydantic.BaseModel):
         return values
 
     @pydantic.root_validator(pre=False)
-    def _postv_2_v_3_void_function_signature_that_takes_actual_result_validate(
+    def _post_v_2_v_3_void_function_signature_that_takes_actual_result_validate(
         cls, values: VoidFunctionSignatureThatTakesActualResult.Partial
     ) -> VoidFunctionSignatureThatTakesActualResult.Partial:
         for validator in VoidFunctionSignatureThatTakesActualResult.Validators._post_validators:


### PR DESCRIPTION
before this change, a derived class would always override the parent class's root validator which would result in not all validators running. by making sure the validators will be named uniquely, they wont overlap.  