### PR TITLE
fix: root client stores environment member

### DIFF
--- a/src/fern_python/generators/sdk/client_generator/root_client_generator.py
+++ b/src/fern_python/generators/sdk/client_generator/root_client_generator.py
@@ -172,9 +172,8 @@ class RootClientGenerator:
     def _get_write_constructor_body(self, *, is_async: bool) -> CodeWriterFunction:
         def _write_constructor_body(writer: AST.NodeWriter) -> None:
             client_wrapper_generator = ClientWrapperGenerator(context=self._context)
-            constructor_parameters = client_wrapper_generator._get_constructor_info().constructor_parameters
             kwargs = []
-            for wrapper_param in constructor_parameters:
+            for wrapper_param in client_wrapper_generator._get_constructor_info().constructor_parameters:
                 kwargs.append(
                     (
                         wrapper_param.constructor_parameter_name,
@@ -197,7 +196,7 @@ class RootClientGenerator:
                     ),
                 )
             )
-            for param in constructor_parameters:
+            for param in self._get_constructor_parameters(is_async=is_async):
                 if param.private_member_name is not None:
                     writer.write_line(f"self.{param.private_member_name} = {param.constructor_parameter_name}")
             writer.write(f"self.{self._get_client_wrapper_member_name()} = ")

--- a/tests/sdk/snapshots/snap_test_sdk/test_circular_imports src_my_org_client.py
+++ b/tests/sdk/snapshots/snap_test_sdk/test_circular_imports src_my_org_client.py
@@ -9,9 +9,11 @@ from .core.client_wrapper import AsyncClientWrapper, SyncClientWrapper
 
 class MyOrgIr:
     def __init__(self, *, environment: str, timeout: typing.Optional[float] = 60):
+        self._environment = environment
         self._client_wrapper = SyncClientWrapper(httpx_client=httpx.Client(timeout=timeout))
 
 
 class AsyncMyOrgIr:
     def __init__(self, *, environment: str, timeout: typing.Optional[float] = 60):
+        self._environment = environment
         self._client_wrapper = AsyncClientWrapper(httpx_client=httpx.AsyncClient(timeout=timeout))

--- a/tests/sdk/snapshots/snap_test_sdk/test_file_upload_sdk client.py
+++ b/tests/sdk/snapshots/snap_test_sdk/test_file_upload_sdk client.py
@@ -10,11 +10,13 @@ from .resources.movie.client import AsyncMovieClient, MovieClient
 
 class FernIr:
     def __init__(self, *, environment: str, timeout: typing.Optional[float] = 60):
+        self._environment = environment
         self._client_wrapper = SyncClientWrapper(httpx_client=httpx.Client(timeout=timeout))
         self.movie = MovieClient(environment=environment, client_wrapper=self._client_wrapper)
 
 
 class AsyncFernIr:
     def __init__(self, *, environment: str, timeout: typing.Optional[float] = 60):
+        self._environment = environment
         self._client_wrapper = AsyncClientWrapper(httpx_client=httpx.AsyncClient(timeout=timeout))
         self.movie = AsyncMovieClient(environment=environment, client_wrapper=self._client_wrapper)

--- a/tests/sdk/snapshots/snap_test_sdk/test_github_no_publish_sdk src_fern_client.py
+++ b/tests/sdk/snapshots/snap_test_sdk/test_github_no_publish_sdk src_fern_client.py
@@ -10,11 +10,13 @@ from .resources.movie.client import AsyncMovieClient, MovieClient
 
 class FernIr:
     def __init__(self, *, environment: str, timeout: typing.Optional[float] = 60):
+        self._environment = environment
         self._client_wrapper = SyncClientWrapper(httpx_client=httpx.Client(timeout=timeout))
         self.movie = MovieClient(environment=environment, client_wrapper=self._client_wrapper)
 
 
 class AsyncFernIr:
     def __init__(self, *, environment: str, timeout: typing.Optional[float] = 60):
+        self._environment = environment
         self._client_wrapper = AsyncClientWrapper(httpx_client=httpx.AsyncClient(timeout=timeout))
         self.movie = AsyncMovieClient(environment=environment, client_wrapper=self._client_wrapper)

--- a/tests/sdk/snapshots/snap_test_sdk/test_github_sdk src_fern_my_client.py
+++ b/tests/sdk/snapshots/snap_test_sdk/test_github_sdk src_fern_my_client.py
@@ -17,8 +17,7 @@ class FernIr:
         api_secret: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
         timeout: typing.Optional[float] = 60
     ):
-        self._api_key = api_key
-        self._api_secret = api_secret
+        self._environment = environment
         self._client_wrapper = SyncClientWrapper(
             api_key=api_key, api_secret=api_secret, httpx_client=httpx.Client(timeout=timeout)
         )
@@ -34,8 +33,7 @@ class AsyncFernIr:
         api_secret: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
         timeout: typing.Optional[float] = 60
     ):
-        self._api_key = api_key
-        self._api_secret = api_secret
+        self._environment = environment
         self._client_wrapper = AsyncClientWrapper(
             api_key=api_key, api_secret=api_secret, httpx_client=httpx.AsyncClient(timeout=timeout)
         )

--- a/tests/sdk/snapshots/snap_test_sdk/test_github_sdk src_fern_my_client.py
+++ b/tests/sdk/snapshots/snap_test_sdk/test_github_sdk src_fern_my_client.py
@@ -17,6 +17,8 @@ class FernIr:
         api_secret: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
         timeout: typing.Optional[float] = 60
     ):
+        self._api_key = api_key
+        self._api_secret = api_secret
         self._client_wrapper = SyncClientWrapper(
             api_key=api_key, api_secret=api_secret, httpx_client=httpx.Client(timeout=timeout)
         )
@@ -32,6 +34,8 @@ class AsyncFernIr:
         api_secret: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
         timeout: typing.Optional[float] = 60
     ):
+        self._api_key = api_key
+        self._api_secret = api_secret
         self._client_wrapper = AsyncClientWrapper(
             api_key=api_key, api_secret=api_secret, httpx_client=httpx.AsyncClient(timeout=timeout)
         )

--- a/tests/sdk/snapshots/snap_test_sdk/test_multiple_urls_sdk client.py
+++ b/tests/sdk/snapshots/snap_test_sdk/test_multiple_urls_sdk client.py
@@ -15,6 +15,7 @@ class FernIr:
     def __init__(
         self, *, environment: FernIrEnvironment = FernIrEnvironment.PRODUCTION, timeout: typing.Optional[float] = 60
     ):
+        self._environment = environment
         self._client_wrapper = SyncClientWrapper(httpx_client=httpx.Client(timeout=timeout))
         self.a = AClient(environment=environment, client_wrapper=self._client_wrapper)
         self.b = BClient(environment=environment, client_wrapper=self._client_wrapper)
@@ -25,6 +26,7 @@ class AsyncFernIr:
     def __init__(
         self, *, environment: FernIrEnvironment = FernIrEnvironment.PRODUCTION, timeout: typing.Optional[float] = 60
     ):
+        self._environment = environment
         self._client_wrapper = AsyncClientWrapper(httpx_client=httpx.AsyncClient(timeout=timeout))
         self.a = AsyncAClient(environment=environment, client_wrapper=self._client_wrapper)
         self.b = AsyncBClient(environment=environment, client_wrapper=self._client_wrapper)

--- a/tests/sdk/snapshots/snap_test_sdk/test_publish_sdk src_fern_api_client.py
+++ b/tests/sdk/snapshots/snap_test_sdk/test_publish_sdk src_fern_api_client.py
@@ -10,14 +10,14 @@ from .resources.movie.client import AsyncMovieClient, MovieClient
 
 class FernIr:
     def __init__(self, *, environment: str, header_auth: str, timeout: typing.Optional[float] = 5):
-        self.header_auth = header_auth
+        self._environment = environment
         self._client_wrapper = SyncClientWrapper(header_auth=header_auth, httpx_client=httpx.Client(timeout=timeout))
         self.movie = MovieClient(environment=environment, client_wrapper=self._client_wrapper)
 
 
 class AsyncFernIr:
     def __init__(self, *, environment: str, header_auth: str, timeout: typing.Optional[float] = 5):
-        self.header_auth = header_auth
+        self._environment = environment
         self._client_wrapper = AsyncClientWrapper(
             header_auth=header_auth, httpx_client=httpx.AsyncClient(timeout=timeout)
         )

--- a/tests/sdk/snapshots/snap_test_sdk/test_publish_sdk src_fern_api_client.py
+++ b/tests/sdk/snapshots/snap_test_sdk/test_publish_sdk src_fern_api_client.py
@@ -10,12 +10,14 @@ from .resources.movie.client import AsyncMovieClient, MovieClient
 
 class FernIr:
     def __init__(self, *, environment: str, header_auth: str, timeout: typing.Optional[float] = 5):
+        self.header_auth = header_auth
         self._client_wrapper = SyncClientWrapper(header_auth=header_auth, httpx_client=httpx.Client(timeout=timeout))
         self.movie = MovieClient(environment=environment, client_wrapper=self._client_wrapper)
 
 
 class AsyncFernIr:
     def __init__(self, *, environment: str, header_auth: str, timeout: typing.Optional[float] = 5):
+        self.header_auth = header_auth
         self._client_wrapper = AsyncClientWrapper(
             header_auth=header_auth, httpx_client=httpx.AsyncClient(timeout=timeout)
         )

--- a/tests/sdk/snapshots/snap_test_sdk/test_streaming_sdk client.py
+++ b/tests/sdk/snapshots/snap_test_sdk/test_streaming_sdk client.py
@@ -10,11 +10,13 @@ from .resources.ai.client import AiClient, AsyncAiClient
 
 class FernIr:
     def __init__(self, *, environment: str, timeout: typing.Optional[float] = 60):
+        self._environment = environment
         self._client_wrapper = SyncClientWrapper(httpx_client=httpx.Client(timeout=timeout))
         self.ai = AiClient(environment=environment, client_wrapper=self._client_wrapper)
 
 
 class AsyncFernIr:
     def __init__(self, *, environment: str, timeout: typing.Optional[float] = 60):
+        self._environment = environment
         self._client_wrapper = AsyncClientWrapper(httpx_client=httpx.AsyncClient(timeout=timeout))
         self.ai = AsyncAiClient(environment=environment, client_wrapper=self._client_wrapper)

--- a/tests/sdk/snapshots/snap_test_sdk/test_trace_sdk client.py
+++ b/tests/sdk/snapshots/snap_test_sdk/test_trace_sdk client.py
@@ -25,6 +25,8 @@ class FernIr:
         token: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
         timeout: typing.Optional[float] = None
     ):
+        self._x_random_header = x_random_header
+        self._token = token
         self._client_wrapper = SyncClientWrapper(
             x_random_header=x_random_header, token=token, httpx_client=httpx.Client(timeout=timeout)
         )
@@ -47,6 +49,8 @@ class AsyncFernIr:
         token: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
         timeout: typing.Optional[float] = None
     ):
+        self._x_random_header = x_random_header
+        self._token = token
         self._client_wrapper = AsyncClientWrapper(
             x_random_header=x_random_header, token=token, httpx_client=httpx.AsyncClient(timeout=timeout)
         )

--- a/tests/sdk/snapshots/snap_test_sdk/test_trace_sdk client.py
+++ b/tests/sdk/snapshots/snap_test_sdk/test_trace_sdk client.py
@@ -25,8 +25,7 @@ class FernIr:
         token: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
         timeout: typing.Optional[float] = None
     ):
-        self._x_random_header = x_random_header
-        self._token = token
+        self._environment = environment
         self._client_wrapper = SyncClientWrapper(
             x_random_header=x_random_header, token=token, httpx_client=httpx.Client(timeout=timeout)
         )
@@ -49,8 +48,7 @@ class AsyncFernIr:
         token: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
         timeout: typing.Optional[float] = None
     ):
-        self._x_random_header = x_random_header
-        self._token = token
+        self._environment = environment
         self._client_wrapper = AsyncClientWrapper(
             x_random_header=x_random_header, token=token, httpx_client=httpx.AsyncClient(timeout=timeout)
         )


### PR DESCRIPTION
The root python client stores the environment member variable. Without this PR, any sdk that had root level endpoints would fail to compile as reported by https://github.com/fern-api/fern-python/issues/289