### PR TITLE
Allow for optional allow-multiple query params

### DIFF
--- a/seed/sdk/examples/src/seed/resources/service/client.py
+++ b/seed/sdk/examples/src/seed/resources/service/client.py
@@ -83,14 +83,14 @@ class ServiceClient:
         self,
         *,
         shallow: typing.Optional[bool] = None,
-        tag: typing.Optional[typing.Union[typing.Optional[str], typing.List[str]]] = None,
+        tag: typing.Optional[typing.Union[str, typing.List[str]]] = None,
         x_api_version: str,
     ) -> Metadata:
         """
         Parameters:
             - shallow: typing.Optional[bool].
 
-            - tag: typing.Optional[typing.Union[typing.Optional[str], typing.List[str]]].
+            - tag: typing.Optional[typing.Union[str, typing.List[str]]].
 
             - x_api_version: str.
         ---
@@ -178,14 +178,14 @@ class AsyncServiceClient:
         self,
         *,
         shallow: typing.Optional[bool] = None,
-        tag: typing.Optional[typing.Union[typing.Optional[str], typing.List[str]]] = None,
+        tag: typing.Optional[typing.Union[str, typing.List[str]]] = None,
         x_api_version: str,
     ) -> Metadata:
         """
         Parameters:
             - shallow: typing.Optional[bool].
 
-            - tag: typing.Optional[typing.Union[typing.Optional[str], typing.List[str]]].
+            - tag: typing.Optional[typing.Union[str, typing.List[str]]].
 
             - x_api_version: str.
         ---

--- a/seed/sdk/examples/src/seed/resources/service/client.py
+++ b/seed/sdk/examples/src/seed/resources/service/client.py
@@ -83,14 +83,14 @@ class ServiceClient:
         self,
         *,
         shallow: typing.Optional[bool] = None,
-        tag: typing.Union[typing.Optional[str], typing.List[str]],
+        tag: typing.Optional[typing.Union[typing.Optional[str], typing.List[str]]] = None,
         x_api_version: str,
     ) -> Metadata:
         """
         Parameters:
             - shallow: typing.Optional[bool].
 
-            - tag: typing.Union[typing.Optional[str], typing.List[str]].
+            - tag: typing.Optional[typing.Union[typing.Optional[str], typing.List[str]]].
 
             - x_api_version: str.
         ---
@@ -178,14 +178,14 @@ class AsyncServiceClient:
         self,
         *,
         shallow: typing.Optional[bool] = None,
-        tag: typing.Union[typing.Optional[str], typing.List[str]],
+        tag: typing.Optional[typing.Union[typing.Optional[str], typing.List[str]]] = None,
         x_api_version: str,
     ) -> Metadata:
         """
         Parameters:
             - shallow: typing.Optional[bool].
 
-            - tag: typing.Union[typing.Optional[str], typing.List[str]].
+            - tag: typing.Optional[typing.Union[typing.Optional[str], typing.List[str]]].
 
             - x_api_version: str.
         ---

--- a/seed/sdk/trace/src/seed/resources/playlist/client.py
+++ b/seed/sdk/trace/src/seed/resources/playlist/client.py
@@ -81,7 +81,7 @@ class PlaylistClient:
         limit: typing.Optional[int] = None,
         other_field: str,
         multi_line_docs: str,
-        optional_multiple_field: typing.Optional[typing.Union[typing.Optional[str], typing.List[str]]] = None,
+        optional_multiple_field: typing.Optional[typing.Union[str, typing.List[str]]] = None,
         multiple_field: typing.Union[str, typing.List[str]],
     ) -> typing.List[Playlist]:
         """
@@ -97,7 +97,7 @@ class PlaylistClient:
             - multi_line_docs: str. I'm a multiline
                                     description
 
-            - optional_multiple_field: typing.Optional[typing.Union[typing.Optional[str], typing.List[str]]].
+            - optional_multiple_field: typing.Optional[typing.Union[str, typing.List[str]]].
 
             - multiple_field: typing.Union[str, typing.List[str]].
         """
@@ -271,7 +271,7 @@ class AsyncPlaylistClient:
         limit: typing.Optional[int] = None,
         other_field: str,
         multi_line_docs: str,
-        optional_multiple_field: typing.Optional[typing.Union[typing.Optional[str], typing.List[str]]] = None,
+        optional_multiple_field: typing.Optional[typing.Union[str, typing.List[str]]] = None,
         multiple_field: typing.Union[str, typing.List[str]],
     ) -> typing.List[Playlist]:
         """
@@ -287,7 +287,7 @@ class AsyncPlaylistClient:
             - multi_line_docs: str. I'm a multiline
                                     description
 
-            - optional_multiple_field: typing.Optional[typing.Union[typing.Optional[str], typing.List[str]]].
+            - optional_multiple_field: typing.Optional[typing.Union[str, typing.List[str]]].
 
             - multiple_field: typing.Union[str, typing.List[str]].
         """

--- a/seed/sdk/trace/src/seed/resources/playlist/client.py
+++ b/seed/sdk/trace/src/seed/resources/playlist/client.py
@@ -81,7 +81,7 @@ class PlaylistClient:
         limit: typing.Optional[int] = None,
         other_field: str,
         multi_line_docs: str,
-        optional_multiple_field: typing.Union[typing.Optional[str], typing.List[str]],
+        optional_multiple_field: typing.Optional[typing.Union[typing.Optional[str], typing.List[str]]] = None,
         multiple_field: typing.Union[str, typing.List[str]],
     ) -> typing.List[Playlist]:
         """
@@ -97,7 +97,7 @@ class PlaylistClient:
             - multi_line_docs: str. I'm a multiline
                                     description
 
-            - optional_multiple_field: typing.Union[typing.Optional[str], typing.List[str]].
+            - optional_multiple_field: typing.Optional[typing.Union[typing.Optional[str], typing.List[str]]].
 
             - multiple_field: typing.Union[str, typing.List[str]].
         """
@@ -271,7 +271,7 @@ class AsyncPlaylistClient:
         limit: typing.Optional[int] = None,
         other_field: str,
         multi_line_docs: str,
-        optional_multiple_field: typing.Union[typing.Optional[str], typing.List[str]],
+        optional_multiple_field: typing.Optional[typing.Union[typing.Optional[str], typing.List[str]]] = None,
         multiple_field: typing.Union[str, typing.List[str]],
     ) -> typing.List[Playlist]:
         """
@@ -287,7 +287,7 @@ class AsyncPlaylistClient:
             - multi_line_docs: str. I'm a multiline
                                     description
 
-            - optional_multiple_field: typing.Union[typing.Optional[str], typing.List[str]].
+            - optional_multiple_field: typing.Optional[typing.Union[typing.Optional[str], typing.List[str]]].
 
             - multiple_field: typing.Union[str, typing.List[str]].
         """

--- a/src/fern_python/generators/sdk/client_generator/endpoint_function_generator.py
+++ b/src/fern_python/generators/sdk/client_generator/endpoint_function_generator.py
@@ -705,7 +705,9 @@ class EndpointFunctionGenerator:
         is_optional = value_type.type == "container" and value_type.container.get_as_union().type == "optional"
         if is_optional and query_parameter.allow_multiple:
             return AST.TypeHint.optional(AST.TypeHint.union(
-                query_parameter_type_hint,
+                self._context.pydantic_generator_context.get_type_hint_for_type_reference(
+                    unwrap_optional_type(query_parameter.value_type)
+                ),
                 AST.TypeHint.list(
                     self._context.pydantic_generator_context.get_type_hint_for_type_reference(
                         unwrap_optional_type(query_parameter.value_type)

--- a/src/fern_python/generators/sdk/client_generator/endpoint_function_generator.py
+++ b/src/fern_python/generators/sdk/client_generator/endpoint_function_generator.py
@@ -149,7 +149,7 @@ class EndpointFunctionGenerator:
                 AST.NamedFunctionParameter(
                     name=self._get_query_parameter_name(query_parameter),
                     docs=query_parameter.docs,
-                    type_hint=self._get_typehint_for_query_param(query_parameter,query_parameter_type_hint),
+                    type_hint=self._get_typehint_for_query_param(query_parameter, query_parameter_type_hint),
                 ),
             )
 
@@ -170,7 +170,7 @@ class EndpointFunctionGenerator:
 
         return parameters
 
-    def _get_typehint_for_query_param(query_param, query_parameter_type_hint):
+    def _get_typehint_for_query_param(self, query_param, query_parameter_type_hint):
         if query_param.is_optional and query_param.allow_multiple:
             return AST.TypeHint.optional(AST.TypeHint.union(
                 query_parameter_type_hint,
@@ -189,8 +189,7 @@ class EndpointFunctionGenerator:
                     )
                 ),
             )
-        else:
-            return query_parameter_type_hint,
+        return query_parameter_type_hint
 
     def _create_endpoint_body_writer(
         self,


### PR DESCRIPTION
Previously, when a query parameter was set to allow-multiple, it would no longer be optional. This PR attempts to fix that.