### PR TITLE
pass httpx client

### DIFF
--- a/seed/sdk/api-wide-base-path/src/seed/client.py
+++ b/seed/sdk/api-wide-base-path/src/seed/client.py
@@ -9,12 +9,24 @@ from .resources.service.client import AsyncServiceClient, ServiceClient
 
 
 class SeedApiWideBasePath:
-    def __init__(self, *, base_url: str, timeout: typing.Optional[float] = 60):
-        self._client_wrapper = SyncClientWrapper(base_url=base_url, httpx_client=httpx.Client(timeout=timeout))
+    def __init__(
+        self, *, base_url: str, timeout: typing.Optional[float] = 60, httpx_client: typing.Optional[httpx.Client] = None
+    ):
+        self._client_wrapper = SyncClientWrapper(
+            base_url=base_url, httpx_client=httpx.Client(timeout=timeout) if httpx_client is None else httpx_client
+        )
         self.service = ServiceClient(client_wrapper=self._client_wrapper)
 
 
 class AsyncSeedApiWideBasePath:
-    def __init__(self, *, base_url: str, timeout: typing.Optional[float] = 60):
-        self._client_wrapper = AsyncClientWrapper(base_url=base_url, httpx_client=httpx.AsyncClient(timeout=timeout))
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        timeout: typing.Optional[float] = 60,
+        httpx_client: typing.Optional[httpx.AsyncClient] = None
+    ):
+        self._client_wrapper = AsyncClientWrapper(
+            base_url=base_url, httpx_client=httpx.AsyncClient(timeout=timeout) if httpx_client is None else httpx_client
+        )
         self.service = AsyncServiceClient(client_wrapper=self._client_wrapper)

--- a/seed/sdk/audiences/src/seed/client.py
+++ b/seed/sdk/audiences/src/seed/client.py
@@ -10,14 +10,26 @@ from .resources.foo.client import AsyncFooClient, FooClient
 
 
 class SeedAudiences:
-    def __init__(self, *, base_url: str, timeout: typing.Optional[float] = 60):
-        self._client_wrapper = SyncClientWrapper(base_url=base_url, httpx_client=httpx.Client(timeout=timeout))
+    def __init__(
+        self, *, base_url: str, timeout: typing.Optional[float] = 60, httpx_client: typing.Optional[httpx.Client] = None
+    ):
+        self._client_wrapper = SyncClientWrapper(
+            base_url=base_url, httpx_client=httpx.Client(timeout=timeout) if httpx_client is None else httpx_client
+        )
         self.folder_a = FolderAClient(client_wrapper=self._client_wrapper)
         self.foo = FooClient(client_wrapper=self._client_wrapper)
 
 
 class AsyncSeedAudiences:
-    def __init__(self, *, base_url: str, timeout: typing.Optional[float] = 60):
-        self._client_wrapper = AsyncClientWrapper(base_url=base_url, httpx_client=httpx.AsyncClient(timeout=timeout))
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        timeout: typing.Optional[float] = 60,
+        httpx_client: typing.Optional[httpx.AsyncClient] = None
+    ):
+        self._client_wrapper = AsyncClientWrapper(
+            base_url=base_url, httpx_client=httpx.AsyncClient(timeout=timeout) if httpx_client is None else httpx_client
+        )
         self.folder_a = AsyncFolderAClient(client_wrapper=self._client_wrapper)
         self.foo = AsyncFooClient(client_wrapper=self._client_wrapper)

--- a/seed/sdk/auth-environment-variables/src/seed/client.py
+++ b/seed/sdk/auth-environment-variables/src/seed/client.py
@@ -9,16 +9,34 @@ from .resources.service.client import AsyncServiceClient, ServiceClient
 
 
 class SeedAuthEnvironmentVariables:
-    def __init__(self, *, base_url: str, api_key: str, timeout: typing.Optional[float] = 60):
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        api_key: str,
+        timeout: typing.Optional[float] = 60,
+        httpx_client: typing.Optional[httpx.Client] = None
+    ):
         self._client_wrapper = SyncClientWrapper(
-            base_url=base_url, api_key=api_key, httpx_client=httpx.Client(timeout=timeout)
+            base_url=base_url,
+            api_key=api_key,
+            httpx_client=httpx.Client(timeout=timeout) if httpx_client is None else httpx_client,
         )
         self.service = ServiceClient(client_wrapper=self._client_wrapper)
 
 
 class AsyncSeedAuthEnvironmentVariables:
-    def __init__(self, *, base_url: str, api_key: str, timeout: typing.Optional[float] = 60):
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        api_key: str,
+        timeout: typing.Optional[float] = 60,
+        httpx_client: typing.Optional[httpx.AsyncClient] = None
+    ):
         self._client_wrapper = AsyncClientWrapper(
-            base_url=base_url, api_key=api_key, httpx_client=httpx.AsyncClient(timeout=timeout)
+            base_url=base_url,
+            api_key=api_key,
+            httpx_client=httpx.AsyncClient(timeout=timeout) if httpx_client is None else httpx_client,
         )
         self.service = AsyncServiceClient(client_wrapper=self._client_wrapper)

--- a/seed/sdk/basic-auth/src/seed/client.py
+++ b/seed/sdk/basic-auth/src/seed/client.py
@@ -15,10 +15,14 @@ class SeedBasicAuth:
         base_url: str,
         username: typing.Union[str, typing.Callable[[], str]],
         password: typing.Union[str, typing.Callable[[], str]],
-        timeout: typing.Optional[float] = 60
+        timeout: typing.Optional[float] = 60,
+        httpx_client: typing.Optional[httpx.Client] = None
     ):
         self._client_wrapper = SyncClientWrapper(
-            base_url=base_url, username=username, password=password, httpx_client=httpx.Client(timeout=timeout)
+            base_url=base_url,
+            username=username,
+            password=password,
+            httpx_client=httpx.Client(timeout=timeout) if httpx_client is None else httpx_client,
         )
         self.basic_auth = BasicAuthClient(client_wrapper=self._client_wrapper)
 
@@ -30,9 +34,13 @@ class AsyncSeedBasicAuth:
         base_url: str,
         username: typing.Union[str, typing.Callable[[], str]],
         password: typing.Union[str, typing.Callable[[], str]],
-        timeout: typing.Optional[float] = 60
+        timeout: typing.Optional[float] = 60,
+        httpx_client: typing.Optional[httpx.AsyncClient] = None
     ):
         self._client_wrapper = AsyncClientWrapper(
-            base_url=base_url, username=username, password=password, httpx_client=httpx.AsyncClient(timeout=timeout)
+            base_url=base_url,
+            username=username,
+            password=password,
+            httpx_client=httpx.AsyncClient(timeout=timeout) if httpx_client is None else httpx_client,
         )
         self.basic_auth = AsyncBasicAuthClient(client_wrapper=self._client_wrapper)

--- a/seed/sdk/circular-references/src/seed/client.py
+++ b/seed/sdk/circular-references/src/seed/client.py
@@ -8,10 +8,22 @@ from .core.client_wrapper import AsyncClientWrapper, SyncClientWrapper
 
 
 class SeedApi:
-    def __init__(self, *, base_url: str, timeout: typing.Optional[float] = 60):
-        self._client_wrapper = SyncClientWrapper(base_url=base_url, httpx_client=httpx.Client(timeout=timeout))
+    def __init__(
+        self, *, base_url: str, timeout: typing.Optional[float] = 60, httpx_client: typing.Optional[httpx.Client] = None
+    ):
+        self._client_wrapper = SyncClientWrapper(
+            base_url=base_url, httpx_client=httpx.Client(timeout=timeout) if httpx_client is None else httpx_client
+        )
 
 
 class AsyncSeedApi:
-    def __init__(self, *, base_url: str, timeout: typing.Optional[float] = 60):
-        self._client_wrapper = AsyncClientWrapper(base_url=base_url, httpx_client=httpx.AsyncClient(timeout=timeout))
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        timeout: typing.Optional[float] = 60,
+        httpx_client: typing.Optional[httpx.AsyncClient] = None
+    ):
+        self._client_wrapper = AsyncClientWrapper(
+            base_url=base_url, httpx_client=httpx.AsyncClient(timeout=timeout) if httpx_client is None else httpx_client
+        )

--- a/seed/sdk/custom-auth/src/seed/client.py
+++ b/seed/sdk/custom-auth/src/seed/client.py
@@ -9,16 +9,34 @@ from .resources.custom_auth.client import AsyncCustomAuthClient, CustomAuthClien
 
 
 class SeedCustomAuth:
-    def __init__(self, *, base_url: str, custom_auth_scheme: str, timeout: typing.Optional[float] = 60):
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        custom_auth_scheme: str,
+        timeout: typing.Optional[float] = 60,
+        httpx_client: typing.Optional[httpx.Client] = None
+    ):
         self._client_wrapper = SyncClientWrapper(
-            base_url=base_url, custom_auth_scheme=custom_auth_scheme, httpx_client=httpx.Client(timeout=timeout)
+            base_url=base_url,
+            custom_auth_scheme=custom_auth_scheme,
+            httpx_client=httpx.Client(timeout=timeout) if httpx_client is None else httpx_client,
         )
         self.custom_auth = CustomAuthClient(client_wrapper=self._client_wrapper)
 
 
 class AsyncSeedCustomAuth:
-    def __init__(self, *, base_url: str, custom_auth_scheme: str, timeout: typing.Optional[float] = 60):
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        custom_auth_scheme: str,
+        timeout: typing.Optional[float] = 60,
+        httpx_client: typing.Optional[httpx.AsyncClient] = None
+    ):
         self._client_wrapper = AsyncClientWrapper(
-            base_url=base_url, custom_auth_scheme=custom_auth_scheme, httpx_client=httpx.AsyncClient(timeout=timeout)
+            base_url=base_url,
+            custom_auth_scheme=custom_auth_scheme,
+            httpx_client=httpx.AsyncClient(timeout=timeout) if httpx_client is None else httpx_client,
         )
         self.custom_auth = AsyncCustomAuthClient(client_wrapper=self._client_wrapper)

--- a/seed/sdk/error-property/src/seed/client.py
+++ b/seed/sdk/error-property/src/seed/client.py
@@ -9,12 +9,24 @@ from .resources.property_based_error.client import AsyncPropertyBasedErrorClient
 
 
 class SeedErrorProperty:
-    def __init__(self, *, base_url: str, timeout: typing.Optional[float] = 60):
-        self._client_wrapper = SyncClientWrapper(base_url=base_url, httpx_client=httpx.Client(timeout=timeout))
+    def __init__(
+        self, *, base_url: str, timeout: typing.Optional[float] = 60, httpx_client: typing.Optional[httpx.Client] = None
+    ):
+        self._client_wrapper = SyncClientWrapper(
+            base_url=base_url, httpx_client=httpx.Client(timeout=timeout) if httpx_client is None else httpx_client
+        )
         self.property_based_error = PropertyBasedErrorClient(client_wrapper=self._client_wrapper)
 
 
 class AsyncSeedErrorProperty:
-    def __init__(self, *, base_url: str, timeout: typing.Optional[float] = 60):
-        self._client_wrapper = AsyncClientWrapper(base_url=base_url, httpx_client=httpx.AsyncClient(timeout=timeout))
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        timeout: typing.Optional[float] = 60,
+        httpx_client: typing.Optional[httpx.AsyncClient] = None
+    ):
+        self._client_wrapper = AsyncClientWrapper(
+            base_url=base_url, httpx_client=httpx.AsyncClient(timeout=timeout) if httpx_client is None else httpx_client
+        )
         self.property_based_error = AsyncPropertyBasedErrorClient(client_wrapper=self._client_wrapper)

--- a/seed/sdk/examples/src/seed/client.py
+++ b/seed/sdk/examples/src/seed/client.py
@@ -29,12 +29,13 @@ class SeedExamples:
         base_url: typing.Optional[str] = None,
         environment: typing.Optional[SeedExamplesEnvironment] = None,
         token: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
-        timeout: typing.Optional[float] = 60
+        timeout: typing.Optional[float] = 60,
+        httpx_client: typing.Optional[httpx.Client] = None
     ):
         self._client_wrapper = SyncClientWrapper(
             base_url=_get_base_url(base_url=base_url, environment=environment),
             token=token,
-            httpx_client=httpx.Client(timeout=timeout),
+            httpx_client=httpx.Client(timeout=timeout) if httpx_client is None else httpx_client,
         )
         self.file = FileClient(client_wrapper=self._client_wrapper)
         self.health = HealthClient(client_wrapper=self._client_wrapper)
@@ -79,12 +80,13 @@ class AsyncSeedExamples:
         base_url: typing.Optional[str] = None,
         environment: typing.Optional[SeedExamplesEnvironment] = None,
         token: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
-        timeout: typing.Optional[float] = 60
+        timeout: typing.Optional[float] = 60,
+        httpx_client: typing.Optional[httpx.AsyncClient] = None
     ):
         self._client_wrapper = AsyncClientWrapper(
             base_url=_get_base_url(base_url=base_url, environment=environment),
             token=token,
-            httpx_client=httpx.AsyncClient(timeout=timeout),
+            httpx_client=httpx.AsyncClient(timeout=timeout) if httpx_client is None else httpx_client,
         )
         self.file = AsyncFileClient(client_wrapper=self._client_wrapper)
         self.health = AsyncHealthClient(client_wrapper=self._client_wrapper)

--- a/seed/sdk/exhaustive/five-second-timeout/src/seed/client.py
+++ b/seed/sdk/exhaustive/five-second-timeout/src/seed/client.py
@@ -18,10 +18,13 @@ class SeedExhaustive:
         *,
         base_url: str,
         token: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
-        timeout: typing.Optional[float] = 5
+        timeout: typing.Optional[float] = 5,
+        httpx_client: typing.Optional[httpx.Client] = None
     ):
         self._client_wrapper = SyncClientWrapper(
-            base_url=base_url, token=token, httpx_client=httpx.Client(timeout=timeout)
+            base_url=base_url,
+            token=token,
+            httpx_client=httpx.Client(timeout=timeout) if httpx_client is None else httpx_client,
         )
         self.endpoints = EndpointsClient(client_wrapper=self._client_wrapper)
         self.inlined_requests = InlinedRequestsClient(client_wrapper=self._client_wrapper)
@@ -36,10 +39,13 @@ class AsyncSeedExhaustive:
         *,
         base_url: str,
         token: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
-        timeout: typing.Optional[float] = 5
+        timeout: typing.Optional[float] = 5,
+        httpx_client: typing.Optional[httpx.AsyncClient] = None
     ):
         self._client_wrapper = AsyncClientWrapper(
-            base_url=base_url, token=token, httpx_client=httpx.AsyncClient(timeout=timeout)
+            base_url=base_url,
+            token=token,
+            httpx_client=httpx.AsyncClient(timeout=timeout) if httpx_client is None else httpx_client,
         )
         self.endpoints = AsyncEndpointsClient(client_wrapper=self._client_wrapper)
         self.inlined_requests = AsyncInlinedRequestsClient(client_wrapper=self._client_wrapper)

--- a/seed/sdk/exhaustive/infinite-timeout/src/seed/client.py
+++ b/seed/sdk/exhaustive/infinite-timeout/src/seed/client.py
@@ -18,10 +18,13 @@ class SeedExhaustive:
         *,
         base_url: str,
         token: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
-        timeout: typing.Optional[float] = None
+        timeout: typing.Optional[float] = None,
+        httpx_client: typing.Optional[httpx.Client] = None
     ):
         self._client_wrapper = SyncClientWrapper(
-            base_url=base_url, token=token, httpx_client=httpx.Client(timeout=timeout)
+            base_url=base_url,
+            token=token,
+            httpx_client=httpx.Client(timeout=timeout) if httpx_client is None else httpx_client,
         )
         self.endpoints = EndpointsClient(client_wrapper=self._client_wrapper)
         self.inlined_requests = InlinedRequestsClient(client_wrapper=self._client_wrapper)
@@ -36,10 +39,13 @@ class AsyncSeedExhaustive:
         *,
         base_url: str,
         token: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
-        timeout: typing.Optional[float] = None
+        timeout: typing.Optional[float] = None,
+        httpx_client: typing.Optional[httpx.AsyncClient] = None
     ):
         self._client_wrapper = AsyncClientWrapper(
-            base_url=base_url, token=token, httpx_client=httpx.AsyncClient(timeout=timeout)
+            base_url=base_url,
+            token=token,
+            httpx_client=httpx.AsyncClient(timeout=timeout) if httpx_client is None else httpx_client,
         )
         self.endpoints = AsyncEndpointsClient(client_wrapper=self._client_wrapper)
         self.inlined_requests = AsyncInlinedRequestsClient(client_wrapper=self._client_wrapper)

--- a/seed/sdk/exhaustive/no-custom-config/src/seed/client.py
+++ b/seed/sdk/exhaustive/no-custom-config/src/seed/client.py
@@ -18,10 +18,13 @@ class SeedExhaustive:
         *,
         base_url: str,
         token: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
-        timeout: typing.Optional[float] = 60
+        timeout: typing.Optional[float] = 60,
+        httpx_client: typing.Optional[httpx.Client] = None
     ):
         self._client_wrapper = SyncClientWrapper(
-            base_url=base_url, token=token, httpx_client=httpx.Client(timeout=timeout)
+            base_url=base_url,
+            token=token,
+            httpx_client=httpx.Client(timeout=timeout) if httpx_client is None else httpx_client,
         )
         self.endpoints = EndpointsClient(client_wrapper=self._client_wrapper)
         self.inlined_requests = InlinedRequestsClient(client_wrapper=self._client_wrapper)
@@ -36,10 +39,13 @@ class AsyncSeedExhaustive:
         *,
         base_url: str,
         token: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
-        timeout: typing.Optional[float] = 60
+        timeout: typing.Optional[float] = 60,
+        httpx_client: typing.Optional[httpx.AsyncClient] = None
     ):
         self._client_wrapper = AsyncClientWrapper(
-            base_url=base_url, token=token, httpx_client=httpx.AsyncClient(timeout=timeout)
+            base_url=base_url,
+            token=token,
+            httpx_client=httpx.AsyncClient(timeout=timeout) if httpx_client is None else httpx_client,
         )
         self.endpoints = AsyncEndpointsClient(client_wrapper=self._client_wrapper)
         self.inlined_requests = AsyncInlinedRequestsClient(client_wrapper=self._client_wrapper)

--- a/seed/sdk/exhaustive/union-utils/src/seed/client.py
+++ b/seed/sdk/exhaustive/union-utils/src/seed/client.py
@@ -18,10 +18,13 @@ class SeedExhaustive:
         *,
         base_url: str,
         token: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
-        timeout: typing.Optional[float] = 60
+        timeout: typing.Optional[float] = 60,
+        httpx_client: typing.Optional[httpx.Client] = None
     ):
         self._client_wrapper = SyncClientWrapper(
-            base_url=base_url, token=token, httpx_client=httpx.Client(timeout=timeout)
+            base_url=base_url,
+            token=token,
+            httpx_client=httpx.Client(timeout=timeout) if httpx_client is None else httpx_client,
         )
         self.endpoints = EndpointsClient(client_wrapper=self._client_wrapper)
         self.inlined_requests = InlinedRequestsClient(client_wrapper=self._client_wrapper)
@@ -36,10 +39,13 @@ class AsyncSeedExhaustive:
         *,
         base_url: str,
         token: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
-        timeout: typing.Optional[float] = 60
+        timeout: typing.Optional[float] = 60,
+        httpx_client: typing.Optional[httpx.AsyncClient] = None
     ):
         self._client_wrapper = AsyncClientWrapper(
-            base_url=base_url, token=token, httpx_client=httpx.AsyncClient(timeout=timeout)
+            base_url=base_url,
+            token=token,
+            httpx_client=httpx.AsyncClient(timeout=timeout) if httpx_client is None else httpx_client,
         )
         self.endpoints = AsyncEndpointsClient(client_wrapper=self._client_wrapper)
         self.inlined_requests = AsyncInlinedRequestsClient(client_wrapper=self._client_wrapper)

--- a/seed/sdk/file-download/src/seed/client.py
+++ b/seed/sdk/file-download/src/seed/client.py
@@ -9,12 +9,24 @@ from .resources.service.client import AsyncServiceClient, ServiceClient
 
 
 class SeedFileDownload:
-    def __init__(self, *, base_url: str, timeout: typing.Optional[float] = 60):
-        self._client_wrapper = SyncClientWrapper(base_url=base_url, httpx_client=httpx.Client(timeout=timeout))
+    def __init__(
+        self, *, base_url: str, timeout: typing.Optional[float] = 60, httpx_client: typing.Optional[httpx.Client] = None
+    ):
+        self._client_wrapper = SyncClientWrapper(
+            base_url=base_url, httpx_client=httpx.Client(timeout=timeout) if httpx_client is None else httpx_client
+        )
         self.service = ServiceClient(client_wrapper=self._client_wrapper)
 
 
 class AsyncSeedFileDownload:
-    def __init__(self, *, base_url: str, timeout: typing.Optional[float] = 60):
-        self._client_wrapper = AsyncClientWrapper(base_url=base_url, httpx_client=httpx.AsyncClient(timeout=timeout))
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        timeout: typing.Optional[float] = 60,
+        httpx_client: typing.Optional[httpx.AsyncClient] = None
+    ):
+        self._client_wrapper = AsyncClientWrapper(
+            base_url=base_url, httpx_client=httpx.AsyncClient(timeout=timeout) if httpx_client is None else httpx_client
+        )
         self.service = AsyncServiceClient(client_wrapper=self._client_wrapper)

--- a/seed/sdk/file-upload/src/seed/client.py
+++ b/seed/sdk/file-upload/src/seed/client.py
@@ -9,12 +9,24 @@ from .resources.service.client import AsyncServiceClient, ServiceClient
 
 
 class SeedFileUpload:
-    def __init__(self, *, base_url: str, timeout: typing.Optional[float] = 60):
-        self._client_wrapper = SyncClientWrapper(base_url=base_url, httpx_client=httpx.Client(timeout=timeout))
+    def __init__(
+        self, *, base_url: str, timeout: typing.Optional[float] = 60, httpx_client: typing.Optional[httpx.Client] = None
+    ):
+        self._client_wrapper = SyncClientWrapper(
+            base_url=base_url, httpx_client=httpx.Client(timeout=timeout) if httpx_client is None else httpx_client
+        )
         self.service = ServiceClient(client_wrapper=self._client_wrapper)
 
 
 class AsyncSeedFileUpload:
-    def __init__(self, *, base_url: str, timeout: typing.Optional[float] = 60):
-        self._client_wrapper = AsyncClientWrapper(base_url=base_url, httpx_client=httpx.AsyncClient(timeout=timeout))
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        timeout: typing.Optional[float] = 60,
+        httpx_client: typing.Optional[httpx.AsyncClient] = None
+    ):
+        self._client_wrapper = AsyncClientWrapper(
+            base_url=base_url, httpx_client=httpx.AsyncClient(timeout=timeout) if httpx_client is None else httpx_client
+        )
         self.service = AsyncServiceClient(client_wrapper=self._client_wrapper)

--- a/seed/sdk/folders/src/seed/client.py
+++ b/seed/sdk/folders/src/seed/client.py
@@ -12,8 +12,12 @@ from .resources.folder.client import AsyncFolderClient, FolderClient
 
 
 class SeedApi:
-    def __init__(self, *, base_url: str, timeout: typing.Optional[float] = 60):
-        self._client_wrapper = SyncClientWrapper(base_url=base_url, httpx_client=httpx.Client(timeout=timeout))
+    def __init__(
+        self, *, base_url: str, timeout: typing.Optional[float] = 60, httpx_client: typing.Optional[httpx.Client] = None
+    ):
+        self._client_wrapper = SyncClientWrapper(
+            base_url=base_url, httpx_client=httpx.Client(timeout=timeout) if httpx_client is None else httpx_client
+        )
         self.a = AClient(client_wrapper=self._client_wrapper)
         self.folder = FolderClient(client_wrapper=self._client_wrapper)
 
@@ -31,8 +35,16 @@ class SeedApi:
 
 
 class AsyncSeedApi:
-    def __init__(self, *, base_url: str, timeout: typing.Optional[float] = 60):
-        self._client_wrapper = AsyncClientWrapper(base_url=base_url, httpx_client=httpx.AsyncClient(timeout=timeout))
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        timeout: typing.Optional[float] = 60,
+        httpx_client: typing.Optional[httpx.AsyncClient] = None
+    ):
+        self._client_wrapper = AsyncClientWrapper(
+            base_url=base_url, httpx_client=httpx.AsyncClient(timeout=timeout) if httpx_client is None else httpx_client
+        )
         self.a = AsyncAClient(client_wrapper=self._client_wrapper)
         self.folder = AsyncFolderClient(client_wrapper=self._client_wrapper)
 

--- a/seed/sdk/imdb/src/seed/client.py
+++ b/seed/sdk/imdb/src/seed/client.py
@@ -14,10 +14,13 @@ class SeedApi:
         *,
         base_url: str,
         token: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
-        timeout: typing.Optional[float] = 60
+        timeout: typing.Optional[float] = 60,
+        httpx_client: typing.Optional[httpx.Client] = None
     ):
         self._client_wrapper = SyncClientWrapper(
-            base_url=base_url, token=token, httpx_client=httpx.Client(timeout=timeout)
+            base_url=base_url,
+            token=token,
+            httpx_client=httpx.Client(timeout=timeout) if httpx_client is None else httpx_client,
         )
         self.imdb = ImdbClient(client_wrapper=self._client_wrapper)
 
@@ -28,9 +31,12 @@ class AsyncSeedApi:
         *,
         base_url: str,
         token: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
-        timeout: typing.Optional[float] = 60
+        timeout: typing.Optional[float] = 60,
+        httpx_client: typing.Optional[httpx.AsyncClient] = None
     ):
         self._client_wrapper = AsyncClientWrapper(
-            base_url=base_url, token=token, httpx_client=httpx.AsyncClient(timeout=timeout)
+            base_url=base_url,
+            token=token,
+            httpx_client=httpx.AsyncClient(timeout=timeout) if httpx_client is None else httpx_client,
         )
         self.imdb = AsyncImdbClient(client_wrapper=self._client_wrapper)

--- a/seed/sdk/literal-headers/src/seed/client.py
+++ b/seed/sdk/literal-headers/src/seed/client.py
@@ -18,10 +18,14 @@ class SeedNurseryApi:
         base_url: str,
         api_header: typing_extensions.Literal["api header value"],
         api_test: bool,
-        timeout: typing.Optional[float] = 60
+        timeout: typing.Optional[float] = 60,
+        httpx_client: typing.Optional[httpx.Client] = None
     ):
         self._client_wrapper = SyncClientWrapper(
-            base_url=base_url, api_header=api_header, api_test=api_test, httpx_client=httpx.Client(timeout=timeout)
+            base_url=base_url,
+            api_header=api_header,
+            api_test=api_test,
+            httpx_client=httpx.Client(timeout=timeout) if httpx_client is None else httpx_client,
         )
         self.no_headers = NoHeadersClient(client_wrapper=self._client_wrapper)
         self.only_literal_headers = OnlyLiteralHeadersClient(client_wrapper=self._client_wrapper)
@@ -35,10 +39,14 @@ class AsyncSeedNurseryApi:
         base_url: str,
         api_header: typing_extensions.Literal["api header value"],
         api_test: bool,
-        timeout: typing.Optional[float] = 60
+        timeout: typing.Optional[float] = 60,
+        httpx_client: typing.Optional[httpx.AsyncClient] = None
     ):
         self._client_wrapper = AsyncClientWrapper(
-            base_url=base_url, api_header=api_header, api_test=api_test, httpx_client=httpx.AsyncClient(timeout=timeout)
+            base_url=base_url,
+            api_header=api_header,
+            api_test=api_test,
+            httpx_client=httpx.AsyncClient(timeout=timeout) if httpx_client is None else httpx_client,
         )
         self.no_headers = AsyncNoHeadersClient(client_wrapper=self._client_wrapper)
         self.only_literal_headers = AsyncOnlyLiteralHeadersClient(client_wrapper=self._client_wrapper)

--- a/seed/sdk/literal/src/seed/client.py
+++ b/seed/sdk/literal/src/seed/client.py
@@ -9,12 +9,24 @@ from .resources.literal.client import AsyncLiteralClient, LiteralClient
 
 
 class SeedLiteral:
-    def __init__(self, *, base_url: str, timeout: typing.Optional[float] = 60):
-        self._client_wrapper = SyncClientWrapper(base_url=base_url, httpx_client=httpx.Client(timeout=timeout))
+    def __init__(
+        self, *, base_url: str, timeout: typing.Optional[float] = 60, httpx_client: typing.Optional[httpx.Client] = None
+    ):
+        self._client_wrapper = SyncClientWrapper(
+            base_url=base_url, httpx_client=httpx.Client(timeout=timeout) if httpx_client is None else httpx_client
+        )
         self.literal = LiteralClient(client_wrapper=self._client_wrapper)
 
 
 class AsyncSeedLiteral:
-    def __init__(self, *, base_url: str, timeout: typing.Optional[float] = 60):
-        self._client_wrapper = AsyncClientWrapper(base_url=base_url, httpx_client=httpx.AsyncClient(timeout=timeout))
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        timeout: typing.Optional[float] = 60,
+        httpx_client: typing.Optional[httpx.AsyncClient] = None
+    ):
+        self._client_wrapper = AsyncClientWrapper(
+            base_url=base_url, httpx_client=httpx.AsyncClient(timeout=timeout) if httpx_client is None else httpx_client
+        )
         self.literal = AsyncLiteralClient(client_wrapper=self._client_wrapper)

--- a/seed/sdk/multi-url-environment/src/seed/client.py
+++ b/seed/sdk/multi-url-environment/src/seed/client.py
@@ -16,10 +16,13 @@ class SeedMultiUrlEnvironment:
         *,
         environment: SeedMultiUrlEnvironmentEnvironment = SeedMultiUrlEnvironmentEnvironment.PRODUCTION,
         token: typing.Union[str, typing.Callable[[], str]],
-        timeout: typing.Optional[float] = 60
+        timeout: typing.Optional[float] = 60,
+        httpx_client: typing.Optional[httpx.Client] = None
     ):
         self._client_wrapper = SyncClientWrapper(
-            environment=environment, token=token, httpx_client=httpx.Client(timeout=timeout)
+            environment=environment,
+            token=token,
+            httpx_client=httpx.Client(timeout=timeout) if httpx_client is None else httpx_client,
         )
         self.ec_2 = Ec2Client(client_wrapper=self._client_wrapper)
         self.s_3 = S3Client(client_wrapper=self._client_wrapper)
@@ -31,10 +34,13 @@ class AsyncSeedMultiUrlEnvironment:
         *,
         environment: SeedMultiUrlEnvironmentEnvironment = SeedMultiUrlEnvironmentEnvironment.PRODUCTION,
         token: typing.Union[str, typing.Callable[[], str]],
-        timeout: typing.Optional[float] = 60
+        timeout: typing.Optional[float] = 60,
+        httpx_client: typing.Optional[httpx.AsyncClient] = None
     ):
         self._client_wrapper = AsyncClientWrapper(
-            environment=environment, token=token, httpx_client=httpx.AsyncClient(timeout=timeout)
+            environment=environment,
+            token=token,
+            httpx_client=httpx.AsyncClient(timeout=timeout) if httpx_client is None else httpx_client,
         )
         self.ec_2 = AsyncEc2Client(client_wrapper=self._client_wrapper)
         self.s_3 = AsyncS3Client(client_wrapper=self._client_wrapper)

--- a/seed/sdk/no-environment/src/seed/client.py
+++ b/seed/sdk/no-environment/src/seed/client.py
@@ -10,19 +10,33 @@ from .resources.dummy.client import AsyncDummyClient, DummyClient
 
 class SeedNoEnvironment:
     def __init__(
-        self, *, base_url: str, token: typing.Union[str, typing.Callable[[], str]], timeout: typing.Optional[float] = 60
+        self,
+        *,
+        base_url: str,
+        token: typing.Union[str, typing.Callable[[], str]],
+        timeout: typing.Optional[float] = 60,
+        httpx_client: typing.Optional[httpx.Client] = None
     ):
         self._client_wrapper = SyncClientWrapper(
-            base_url=base_url, token=token, httpx_client=httpx.Client(timeout=timeout)
+            base_url=base_url,
+            token=token,
+            httpx_client=httpx.Client(timeout=timeout) if httpx_client is None else httpx_client,
         )
         self.dummy = DummyClient(client_wrapper=self._client_wrapper)
 
 
 class AsyncSeedNoEnvironment:
     def __init__(
-        self, *, base_url: str, token: typing.Union[str, typing.Callable[[], str]], timeout: typing.Optional[float] = 60
+        self,
+        *,
+        base_url: str,
+        token: typing.Union[str, typing.Callable[[], str]],
+        timeout: typing.Optional[float] = 60,
+        httpx_client: typing.Optional[httpx.AsyncClient] = None
     ):
         self._client_wrapper = AsyncClientWrapper(
-            base_url=base_url, token=token, httpx_client=httpx.AsyncClient(timeout=timeout)
+            base_url=base_url,
+            token=token,
+            httpx_client=httpx.AsyncClient(timeout=timeout) if httpx_client is None else httpx_client,
         )
         self.dummy = AsyncDummyClient(client_wrapper=self._client_wrapper)

--- a/seed/sdk/package-yml/src/seed/client.py
+++ b/seed/sdk/package-yml/src/seed/client.py
@@ -21,8 +21,12 @@ OMIT = typing.cast(typing.Any, ...)
 
 
 class SeedPackageYml:
-    def __init__(self, *, base_url: str, timeout: typing.Optional[float] = 60):
-        self._client_wrapper = SyncClientWrapper(base_url=base_url, httpx_client=httpx.Client(timeout=timeout))
+    def __init__(
+        self, *, base_url: str, timeout: typing.Optional[float] = 60, httpx_client: typing.Optional[httpx.Client] = None
+    ):
+        self._client_wrapper = SyncClientWrapper(
+            base_url=base_url, httpx_client=httpx.Client(timeout=timeout) if httpx_client is None else httpx_client
+        )
         self.service = ServiceClient(client_wrapper=self._client_wrapper)
 
     def echo(self, id: str, *, request: str) -> str:
@@ -59,8 +63,16 @@ class SeedPackageYml:
 
 
 class AsyncSeedPackageYml:
-    def __init__(self, *, base_url: str, timeout: typing.Optional[float] = 60):
-        self._client_wrapper = AsyncClientWrapper(base_url=base_url, httpx_client=httpx.AsyncClient(timeout=timeout))
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        timeout: typing.Optional[float] = 60,
+        httpx_client: typing.Optional[httpx.AsyncClient] = None,
+    ):
+        self._client_wrapper = AsyncClientWrapper(
+            base_url=base_url, httpx_client=httpx.AsyncClient(timeout=timeout) if httpx_client is None else httpx_client
+        )
         self.service = AsyncServiceClient(client_wrapper=self._client_wrapper)
 
     async def echo(self, id: str, *, request: str) -> str:

--- a/seed/sdk/plain-text/src/seed/client.py
+++ b/seed/sdk/plain-text/src/seed/client.py
@@ -9,12 +9,24 @@ from .resources.service.client import AsyncServiceClient, ServiceClient
 
 
 class SeedPlainText:
-    def __init__(self, *, base_url: str, timeout: typing.Optional[float] = 60):
-        self._client_wrapper = SyncClientWrapper(base_url=base_url, httpx_client=httpx.Client(timeout=timeout))
+    def __init__(
+        self, *, base_url: str, timeout: typing.Optional[float] = 60, httpx_client: typing.Optional[httpx.Client] = None
+    ):
+        self._client_wrapper = SyncClientWrapper(
+            base_url=base_url, httpx_client=httpx.Client(timeout=timeout) if httpx_client is None else httpx_client
+        )
         self.service = ServiceClient(client_wrapper=self._client_wrapper)
 
 
 class AsyncSeedPlainText:
-    def __init__(self, *, base_url: str, timeout: typing.Optional[float] = 60):
-        self._client_wrapper = AsyncClientWrapper(base_url=base_url, httpx_client=httpx.AsyncClient(timeout=timeout))
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        timeout: typing.Optional[float] = 60,
+        httpx_client: typing.Optional[httpx.AsyncClient] = None
+    ):
+        self._client_wrapper = AsyncClientWrapper(
+            base_url=base_url, httpx_client=httpx.AsyncClient(timeout=timeout) if httpx_client is None else httpx_client
+        )
         self.service = AsyncServiceClient(client_wrapper=self._client_wrapper)

--- a/seed/sdk/response-property/src/seed/client.py
+++ b/seed/sdk/response-property/src/seed/client.py
@@ -9,12 +9,24 @@ from .resources.service.client import AsyncServiceClient, ServiceClient
 
 
 class SeedResponseProperty:
-    def __init__(self, *, base_url: str, timeout: typing.Optional[float] = 60):
-        self._client_wrapper = SyncClientWrapper(base_url=base_url, httpx_client=httpx.Client(timeout=timeout))
+    def __init__(
+        self, *, base_url: str, timeout: typing.Optional[float] = 60, httpx_client: typing.Optional[httpx.Client] = None
+    ):
+        self._client_wrapper = SyncClientWrapper(
+            base_url=base_url, httpx_client=httpx.Client(timeout=timeout) if httpx_client is None else httpx_client
+        )
         self.service = ServiceClient(client_wrapper=self._client_wrapper)
 
 
 class AsyncSeedResponseProperty:
-    def __init__(self, *, base_url: str, timeout: typing.Optional[float] = 60):
-        self._client_wrapper = AsyncClientWrapper(base_url=base_url, httpx_client=httpx.AsyncClient(timeout=timeout))
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        timeout: typing.Optional[float] = 60,
+        httpx_client: typing.Optional[httpx.AsyncClient] = None
+    ):
+        self._client_wrapper = AsyncClientWrapper(
+            base_url=base_url, httpx_client=httpx.AsyncClient(timeout=timeout) if httpx_client is None else httpx_client
+        )
         self.service = AsyncServiceClient(client_wrapper=self._client_wrapper)

--- a/seed/sdk/single-url-environment-default/src/seed/client.py
+++ b/seed/sdk/single-url-environment-default/src/seed/client.py
@@ -16,12 +16,13 @@ class SeedSingleUrlEnvironmentDefault:
         base_url: typing.Optional[str] = None,
         environment: SeedSingleUrlEnvironmentDefaultEnvironment = SeedSingleUrlEnvironmentDefaultEnvironment.PRODUCTION,
         token: typing.Union[str, typing.Callable[[], str]],
-        timeout: typing.Optional[float] = 60
+        timeout: typing.Optional[float] = 60,
+        httpx_client: typing.Optional[httpx.Client] = None
     ):
         self._client_wrapper = SyncClientWrapper(
             base_url=_get_base_url(base_url=base_url, environment=environment),
             token=token,
-            httpx_client=httpx.Client(timeout=timeout),
+            httpx_client=httpx.Client(timeout=timeout) if httpx_client is None else httpx_client,
         )
         self.dummy = DummyClient(client_wrapper=self._client_wrapper)
 
@@ -33,12 +34,13 @@ class AsyncSeedSingleUrlEnvironmentDefault:
         base_url: typing.Optional[str] = None,
         environment: SeedSingleUrlEnvironmentDefaultEnvironment = SeedSingleUrlEnvironmentDefaultEnvironment.PRODUCTION,
         token: typing.Union[str, typing.Callable[[], str]],
-        timeout: typing.Optional[float] = 60
+        timeout: typing.Optional[float] = 60,
+        httpx_client: typing.Optional[httpx.AsyncClient] = None
     ):
         self._client_wrapper = AsyncClientWrapper(
             base_url=_get_base_url(base_url=base_url, environment=environment),
             token=token,
-            httpx_client=httpx.AsyncClient(timeout=timeout),
+            httpx_client=httpx.AsyncClient(timeout=timeout) if httpx_client is None else httpx_client,
         )
         self.dummy = AsyncDummyClient(client_wrapper=self._client_wrapper)
 

--- a/seed/sdk/single-url-environment-no-default/src/seed/client.py
+++ b/seed/sdk/single-url-environment-no-default/src/seed/client.py
@@ -16,12 +16,13 @@ class SeedSingleUrlEnvironmentNoDefault:
         base_url: typing.Optional[str] = None,
         environment: typing.Optional[SeedSingleUrlEnvironmentNoDefaultEnvironment] = None,
         token: typing.Union[str, typing.Callable[[], str]],
-        timeout: typing.Optional[float] = 60
+        timeout: typing.Optional[float] = 60,
+        httpx_client: typing.Optional[httpx.Client] = None
     ):
         self._client_wrapper = SyncClientWrapper(
             base_url=_get_base_url(base_url=base_url, environment=environment),
             token=token,
-            httpx_client=httpx.Client(timeout=timeout),
+            httpx_client=httpx.Client(timeout=timeout) if httpx_client is None else httpx_client,
         )
         self.dummy = DummyClient(client_wrapper=self._client_wrapper)
 
@@ -33,12 +34,13 @@ class AsyncSeedSingleUrlEnvironmentNoDefault:
         base_url: typing.Optional[str] = None,
         environment: typing.Optional[SeedSingleUrlEnvironmentNoDefaultEnvironment] = None,
         token: typing.Union[str, typing.Callable[[], str]],
-        timeout: typing.Optional[float] = 60
+        timeout: typing.Optional[float] = 60,
+        httpx_client: typing.Optional[httpx.AsyncClient] = None
     ):
         self._client_wrapper = AsyncClientWrapper(
             base_url=_get_base_url(base_url=base_url, environment=environment),
             token=token,
-            httpx_client=httpx.AsyncClient(timeout=timeout),
+            httpx_client=httpx.AsyncClient(timeout=timeout) if httpx_client is None else httpx_client,
         )
         self.dummy = AsyncDummyClient(client_wrapper=self._client_wrapper)
 

--- a/seed/sdk/streaming/src/seed/client.py
+++ b/seed/sdk/streaming/src/seed/client.py
@@ -9,12 +9,24 @@ from .resources.dummy.client import AsyncDummyClient, DummyClient
 
 
 class SeedStreaming:
-    def __init__(self, *, base_url: str, timeout: typing.Optional[float] = 60):
-        self._client_wrapper = SyncClientWrapper(base_url=base_url, httpx_client=httpx.Client(timeout=timeout))
+    def __init__(
+        self, *, base_url: str, timeout: typing.Optional[float] = 60, httpx_client: typing.Optional[httpx.Client] = None
+    ):
+        self._client_wrapper = SyncClientWrapper(
+            base_url=base_url, httpx_client=httpx.Client(timeout=timeout) if httpx_client is None else httpx_client
+        )
         self.dummy = DummyClient(client_wrapper=self._client_wrapper)
 
 
 class AsyncSeedStreaming:
-    def __init__(self, *, base_url: str, timeout: typing.Optional[float] = 60):
-        self._client_wrapper = AsyncClientWrapper(base_url=base_url, httpx_client=httpx.AsyncClient(timeout=timeout))
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        timeout: typing.Optional[float] = 60,
+        httpx_client: typing.Optional[httpx.AsyncClient] = None
+    ):
+        self._client_wrapper = AsyncClientWrapper(
+            base_url=base_url, httpx_client=httpx.AsyncClient(timeout=timeout) if httpx_client is None else httpx_client
+        )
         self.dummy = AsyncDummyClient(client_wrapper=self._client_wrapper)

--- a/seed/sdk/trace/src/seed/client.py
+++ b/seed/sdk/trace/src/seed/client.py
@@ -24,13 +24,14 @@ class SeedTrace:
         environment: SeedTraceEnvironment = SeedTraceEnvironment.PROD,
         x_random_header: typing.Optional[str] = None,
         token: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
-        timeout: typing.Optional[float] = 60
+        timeout: typing.Optional[float] = 60,
+        httpx_client: typing.Optional[httpx.Client] = None
     ):
         self._client_wrapper = SyncClientWrapper(
             base_url=_get_base_url(base_url=base_url, environment=environment),
             x_random_header=x_random_header,
             token=token,
-            httpx_client=httpx.Client(timeout=timeout),
+            httpx_client=httpx.Client(timeout=timeout) if httpx_client is None else httpx_client,
         )
         self.v_2 = V2Client(client_wrapper=self._client_wrapper)
         self.admin = AdminClient(client_wrapper=self._client_wrapper)
@@ -50,13 +51,14 @@ class AsyncSeedTrace:
         environment: SeedTraceEnvironment = SeedTraceEnvironment.PROD,
         x_random_header: typing.Optional[str] = None,
         token: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
-        timeout: typing.Optional[float] = 60
+        timeout: typing.Optional[float] = 60,
+        httpx_client: typing.Optional[httpx.AsyncClient] = None
     ):
         self._client_wrapper = AsyncClientWrapper(
             base_url=_get_base_url(base_url=base_url, environment=environment),
             x_random_header=x_random_header,
             token=token,
-            httpx_client=httpx.AsyncClient(timeout=timeout),
+            httpx_client=httpx.AsyncClient(timeout=timeout) if httpx_client is None else httpx_client,
         )
         self.v_2 = AsyncV2Client(client_wrapper=self._client_wrapper)
         self.admin = AsyncAdminClient(client_wrapper=self._client_wrapper)

--- a/seed/sdk/undiscriminated-unions/src/seed/client.py
+++ b/seed/sdk/undiscriminated-unions/src/seed/client.py
@@ -9,12 +9,24 @@ from .resources.union.client import AsyncUnionClient, UnionClient
 
 
 class SeedUndiscriminatedUnions:
-    def __init__(self, *, base_url: str, timeout: typing.Optional[float] = 60):
-        self._client_wrapper = SyncClientWrapper(base_url=base_url, httpx_client=httpx.Client(timeout=timeout))
+    def __init__(
+        self, *, base_url: str, timeout: typing.Optional[float] = 60, httpx_client: typing.Optional[httpx.Client] = None
+    ):
+        self._client_wrapper = SyncClientWrapper(
+            base_url=base_url, httpx_client=httpx.Client(timeout=timeout) if httpx_client is None else httpx_client
+        )
         self.union = UnionClient(client_wrapper=self._client_wrapper)
 
 
 class AsyncSeedUndiscriminatedUnions:
-    def __init__(self, *, base_url: str, timeout: typing.Optional[float] = 60):
-        self._client_wrapper = AsyncClientWrapper(base_url=base_url, httpx_client=httpx.AsyncClient(timeout=timeout))
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        timeout: typing.Optional[float] = 60,
+        httpx_client: typing.Optional[httpx.AsyncClient] = None
+    ):
+        self._client_wrapper = AsyncClientWrapper(
+            base_url=base_url, httpx_client=httpx.AsyncClient(timeout=timeout) if httpx_client is None else httpx_client
+        )
         self.union = AsyncUnionClient(client_wrapper=self._client_wrapper)

--- a/seed/sdk/unknown/src/seed/client.py
+++ b/seed/sdk/unknown/src/seed/client.py
@@ -9,12 +9,24 @@ from .resources.unknown.client import AsyncUnknownClient, UnknownClient
 
 
 class SeedUnknownAsAny:
-    def __init__(self, *, base_url: str, timeout: typing.Optional[float] = 60):
-        self._client_wrapper = SyncClientWrapper(base_url=base_url, httpx_client=httpx.Client(timeout=timeout))
+    def __init__(
+        self, *, base_url: str, timeout: typing.Optional[float] = 60, httpx_client: typing.Optional[httpx.Client] = None
+    ):
+        self._client_wrapper = SyncClientWrapper(
+            base_url=base_url, httpx_client=httpx.Client(timeout=timeout) if httpx_client is None else httpx_client
+        )
         self.unknown = UnknownClient(client_wrapper=self._client_wrapper)
 
 
 class AsyncSeedUnknownAsAny:
-    def __init__(self, *, base_url: str, timeout: typing.Optional[float] = 60):
-        self._client_wrapper = AsyncClientWrapper(base_url=base_url, httpx_client=httpx.AsyncClient(timeout=timeout))
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        timeout: typing.Optional[float] = 60,
+        httpx_client: typing.Optional[httpx.AsyncClient] = None
+    ):
+        self._client_wrapper = AsyncClientWrapper(
+            base_url=base_url, httpx_client=httpx.AsyncClient(timeout=timeout) if httpx_client is None else httpx_client
+        )
         self.unknown = AsyncUnknownClient(client_wrapper=self._client_wrapper)

--- a/seed/sdk/variables/src/seed/client.py
+++ b/seed/sdk/variables/src/seed/client.py
@@ -9,12 +9,24 @@ from .resources.service.client import AsyncServiceClient, ServiceClient
 
 
 class SeedVariables:
-    def __init__(self, *, base_url: str, timeout: typing.Optional[float] = 60):
-        self._client_wrapper = SyncClientWrapper(base_url=base_url, httpx_client=httpx.Client(timeout=timeout))
+    def __init__(
+        self, *, base_url: str, timeout: typing.Optional[float] = 60, httpx_client: typing.Optional[httpx.Client] = None
+    ):
+        self._client_wrapper = SyncClientWrapper(
+            base_url=base_url, httpx_client=httpx.Client(timeout=timeout) if httpx_client is None else httpx_client
+        )
         self.service = ServiceClient(client_wrapper=self._client_wrapper)
 
 
 class AsyncSeedVariables:
-    def __init__(self, *, base_url: str, timeout: typing.Optional[float] = 60):
-        self._client_wrapper = AsyncClientWrapper(base_url=base_url, httpx_client=httpx.AsyncClient(timeout=timeout))
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        timeout: typing.Optional[float] = 60,
+        httpx_client: typing.Optional[httpx.AsyncClient] = None
+    ):
+        self._client_wrapper = AsyncClientWrapper(
+            base_url=base_url, httpx_client=httpx.AsyncClient(timeout=timeout) if httpx_client is None else httpx_client
+        )
         self.service = AsyncServiceClient(client_wrapper=self._client_wrapper)

--- a/src/fern_python/codegen/ast/nodes/expressions/conditional_expression/conditional_expression.py
+++ b/src/fern_python/codegen/ast/nodes/expressions/conditional_expression/conditional_expression.py
@@ -10,8 +10,13 @@ class ConditionalExpression(AstNode):
         self.test = test
         self.left = left
         self.right = right
+
     def get_metadata(self) -> AstNodeMetadata:
-        pass
+        metadata = AstNodeMetadata()
+        metadata.update(self.test.get_metadata())
+        metadata.update(self.left.get_metadata())
+        metadata.update(self.right.get_metadata())
+        return metadata
 
     def write(self, writer: NodeWriter) -> None:
         writer.write_node(self.left)
@@ -19,3 +24,4 @@ class ConditionalExpression(AstNode):
         writer.write_node(self.test)
         writer.write(" else ")
         writer.write_node(self.right)
+        writer.write_newline_if_last_line_not()

--- a/src/fern_python/codegen/ast/nodes/expressions/conditional_expression/conditional_expression.py
+++ b/src/fern_python/codegen/ast/nodes/expressions/conditional_expression/conditional_expression.py
@@ -1,0 +1,21 @@
+from fern_python.codegen.ast import AstNode
+from fern_python.codegen.ast import AstNodeMetadata
+from fern_python.codegen.ast import Expression
+from fern_python.codegen.ast import NodeWriter
+
+
+class ConditionalExpression(AstNode):
+
+    def __init__(self, test: Expression, left: AstNode, right: AstNode) -> None:
+        self.test = test
+        self.left = left
+        self.right = right
+    def get_metadata(self) -> AstNodeMetadata:
+        pass
+
+    def write(self, writer: NodeWriter) -> None:
+        writer.write_node(self.left)
+        writer.write(" if ")
+        writer.write_node(self.test)
+        writer.write(" else ")
+        writer.write_node(self.right)

--- a/src/fern_python/generators/sdk/client_generator/root_client_generator.py
+++ b/src/fern_python/generators/sdk/client_generator/root_client_generator.py
@@ -292,7 +292,9 @@ class RootClientGenerator:
         parameters.append(
             RootClientConstructorParameter(
                 constructor_parameter_name=RootClientGenerator.HTTPX_CLIENT_CONSTRUCTOR_PARAMETER_NAME,
-                type_hint=AST.TypeHint.optional(AST.TypeHint(httpx.HttpX.CLIENT)),
+                type_hint=AST.TypeHint.optional(AST.TypeHint(httpx.HttpX.CLIENT))
+                if not is_async
+                else AST.TypeHint.optional(AST.TypeHint(httpx.HttpX.ASYNC_CLIENT)),
                 private_member_name=None,
                 initializer=AST.Expression(AST.TypeHint.none()),
             )
@@ -373,7 +375,6 @@ class RootClientGenerator:
                     kwargs=client_wrapper_constructor_kwargs,
                 )
             )
-            writer.write_line(f"if {param.constructor_parameter_name} is not None:")
             writer.write_newline_if_last_line_not()
             for subpackage_id in self._package.subpackages:
                 subpackage = self._context.ir.subpackages[subpackage_id]

--- a/src/fern_python/generators/sdk/client_generator/root_client_generator.py
+++ b/src/fern_python/generators/sdk/client_generator/root_client_generator.py
@@ -6,6 +6,7 @@ import fern.ir.resources as ir_types
 
 from fern_python.codegen import AST, SourceFile
 from fern_python.codegen.ast.nodes.code_writer.code_writer import CodeWriterFunction
+from fern_python.codegen.ast.nodes.expressions.conditional_expression.conditional_expression import ConditionalExpression
 from fern_python.external_dependencies import HttpX
 from fern_python.generators.pydantic_model import SnippetRegistry
 from fern_python.generators.sdk.client_generator.endpoint_response_code_writer import (
@@ -16,6 +17,7 @@ from fern_python.generators.sdk.core_utilities.client_wrapper_generator import (
     ConstructorParameter,
 )
 
+from src.fern_python.external_dependencies import httpx
 from ..context.sdk_generator_context import SdkGeneratorContext
 from ..environment_generators import (
     GeneratedEnvironment,
@@ -42,6 +44,8 @@ class RootClientGenerator:
 
     BASE_URL_CONSTRUCTOR_PARAMETER_NAME = "base_url"
     BASE_URL_MEMBER_NAME = "_base_url"
+
+    HTTPX_CLIENT_CONSTRUCTOR_PARAMETER_NAME = "httpx_client"
 
     RESPONSE_VARIABLE = EndpointResponseCodeWriter.RESPONSE_VARIABLE
     RESPONSE_JSON_VARIABLE = EndpointResponseCodeWriter.RESPONSE_JSON_VARIABLE
@@ -285,6 +289,14 @@ class RootClientGenerator:
                 else AST.Expression(AST.TypeHint.none()),
             )
         )
+        parameters.append(
+            RootClientConstructorParameter(
+                constructor_parameter_name=RootClientGenerator.HTTPX_CLIENT_CONSTRUCTOR_PARAMETER_NAME,
+                type_hint=AST.TypeHint.optional(AST.TypeHint(httpx.HttpX.CLIENT)),
+                private_member_name=None,
+                initializer=AST.Expression(AST.TypeHint.none()),
+            )
+        )
         return parameters
 
     def _environment_is_enum(self) -> bool:
@@ -335,15 +347,19 @@ class RootClientGenerator:
                 (
                     ClientWrapperGenerator.HTTPX_CLIENT_MEMBER_NAME,
                     AST.Expression(
-                        AST.ClassInstantiation(
-                            HttpX.ASYNC_CLIENT if is_async else HttpX.CLIENT,
-                            kwargs=[
-                                (
-                                    "timeout",
-                                    AST.Expression(f"{self._timeout_constructor_parameter_name}"),
-                                )
-                            ],
-                        )
+                        ConditionalExpression(
+                            left=AST.ClassInstantiation(
+                                HttpX.ASYNC_CLIENT if is_async else HttpX.CLIENT,
+                                kwargs=[
+                                    (
+                                        "timeout",
+                                        AST.Expression(f"{self._timeout_constructor_parameter_name}"),
+                                    )
+                                ],
+                            ),
+                            right=AST.Expression(f"{RootClientGenerator.HTTPX_CLIENT_CONSTRUCTOR_PARAMETER_NAME}"),
+                            test=AST.Expression(f"{RootClientGenerator.HTTPX_CLIENT_CONSTRUCTOR_PARAMETER_NAME} is None"),
+                        ),
                     ),
                 )
             )
@@ -357,6 +373,7 @@ class RootClientGenerator:
                     kwargs=client_wrapper_constructor_kwargs,
                 )
             )
+            writer.write_line(f"if {param.constructor_parameter_name} is not None:")
             writer.write_newline_if_last_line_not()
             for subpackage_id in self._package.subpackages:
                 subpackage = self._context.ir.subpackages[subpackage_id]

--- a/tests/sdk/test_root_client_generator.py
+++ b/tests/sdk/test_root_client_generator.py
@@ -46,12 +46,6 @@ def test_generated_root_client_builder() -> None:
                     generated_environment=generated_environment,
                 ),
             ),
-            ConstructorParameter(
-                constructor_parameter_name="httpx_client",
-                type_hint=None,  # type: ignore
-                private_member_name=None,
-                instantiation=AST.Expression('httpx_client=httpx.Client()')
-            ),
         ],
     )
     generated_root_client = builder.build()
@@ -66,7 +60,6 @@ from acme.environments import AcmeEnvironments
 client = Acme(
     base_url="acme.io",
     environment=AcmeEnvironments.PRODUCTION,
-    httpx_client=httpx.Client(),
 )
 """
     )
@@ -81,7 +74,6 @@ from acme.environments import AcmeEnvironments
 client = AcmeAsync(
     base_url="acme.io",
     environment=AcmeEnvironments.PRODUCTION,
-    httpx_client=httpx.Client(),
 )
 """
     )

--- a/tests/sdk/test_root_client_generator.py
+++ b/tests/sdk/test_root_client_generator.py
@@ -46,6 +46,12 @@ def test_generated_root_client_builder() -> None:
                     generated_environment=generated_environment,
                 ),
             ),
+            ConstructorParameter(
+                constructor_parameter_name="httpx_client",
+                type_hint=None,  # type: ignore
+                private_member_name=None,
+                instantiation=AST.Expression('httpx_client=httpx.Client()')
+            ),
         ],
     )
     generated_root_client = builder.build()
@@ -60,6 +66,7 @@ from acme.environments import AcmeEnvironments
 client = Acme(
     base_url="acme.io",
     environment=AcmeEnvironments.PRODUCTION,
+    httpx_client=httpx.Client(),
 )
 """
     )
@@ -74,6 +81,7 @@ from acme.environments import AcmeEnvironments
 client = AcmeAsync(
     base_url="acme.io",
     environment=AcmeEnvironments.PRODUCTION,
+    httpx_client=httpx.Client(),
 )
 """
     )


### PR DESCRIPTION
allows for passing of an arbitrary httpx (async) client impl to the sdk constructor. this specifically allows for passing in a starlette TestClient implementation which allows you to bypass http routing and use the fern api in local tests with direct asgi app routing.