### PR TITLE
Add pydantic config to sdk generator

### DIFF
--- a/src/fern_python/generators/sdk/custom_config.py
+++ b/src/fern_python/generators/sdk/custom_config.py
@@ -2,10 +2,11 @@ from typing import Literal, Optional, Union
 
 import pydantic
 
-from fern_python.external_dependencies import PydanticVersionCompatibility
+from ...external_dependencies.pydantic import PydanticVersionCompatibility
 
 
 class SDKCustomConfig(pydantic.BaseModel):
+    version: PydanticVersionCompatibility = PydanticVersionCompatibility.Both
     wrapped_aliases: bool = False
     skip_formatting: bool = False
     client_class_name: Optional[str] = None
@@ -15,4 +16,3 @@ class SDKCustomConfig(pydantic.BaseModel):
     package_name: Optional[str] = None
     timeout_in_seconds: Union[Literal["infinity"], int] = 60
     flat_layout: bool = False
-    version: PydanticVersionCompatibility = PydanticVersionCompatibility.Both

--- a/src/fern_python/generators/sdk/custom_config.py
+++ b/src/fern_python/generators/sdk/custom_config.py
@@ -1,12 +1,10 @@
 from typing import Literal, Optional, Union
+from fern_python.generators.pydantic_model.custom_config import BasePydanticModelCustomConfig
 
 import pydantic
 
-from ...external_dependencies.pydantic import PydanticVersionCompatibility
-
 
 class SDKCustomConfig(pydantic.BaseModel):
-    pydantic_version: PydanticVersionCompatibility = PydanticVersionCompatibility.Both
     wrapped_aliases: bool = False
     skip_formatting: bool = False
     client_class_name: Optional[str] = None
@@ -16,3 +14,4 @@ class SDKCustomConfig(pydantic.BaseModel):
     package_name: Optional[str] = None
     timeout_in_seconds: Union[Literal["infinity"], int] = 60
     flat_layout: bool = False
+    pydantic_config: BasePydanticModelCustomConfig = BasePydanticModelCustomConfig()

--- a/src/fern_python/generators/sdk/custom_config.py
+++ b/src/fern_python/generators/sdk/custom_config.py
@@ -6,7 +6,7 @@ from ...external_dependencies.pydantic import PydanticVersionCompatibility
 
 
 class SDKCustomConfig(pydantic.BaseModel):
-    version: PydanticVersionCompatibility = PydanticVersionCompatibility.Both
+    pydantic_version: PydanticVersionCompatibility = PydanticVersionCompatibility.Both
     wrapped_aliases: bool = False
     skip_formatting: bool = False
     client_class_name: Optional[str] = None

--- a/src/fern_python/generators/sdk/custom_config.py
+++ b/src/fern_python/generators/sdk/custom_config.py
@@ -2,6 +2,8 @@ from typing import Literal, Optional, Union
 
 import pydantic
 
+from fern_python.external_dependencies import PydanticVersionCompatibility
+
 
 class SDKCustomConfig(pydantic.BaseModel):
     wrapped_aliases: bool = False
@@ -13,3 +15,4 @@ class SDKCustomConfig(pydantic.BaseModel):
     package_name: Optional[str] = None
     timeout_in_seconds: Union[Literal["infinity"], int] = 60
     flat_layout: bool = False
+    version: PydanticVersionCompatibility = PydanticVersionCompatibility.Both

--- a/src/fern_python/generators/sdk/sdk_generator.py
+++ b/src/fern_python/generators/sdk/sdk_generator.py
@@ -7,7 +7,6 @@ from fern.generator_exec.resources.readme import BadgeType, GenerateReadmeReques
 from fern_python.cli.abstract_generator import AbstractGenerator
 from fern_python.codegen import Project
 from fern_python.codegen.filepath import Filepath
-from fern_python.external_dependencies.pydantic import PydanticVersionCompatibility
 from fern_python.generator_exec_wrapper import GeneratorExecWrapper
 from fern_python.generators.pydantic_model import (
     PydanticModelCustomConfig,

--- a/src/fern_python/generators/sdk/sdk_generator.py
+++ b/src/fern_python/generators/sdk/sdk_generator.py
@@ -82,7 +82,7 @@ class SdkGenerator(AbstractGenerator):
             orm_mode=False,
             frozen=True,
             smart_union=True,
-            version=PydanticVersionCompatibility.Both,
+            version=custom_config.version,
         )
 
         context = SdkGeneratorContextImpl(

--- a/src/fern_python/generators/sdk/sdk_generator.py
+++ b/src/fern_python/generators/sdk/sdk_generator.py
@@ -81,7 +81,10 @@ class SdkGenerator(AbstractGenerator):
             orm_mode=False,
             frozen=True,
             smart_union=True,
-            version=custom_config.pydantic_version,
+            # SDK generator config only exposes base pydantic settings.
+            # To merge the base config into the final pydantic config, we need to
+            # cast BasePydanticModelCustomConfig to dict and unpack into kwargs
+            **custom_config.pydantic_config.dict(),
         )
 
         context = SdkGeneratorContextImpl(

--- a/src/fern_python/generators/sdk/sdk_generator.py
+++ b/src/fern_python/generators/sdk/sdk_generator.py
@@ -81,7 +81,7 @@ class SdkGenerator(AbstractGenerator):
             orm_mode=False,
             frozen=True,
             smart_union=True,
-            version=custom_config.version,
+            version=custom_config.pydantic_version,
         )
 
         context = SdkGeneratorContextImpl(


### PR DESCRIPTION
Re-use the pydantic config model that is used for the FastAPI generator and position it the same in custom config