### PR TITLE
support flat-mode instead of just src mode in package layout

### DIFF
--- a/src/fern_python/cli/abstract_generator.py
+++ b/src/fern_python/cli/abstract_generator.py
@@ -47,6 +47,7 @@ class AbstractGenerator(ABC):
             project_config=project_config,
             should_format_files=self.should_format_files(generator_config=generator_config),
             sorted_modules=self.get_sorted_modules(),
+            flat_layout=self.is_flat_layout(),
         ) as project:
             self.run(
                 generator_exec_wrapper=generator_exec_wrapper, ir=ir, generator_config=generator_config, project=project
@@ -219,6 +220,14 @@ def test_client() -> None:
         generator_config: GeneratorConfig,
         ir: ir_types.IntermediateRepresentation,
     ) -> Tuple[str, ...]:
+        ...
+
+    @abstractmethod
+    def is_flat_layout(
+        self,
+        *,
+        generator_config: GeneratorConfig,
+    ) -> bool:
         ...
 
     @abstractmethod

--- a/src/fern_python/cli/abstract_generator.py
+++ b/src/fern_python/cli/abstract_generator.py
@@ -47,7 +47,7 @@ class AbstractGenerator(ABC):
             project_config=project_config,
             should_format_files=self.should_format_files(generator_config=generator_config),
             sorted_modules=self.get_sorted_modules(),
-            flat_layout=self.is_flat_layout(),
+            flat_layout=self.is_flat_layout(generator_config=generator_config),
         ) as project:
             self.run(
                 generator_exec_wrapper=generator_exec_wrapper, ir=ir, generator_config=generator_config, project=project

--- a/src/fern_python/codegen/project.py
+++ b/src/fern_python/codegen/project.py
@@ -37,10 +37,16 @@ class Project:
         project_config: ProjectConfig = None,
         should_format_files: bool,
         sorted_modules: Optional[Sequence[str]] = None,
+        flat_layout: bool = False,
     ) -> None:
-        self._project_filepath = (
-            filepath if project_config is None else os.path.join(filepath, "src", relative_path_to_project)
-        )
+        if flat_layout: 
+            self._project_filepath = (
+                filepath if project_config is None else os.path.join(filepath, relative_path_to_project)
+            )
+        else: 
+            self._project_filepath = (
+                filepath if project_config is None else os.path.join(filepath, "src", relative_path_to_project)
+            )
         self._root_filepath = filepath
         self._relative_path_to_project = relative_path_to_project
         self._project_config = project_config

--- a/src/fern_python/codegen/project.py
+++ b/src/fern_python/codegen/project.py
@@ -39,11 +39,11 @@ class Project:
         sorted_modules: Optional[Sequence[str]] = None,
         flat_layout: bool = False,
     ) -> None:
-        if flat_layout: 
+        if flat_layout:
             self._project_filepath = (
                 filepath if project_config is None else os.path.join(filepath, relative_path_to_project)
             )
-        else: 
+        else:
             self._project_filepath = (
                 filepath if project_config is None else os.path.join(filepath, "src", relative_path_to_project)
             )

--- a/src/fern_python/codegen/pyproject_toml.py
+++ b/src/fern_python/codegen/pyproject_toml.py
@@ -68,8 +68,7 @@ name = "{self.name}"'''
             s += """
 description = ""
 readme = "README.md"
-authors = []
-"""
+authors = []"""
             if self.package._from is not None:
                 s += f"""
 packages = [

--- a/src/fern_python/codegen/pyproject_toml.py
+++ b/src/fern_python/codegen/pyproject_toml.py
@@ -15,7 +15,7 @@ from fern_python.codegen.dependency_manager import DependencyManager
 @dataclass(frozen=True)
 class PyProjectTomlPackageConfig:
     include: str
-    _from: str
+    _from: Optional[str] = None
 
 
 class PyProjectToml:
@@ -65,12 +65,21 @@ class PyProjectToml:
 name = "{self.name}"'''
             if self.version is not None:
                 s += "\n" + f'version = "{self.version}"'
-            s += f"""
+            s += """
 description = ""
 readme = "README.md"
 authors = []
+"""
+            if self.package._from is not None:
+                s += f"""
 packages = [
     {{ include = "{self.package.include}", from = "{self.package._from}"}}
+]
+"""
+            else:
+                s += f"""
+packages = [
+    {{ include = "{self.package.include}"}}
 ]
 """
             return s

--- a/src/fern_python/generators/fastapi/fastapi_generator.py
+++ b/src/fern_python/generators/fastapi/fastapi_generator.py
@@ -159,5 +159,7 @@ class FastApiGenerator(AbstractGenerator):
 
     def is_flat_layout(
         self,
+        *,
+        generator_config: GeneratorConfig,
     ) -> bool:
         return False

--- a/src/fern_python/generators/fastapi/fastapi_generator.py
+++ b/src/fern_python/generators/fastapi/fastapi_generator.py
@@ -156,3 +156,8 @@ class FastApiGenerator(AbstractGenerator):
 
     def get_sorted_modules(self) -> None:
         return None
+
+    def is_flat_layout(
+        self,
+    ) -> bool:
+        return False

--- a/src/fern_python/generators/pydantic_model/pydantic_model_generator.py
+++ b/src/fern_python/generators/pydantic_model/pydantic_model_generator.py
@@ -99,3 +99,8 @@ class PydanticModelGenerator(AbstractGenerator):
 
     def get_sorted_modules(self) -> None:
         return None
+
+    def is_flat_layout(
+        self,
+    ) -> bool:
+        return False

--- a/src/fern_python/generators/pydantic_model/pydantic_model_generator.py
+++ b/src/fern_python/generators/pydantic_model/pydantic_model_generator.py
@@ -102,5 +102,7 @@ class PydanticModelGenerator(AbstractGenerator):
 
     def is_flat_layout(
         self,
+        *,
+        generator_config: GeneratorConfig,
     ) -> bool:
         return False

--- a/src/fern_python/generators/sdk/custom_config.py
+++ b/src/fern_python/generators/sdk/custom_config.py
@@ -12,3 +12,4 @@ class SDKCustomConfig(pydantic.BaseModel):
     use_api_name_in_package: bool = False
     package_name: Optional[str] = None
     timeout_in_seconds: Union[Literal["infinity"], int] = 60
+    flat_layout: bool = False

--- a/src/fern_python/generators/sdk/sdk_generator.py
+++ b/src/fern_python/generators/sdk/sdk_generator.py
@@ -230,3 +230,11 @@ class SdkGenerator(AbstractGenerator):
         # always import types/errors before resources (nested packages)
         # to avoid issues with circular imports
         return [".types", ".errors", ".resources"]
+
+    def is_flat_layout(
+        self,
+        *,
+        generator_config: GeneratorConfig,
+    ) -> bool:
+        custom_config = SDKCustomConfig.parse_obj(generator_config.custom_config or {})
+        return custom_config.flat_layout


### PR DESCRIPTION
python packages were always nested under `src/` but now we have added a mode to support flat mode. This is particularly important when making PRs to an existing python sdk that is already in flat mode. 