### PR TITLE
Share Pydantic config with FastAPI generator

### DIFF
--- a/src/fern_python/generators/fastapi/custom_config.py
+++ b/src/fern_python/generators/fastapi/custom_config.py
@@ -1,14 +1,10 @@
 import pydantic
 
-
-class PydanticConfig(pydantic.BaseModel):
-    frozen: bool = False
-    orm_mode: bool = False
-    smart_union: bool = False
+from ..pydantic_model.custom_config import BasePydanticModelCustomConfig
 
 
 class FastAPICustomConfig(pydantic.BaseModel):
     include_validators: bool = False
     skip_formatting: bool = False
     async_handlers: bool = False
-    pydantic_config: PydanticConfig = PydanticConfig()
+    pydantic_config: BasePydanticModelCustomConfig = BasePydanticModelCustomConfig()

--- a/src/fern_python/generators/fastapi/fastapi_generator.py
+++ b/src/fern_python/generators/fastapi/fastapi_generator.py
@@ -54,12 +54,13 @@ class FastApiGenerator(AbstractGenerator):
         self._pydantic_model_custom_config = PydanticModelCustomConfig(
             forbid_extra_fields=True,
             wrapped_aliases=True,
+            include_union_utils=True,
             include_validators=custom_config.include_validators,
             skip_formatting=custom_config.skip_formatting,
-            include_union_utils=True,
-            frozen=custom_config.pydantic_config.frozen,
-            orm_mode=custom_config.pydantic_config.orm_mode,
-            smart_union=custom_config.pydantic_config.smart_union,
+            # FastAPI generator config only exposes base pydantic settings.
+            # To merge the base config into the final pydantic config, we need to
+            # cast BasePydanticModelCustomConfig to dict and unpack into kwargs
+            **custom_config.pydantic_config.dict(),
         )
 
         context = FastApiGeneratorContextImpl(ir=ir, generator_config=generator_config)

--- a/src/fern_python/generators/pydantic_model/custom_config.py
+++ b/src/fern_python/generators/pydantic_model/custom_config.py
@@ -1,13 +1,16 @@
 import pydantic
 
 
-class PydanticModelCustomConfig(pydantic.BaseModel):
+class BasePydanticModelCustomConfig(pydantic.BaseModel):
+    frozen: bool = False
+    orm_mode: bool = False
+    smart_union: bool = False
+    require_optional_fields: bool = True
+
+
+class PydanticModelCustomConfig(BasePydanticModelCustomConfig):
     include_validators: bool = False
     forbid_extra_fields: bool = False
     wrapped_aliases: bool = False
     skip_formatting: bool = False
     include_union_utils: bool = False
-    frozen: bool = False
-    orm_mode: bool = False
-    smart_union: bool = False
-    require_optional_fields: bool = True


### PR DESCRIPTION
N.B. this doesn't touch the SDK generator, so the new `require_optional_fields` config option won't have any effect there. We could add it to the `SDKCustomConfig` model but that kinda clashes with the `BasePydanticModelCustomConfig` merging approach used here—let me know what you think!