### PR TITLE
fix: dont generate blank readme if fern cloud generates

### DIFF
--- a/src/fern_python/codegen/project.py
+++ b/src/fern_python/codegen/project.py
@@ -47,6 +47,7 @@ class Project:
             self._project_filepath = (
                 filepath if project_config is None else os.path.join(filepath, "src", relative_path_to_project)
             )
+        self._generate_readme = True
         self._root_filepath = filepath
         self._relative_path_to_project = relative_path_to_project
         self._project_config = project_config
@@ -54,6 +55,9 @@ class Project:
         self._python_version = python_version
         self._dependency_manager = DependencyManager()
         self._should_format_files = should_format_files
+
+    def set_generate_readme(self, generate_readme: bool) -> None:
+        self._generate_readme = generate_readme
 
     def source_file(self, filepath: Filepath) -> SourceFile:
         """
@@ -119,8 +123,9 @@ class Project:
                 f.write("")
 
             # generate empty README so poetry doesn't fail
-            with open(os.path.join(self._root_filepath, "README.md"), "w") as f:
-                f.write("")
+            if self._generate_readme:
+                with open(os.path.join(self._root_filepath, "README.md"), "w") as f:
+                    f.write("")
 
     def __enter__(self) -> Project:
         return self

--- a/src/fern_python/generator_exec_wrapper/generator_exec_wrapper.py
+++ b/src/fern_python/generator_exec_wrapper/generator_exec_wrapper.py
@@ -26,6 +26,9 @@ class GeneratorExecWrapper:
         if self.generator_exec_client is not None and self.task_id is not None:
             self.generator_exec_client.logging.send_update(task_id=self.task_id, request=generator_updates)
 
-    def generate_readme(self, generate_readme_request: GenerateReadmeRequest) -> None:
+    # Returns if the request was actually sent
+    def generate_readme(self, generate_readme_request: GenerateReadmeRequest) -> bool:
         if self.generator_exec_client is not None and self.task_id is not None:
             self.generator_exec_client.readme.generate_readme(task_id=self.task_id, request=generate_readme_request)
+            return True
+        return False

--- a/src/fern_python/generators/sdk/sdk_generator.py
+++ b/src/fern_python/generators/sdk/sdk_generator.py
@@ -140,8 +140,8 @@ class SdkGenerator(AbstractGenerator):
 
         output_mode = generator_config.output.mode.get_as_union()
         if output_mode.type == "github":
-            capitalized_org_name = {generator_config.organization.capitalize()}
-            generator_exec_wrapper.generate_readme(
+            capitalized_org_name = generator_config.organization.capitalize()
+            request_sent = generator_exec_wrapper.generate_readme(
                 GenerateReadmeRequest(
                     title=f"{capitalized_org_name} Python Library",
                     summary=f"The {capitalized_org_name} Python Library provides convenient access to the {capitalized_org_name} from applications written in Python.",
@@ -149,6 +149,8 @@ class SdkGenerator(AbstractGenerator):
                     requirements=[],
                 )
             )
+            if request_sent:
+                project.set_generate_readme(False)
 
     def _generate_environments(
         self,


### PR DESCRIPTION
The generator should not generate a README.md if fern cloud is going to generate one