### PR TITLE
fix: file download endpoint returns after parsing stream

### DIFF
--- a/src/fern_python/generators/sdk/client_generator/endpoint_response_code_writer.py
+++ b/src/fern_python/generators/sdk/client_generator/endpoint_response_code_writer.py
@@ -92,6 +92,7 @@ class EndpointResponseCodeWriter:
         with writer.indent():
             writer.write(f"yield {EndpointResponseCodeWriter.FILE_CHUNK_VARIABLE}")
         writer.write_newline_if_last_line_not()
+        writer.write_line("return")
 
     def _get_iter_bytes_method(self, *, is_async: bool) -> str:
         if is_async:
@@ -224,7 +225,10 @@ class EndpointResponseCodeWriter:
     def _deserialize_json_response(self, *, writer: AST.NodeWriter) -> None:
         # in streaming responses, we need to call read() or aread()
         # before deserializing or httpx will raise ResponseNotRead
-        if self._endpoint.sdk_response is not None and self._endpoint.sdk_response.get_as_union().type == "streaming":
+        if self._endpoint.sdk_response is not None and (
+            self._endpoint.sdk_response.get_as_union().type == "streaming"
+            or self._endpoint.sdk_response.get_as_union().type == "fileDownload"
+        ):
             writer.write_line(
                 f"await {EndpointResponseCodeWriter.RESPONSE_VARIABLE}.aread()"
                 if self._is_async

--- a/tests/sdk/snapshots/snap_test_sdk/test_file_upload_sdk resources_movie_client.py
+++ b/tests/sdk/snapshots/snap_test_sdk/test_file_upload_sdk resources_movie_client.py
@@ -57,7 +57,9 @@ class MovieClient:
             if 200 <= _response.status_code < 300:
                 for _chunk in _response.iter_bytes():
                     yield _chunk
+                return
             try:
+                _response.read()
                 _response_json = _response.json()
             except JSONDecodeError:
                 raise ApiError(status_code=_response.status_code, body=_response.text)
@@ -108,7 +110,9 @@ class AsyncMovieClient:
             if 200 <= _response.status_code < 300:
                 async for _chunk in _response.aiter_bytes():
                     yield _chunk
+                return
             try:
+                await _response.aread()
                 _response_json = _response.json()
             except JSONDecodeError:
                 raise ApiError(status_code=_response.status_code, body=_response.text)


### PR DESCRIPTION
Before this change, the file download response was always sent to the error handler which would fail. Additionally, the stream needs to be fully read before being parsed. 