### PR TITLE
fix: sdk calls response.read() is called before parsing any errors in streaming

### DIFF
--- a/src/fern_python/generators/sdk/client_generator/endpoint_response_code_writer.py
+++ b/src/fern_python/generators/sdk/client_generator/endpoint_response_code_writer.py
@@ -117,20 +117,21 @@ class EndpointResponseCodeWriter:
                     file_download=lambda _: self._handle_success_file_download(writer=writer),
                 )
 
-        for error in self._endpoint.errors.get_as_list():
-            # in streaming responses, we need to call read() or aread()
-            # before deserializing or httpx will raise ResponseNotRead
-            if self._endpoint.sdk_response is not None and (
-                self._endpoint.sdk_response.get_as_union().type == "streaming"
-                or self._endpoint.sdk_response.get_as_union().type == "fileDownload"
-            ):
-                writer.write_line(
-                    f"await {EndpointResponseCodeWriter.RESPONSE_VARIABLE}.aread()"
-                    if self._is_async
-                    else f"{EndpointResponseCodeWriter.RESPONSE_VARIABLE}.read()"
-                )
+        # in streaming responses, we need to call read() or aread()
+        # before deserializing or httpx will raise ResponseNotRead
+        if self._endpoint.sdk_response is not None and (
+            self._endpoint.sdk_response.get_as_union().type == "streaming"
+            or self._endpoint.sdk_response.get_as_union().type == "fileDownload"
+        ):
+            writer.write_line(
+                f"await {EndpointResponseCodeWriter.RESPONSE_VARIABLE}.aread()"
+                if self._is_async
+                else f"{EndpointResponseCodeWriter.RESPONSE_VARIABLE}.read()"
+            )
 
+        for error in self._endpoint.errors.get_as_list():
             error_declaration = self._context.ir.errors[error.error.error_id]
+
             writer.write_line(
                 f"if {EndpointResponseCodeWriter.RESPONSE_VARIABLE}.status_code == {error_declaration.status_code}:"
             )

--- a/src/fern_python/generators/sdk/client_generator/endpoint_response_code_writer.py
+++ b/src/fern_python/generators/sdk/client_generator/endpoint_response_code_writer.py
@@ -118,8 +118,19 @@ class EndpointResponseCodeWriter:
                 )
 
         for error in self._endpoint.errors.get_as_list():
-            error_declaration = self._context.ir.errors[error.error.error_id]
+            # in streaming responses, we need to call read() or aread()
+            # before deserializing or httpx will raise ResponseNotRead
+            if self._endpoint.sdk_response is not None and (
+                self._endpoint.sdk_response.get_as_union().type == "streaming"
+                or self._endpoint.sdk_response.get_as_union().type == "fileDownload"
+            ):
+                writer.write_line(
+                    f"await {EndpointResponseCodeWriter.RESPONSE_VARIABLE}.aread()"
+                    if self._is_async
+                    else f"{EndpointResponseCodeWriter.RESPONSE_VARIABLE}.read()"
+                )
 
+            error_declaration = self._context.ir.errors[error.error.error_id]
             writer.write_line(
                 f"if {EndpointResponseCodeWriter.RESPONSE_VARIABLE}.status_code == {error_declaration.status_code}:"
             )
@@ -223,17 +234,6 @@ class EndpointResponseCodeWriter:
         writer.write_newline_if_last_line_not()
 
     def _deserialize_json_response(self, *, writer: AST.NodeWriter) -> None:
-        # in streaming responses, we need to call read() or aread()
-        # before deserializing or httpx will raise ResponseNotRead
-        if self._endpoint.sdk_response is not None and (
-            self._endpoint.sdk_response.get_as_union().type == "streaming"
-            or self._endpoint.sdk_response.get_as_union().type == "fileDownload"
-        ):
-            writer.write_line(
-                f"await {EndpointResponseCodeWriter.RESPONSE_VARIABLE}.aread()"
-                if self._is_async
-                else f"{EndpointResponseCodeWriter.RESPONSE_VARIABLE}.read()"
-            )
         writer.write_line(
             f"{EndpointResponseCodeWriter.RESPONSE_JSON_VARIABLE} = {EndpointResponseCodeWriter.RESPONSE_VARIABLE}.json()"
         )

--- a/tests/sdk/snapshots/snap_test_sdk/test_file_upload_sdk resources_movie_client.py
+++ b/tests/sdk/snapshots/snap_test_sdk/test_file_upload_sdk resources_movie_client.py
@@ -58,6 +58,7 @@ class MovieClient:
                 for _chunk in _response.iter_bytes():
                     yield _chunk
                 return
+            _response.read()
             try:
                 _response_json = _response.json()
             except JSONDecodeError:
@@ -110,6 +111,7 @@ class AsyncMovieClient:
                 async for _chunk in _response.aiter_bytes():
                     yield _chunk
                 return
+            await _response.aread()
             try:
                 _response_json = _response.json()
             except JSONDecodeError:

--- a/tests/sdk/snapshots/snap_test_sdk/test_file_upload_sdk resources_movie_client.py
+++ b/tests/sdk/snapshots/snap_test_sdk/test_file_upload_sdk resources_movie_client.py
@@ -59,7 +59,6 @@ class MovieClient:
                     yield _chunk
                 return
             try:
-                _response.read()
                 _response_json = _response.json()
             except JSONDecodeError:
                 raise ApiError(status_code=_response.status_code, body=_response.text)
@@ -112,7 +111,6 @@ class AsyncMovieClient:
                     yield _chunk
                 return
             try:
-                await _response.aread()
                 _response_json = _response.json()
             except JSONDecodeError:
                 raise ApiError(status_code=_response.status_code, body=_response.text)

--- a/tests/sdk/snapshots/snap_test_sdk/test_streaming_sdk resources_ai_client.py
+++ b/tests/sdk/snapshots/snap_test_sdk/test_streaming_sdk resources_ai_client.py
@@ -39,6 +39,7 @@ class AiClient:
                         continue
                     yield pydantic.parse_obj_as(StreamResponse, json.loads(_text))  # type: ignore
                 return
+            _response.read()
             try:
                 _response_json = _response.json()
             except JSONDecodeError:
@@ -69,6 +70,7 @@ class AsyncAiClient:
                         continue
                     yield pydantic.parse_obj_as(StreamResponse, json.loads(_text))  # type: ignore
                 return
+            await _response.aread()
             try:
                 _response_json = _response.json()
             except JSONDecodeError:

--- a/tests/sdk/snapshots/snap_test_sdk/test_streaming_sdk resources_ai_client.py
+++ b/tests/sdk/snapshots/snap_test_sdk/test_streaming_sdk resources_ai_client.py
@@ -40,7 +40,6 @@ class AiClient:
                     yield pydantic.parse_obj_as(StreamResponse, json.loads(_text))  # type: ignore
                 return
             try:
-                _response.read()
                 _response_json = _response.json()
             except JSONDecodeError:
                 raise ApiError(status_code=_response.status_code, body=_response.text)
@@ -71,7 +70,6 @@ class AsyncAiClient:
                     yield pydantic.parse_obj_as(StreamResponse, json.loads(_text))  # type: ignore
                 return
             try:
-                await _response.aread()
                 _response_json = _response.json()
             except JSONDecodeError:
                 raise ApiError(status_code=_response.status_code, body=_response.text)


### PR DESCRIPTION
In a streaming endpoint, we must call `response.read()` before calling `response.json()`