### PR TITLE
Use concurrency for codegen

### DIFF
--- a/src/fern_python/generator_exec_wrapper/generator_exec_wrapper.py
+++ b/src/fern_python/generator_exec_wrapper/generator_exec_wrapper.py
@@ -7,12 +7,15 @@ from fern.generator_exec.resources.config import (
 )
 from fern.generator_exec.resources.logging import GeneratorUpdate, TaskId
 from fern.generator_exec.resources.readme import GenerateReadmeRequest
+from concurrent.futures import Executor, ThreadPoolExecutor
 
 
 class GeneratorExecWrapper:
     def __init__(self, generator_config: GeneratorConfig):
         self.generator_exec_client: typing.Optional[FernGeneratorExec] = None
         self.task_id: typing.Optional[TaskId] = None
+        # TODO(tjb9dc): It would be nice for this to be configurable, namely on multiprocess vs threading and parallelization factor
+        self.executor: Executor = ThreadPoolExecutor(max_workers=10)
         generator_config.environment.visit(local=lambda: (), remote=lambda env: self._init_remote(env))
 
     def _init_remote(self, env: RemoteGeneratorEnvironment) -> None:

--- a/src/fern_python/generator_exec_wrapper/generator_exec_wrapper.py
+++ b/src/fern_python/generator_exec_wrapper/generator_exec_wrapper.py
@@ -15,7 +15,7 @@ class GeneratorExecWrapper:
         self.generator_exec_client: typing.Optional[FernGeneratorExec] = None
         self.task_id: typing.Optional[TaskId] = None
         # TODO(tjb9dc): It would be nice for this to be configurable, namely on multiprocess vs threading and parallelization factor
-        self.executor: Executor = ThreadPoolExecutor(max_workers=10)
+        self.executor: Executor = ThreadPoolExecutor()
         generator_config.environment.visit(local=lambda: (), remote=lambda env: self._init_remote(env))
 
     def _init_remote(self, env: RemoteGeneratorEnvironment) -> None:


### PR DESCRIPTION
Attempt to use python concurrency to run all the codegen things. Supply a thread executor with parallelization of 10 as the default, but ideally this would be configurable for the user to tweak (between SERIAL/MULTIPROCESS/MULTITHREAD and parallelization factor).

Also explored asyncio, but the theory is that we're blocked on local resources so going with concurrency instead!