### PR TITLE
feature: python sdks send global headers

### DIFF
--- a/src/fern_python/generators/sdk/core_utilities/client_wrapper_generator.py
+++ b/src/fern_python/generators/sdk/core_utilities/client_wrapper_generator.py
@@ -52,7 +52,9 @@ class ClientWrapperGenerator:
     def generate(self, source_file: SourceFile, project: Project) -> None:
         constructor_info = self._get_constructor_info()
         source_file.add_class_declaration(
-            declaration=self._create_base_client_wrapper_class_declaration(constructor_info=constructor_info, project=project),
+            declaration=self._create_base_client_wrapper_class_declaration(
+                constructor_info=constructor_info, project=project
+            ),
             should_export=True,
         )
         source_file.add_class_declaration(
@@ -89,7 +91,8 @@ class ClientWrapperGenerator:
                 ),
                 body=AST.CodeWriter(
                     self._get_write_get_headers_body(
-                        constructor_parameters=constructor_info.constructor_parameters, project=project,
+                        constructor_parameters=constructor_info.constructor_parameters,
+                        project=project,
                     )
                 ),
             )

--- a/src/fern_python/generators/sdk/core_utilities/client_wrapper_generator.py
+++ b/src/fern_python/generators/sdk/core_utilities/client_wrapper_generator.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 
 import fern.ir.resources as ir_types
 
-from fern_python.codegen import AST, SourceFile
+from fern_python.codegen import AST, Project, SourceFile
 from fern_python.codegen.ast.nodes.code_writer.code_writer import CodeWriterFunction
 from fern_python.external_dependencies import httpx
 from fern_python.generators.sdk.core_utilities.core_utilities import CoreUtilities
@@ -52,10 +52,10 @@ class ClientWrapperGenerator:
     ):
         self._context = context
 
-    def generate(self, source_file: SourceFile) -> None:
+    def generate(self, source_file: SourceFile, project: Project) -> None:
         constructor_info = self._get_constructor_info()
         source_file.add_class_declaration(
-            declaration=self._create_base_client_wrapper_class_declaration(constructor_info=constructor_info),
+            declaration=self._create_base_client_wrapper_class_declaration(constructor_info=constructor_info, project=project),
             should_export=True,
         )
         source_file.add_class_declaration(
@@ -68,7 +68,7 @@ class ClientWrapperGenerator:
         )
 
     def _create_base_client_wrapper_class_declaration(
-        self, *, constructor_info: ConstructorInfo
+        self, *, constructor_info: ConstructorInfo, project: Project
     ) -> AST.ClassDeclaration:
         named_parameters = self._get_named_parameters(constructor_parameters=constructor_info.constructor_parameters)
 
@@ -91,7 +91,9 @@ class ClientWrapperGenerator:
                     return_type=AST.TypeHint.dict(AST.TypeHint.str_(), AST.TypeHint.str_())
                 ),
                 body=AST.CodeWriter(
-                    self._get_write_get_headers_body(constructor_parameters=constructor_info.constructor_parameters)
+                    self._get_write_get_headers_body(
+                        constructor_parameters=constructor_info.constructor_parameters, project=project,
+                    )
                 ),
             )
         )
@@ -191,11 +193,22 @@ class ClientWrapperGenerator:
             for param in constructor_parameters
         ]
 
-    def _get_write_get_headers_body(self, *, constructor_parameters: List[ConstructorParameter]) -> CodeWriterFunction:
+    def _get_write_get_headers_body(
+        self, *, constructor_parameters: List[ConstructorParameter], project: Project
+    ) -> CodeWriterFunction:
         def _write_get_headers_body(writer: AST.NodeWriter) -> None:
             writer.write("headers: ")
             writer.write_node(AST.TypeHint.dict(AST.TypeHint.str_(), AST.TypeHint.str_()))
-            writer.write("= {}")
+            writer.write_line("= {")
+            writer.write_line(f'"{self._context.ir.sdk_config.platform_headers.language}": "Python",')
+            if project._project_config is not None:
+                writer.write_line(
+                    f'"{self._context.ir.sdk_config.platform_headers.sdk_name}": "{project._project_config.package_name}",'
+                )
+                writer.write_line(
+                    f'"{self._context.ir.sdk_config.platform_headers.sdk_version}": "{project._project_config.package_version}",'
+                )
+            writer.write_line("}")
             writer.write_newline_if_last_line_not()
             basic_auth_scheme = self._get_basic_auth_scheme()
             if basic_auth_scheme is not None:

--- a/src/fern_python/generators/sdk/sdk_generator.py
+++ b/src/fern_python/generators/sdk/sdk_generator.py
@@ -169,7 +169,7 @@ class SdkGenerator(AbstractGenerator):
             filepath=filepath,
             generator_exec_wrapper=generator_exec_wrapper,
         ) as source_file:
-            ClientWrapperGenerator(context=context).generate(source_file=source_file)
+            ClientWrapperGenerator(context=context).generate(source_file=source_file, project=project)
 
     def _generate_root_client(
         self,

--- a/tests/sdk/snapshots/snap_test_sdk/test_circular_imports src_my_org_core_client_wrapper.py
+++ b/tests/sdk/snapshots/snap_test_sdk/test_circular_imports src_my_org_core_client_wrapper.py
@@ -10,7 +10,11 @@ class BaseClientWrapper:
         pass
 
     def get_headers(self) -> typing.Dict[str, str]:
-        headers: typing.Dict[str, str] = {}
+        headers: typing.Dict[str, str] = {
+            "X-Fern-Language": "Python",
+            "X-Fern-SDK-Name": "my_org",
+            "X-Fern-SDK-Version": "1.0.0",
+        }
         return headers
 
 

--- a/tests/sdk/snapshots/snap_test_sdk/test_file_upload_sdk core_client_wrapper.py
+++ b/tests/sdk/snapshots/snap_test_sdk/test_file_upload_sdk core_client_wrapper.py
@@ -10,7 +10,7 @@ class BaseClientWrapper:
         pass
 
     def get_headers(self) -> typing.Dict[str, str]:
-        headers: typing.Dict[str, str] = {}
+        headers: typing.Dict[str, str] = {"X-Fern-Language": "Python"}
         return headers
 
 

--- a/tests/sdk/snapshots/snap_test_sdk/test_github_no_publish_sdk src_fern_core_client_wrapper.py
+++ b/tests/sdk/snapshots/snap_test_sdk/test_github_no_publish_sdk src_fern_core_client_wrapper.py
@@ -10,7 +10,11 @@ class BaseClientWrapper:
         pass
 
     def get_headers(self) -> typing.Dict[str, str]:
-        headers: typing.Dict[str, str] = {}
+        headers: typing.Dict[str, str] = {
+            "X-Fern-Language": "Python",
+            "X-Fern-SDK-Name": "fern",
+            "X-Fern-SDK-Version": "0.0.0",
+        }
         return headers
 
 

--- a/tests/sdk/snapshots/snap_test_sdk/test_github_sdk src_fern_core_client_wrapper.py
+++ b/tests/sdk/snapshots/snap_test_sdk/test_github_sdk src_fern_core_client_wrapper.py
@@ -16,7 +16,11 @@ class BaseClientWrapper:
         self._api_secret = api_secret
 
     def get_headers(self) -> typing.Dict[str, str]:
-        headers: typing.Dict[str, str] = {}
+        headers: typing.Dict[str, str] = {
+            "X-Fern-Language": "Python",
+            "X-Fern-SDK-Name": "my-package-name",
+            "X-Fern-SDK-Version": "1.0.0",
+        }
         api_key = self._get_api_key()
         api_secret = self._get_api_secret()
         if api_key is not None and api_secret is not None:

--- a/tests/sdk/snapshots/snap_test_sdk/test_multiple_urls_sdk core_client_wrapper.py
+++ b/tests/sdk/snapshots/snap_test_sdk/test_multiple_urls_sdk core_client_wrapper.py
@@ -10,7 +10,7 @@ class BaseClientWrapper:
         pass
 
     def get_headers(self) -> typing.Dict[str, str]:
-        headers: typing.Dict[str, str] = {}
+        headers: typing.Dict[str, str] = {"X-Fern-Language": "Python"}
         return headers
 
 

--- a/tests/sdk/snapshots/snap_test_sdk/test_publish_sdk src_fern_api_core_client_wrapper.py
+++ b/tests/sdk/snapshots/snap_test_sdk/test_publish_sdk src_fern_api_core_client_wrapper.py
@@ -10,7 +10,11 @@ class BaseClientWrapper:
         self.header_auth = header_auth
 
     def get_headers(self) -> typing.Dict[str, str]:
-        headers: typing.Dict[str, str] = {}
+        headers: typing.Dict[str, str] = {
+            "X-Fern-Language": "Python",
+            "X-Fern-SDK-Name": "my-package-name",
+            "X-Fern-SDK-Version": "1.0.0",
+        }
         headers["X-Header-Auth"] = f"MyPrefix {self.header_auth}"
         return headers
 

--- a/tests/sdk/snapshots/snap_test_sdk/test_streaming_sdk core_client_wrapper.py
+++ b/tests/sdk/snapshots/snap_test_sdk/test_streaming_sdk core_client_wrapper.py
@@ -10,7 +10,7 @@ class BaseClientWrapper:
         pass
 
     def get_headers(self) -> typing.Dict[str, str]:
-        headers: typing.Dict[str, str] = {}
+        headers: typing.Dict[str, str] = {"X-Fern-Language": "Python"}
         return headers
 
 

--- a/tests/sdk/snapshots/snap_test_sdk/test_trace_sdk core_client_wrapper.py
+++ b/tests/sdk/snapshots/snap_test_sdk/test_trace_sdk core_client_wrapper.py
@@ -16,7 +16,7 @@ class BaseClientWrapper:
         self._token = token
 
     def get_headers(self) -> typing.Dict[str, str]:
-        headers: typing.Dict[str, str] = {}
+        headers: typing.Dict[str, str] = {"X-Fern-Language": "Python"}
         if self._x_random_header is not None:
             headers["X-Random-Header"] = self._x_random_header
         token = self._get_token()


### PR DESCRIPTION
The SDKs will send the headers `X-Fern-Language`, `X-Fern-SDK-Name` and `X-Fern-SDK-Version` with each API call. 