### PR TITLE
Codegen is deterministic sans formatting (Take 3)

### DIFF
--- a/src/fern_python/codegen/ast/nodes/declarations/class_/class_declaration.py
+++ b/src/fern_python/codegen/ast/nodes/declarations/class_/class_declaration.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from typing import List, Optional, Sequence, Set
+from typing import List, Optional, Sequence
+
+from ordered_set import OrderedSet
 
 from ....ast_node import AstNode, AstNodeMetadata, NodeWriter
 from ....references import ClassReference, Module, Reference, ReferenceImport
@@ -39,7 +41,7 @@ class ClassDeclaration(AstNode):
         self.snippet = snippet
         self.class_vars: List[VariableDeclaration] = []
         self.statements: List[AstNode] = []
-        self.ghost_references: Set[Reference] = set()
+        self.ghost_references: OrderedSet[Reference] = OrderedSet()
 
     def add_class_var(self, variable_declaration: VariableDeclaration) -> None:
         self.class_vars.append(variable_declaration)
@@ -125,7 +127,8 @@ class ClassDeclaration(AstNode):
     def get_metadata(self) -> AstNodeMetadata:
         metadata = AstNodeMetadata()
         metadata.declarations.add(self.name)
-        metadata.references.update({*self.extends, *self.ghost_references})
+        metadata.references.update(self.extends)
+        metadata.references.update(self.ghost_references)
         if self.constructor is not None:
             metadata.update(self.constructor.get_metadata())
         for class_var in self.class_vars:

--- a/src/fern_python/codegen/reference_resolver_impl.py
+++ b/src/fern_python/codegen/reference_resolver_impl.py
@@ -2,6 +2,8 @@ import dataclasses
 from collections import defaultdict
 from typing import DefaultDict, Dict, Optional, Set
 
+from ordered_set import OrderedSet
+
 from . import AST
 from .reference_resolver import ReferenceResolver
 
@@ -15,7 +17,7 @@ class ResolvedImport:
 class ReferenceResolverImpl(ReferenceResolver):
     def __init__(self, module_path_of_source_file: AST.ModulePath):
         self._module_path_of_source_file = module_path_of_source_file
-        self._default_name_to_original_references: DefaultDict[AST.QualifiedName, Set[AST.Reference]] = defaultdict(set)
+        self._default_name_to_original_references: DefaultDict[AST.QualifiedName, OrderedSet[AST.Reference]] = defaultdict(OrderedSet)
         self._original_import_to_resolved_import: Optional[Dict[AST.ReferenceImport, ResolvedImport]] = None
         self._does_file_self_import = False
         self._declarations: Set[AST.QualifiedName] = set()
@@ -34,7 +36,7 @@ class ReferenceResolverImpl(ReferenceResolver):
             # get the set of all imports that result in this default name.
             # if len(set) > 1, or this default name is the same as a declaration,
             # then there's a collision, so we need to alias the imports.
-            original_imports = set(
+            original_imports = OrderedSet(
                 reference.import_ for reference in original_references if reference.import_ is not None
             )
 


### PR DESCRIPTION
This actually makes sense for why `abc` and `fastapi` are getting mixed up